### PR TITLE
Improve STEIM2 decode performance

### DIFF
--- a/example/lm_read_timewin.c
+++ b/example/lm_read_timewin.c
@@ -1,0 +1,97 @@
+/***************************************************************************
+ * A program for reading miniSEED using ms3_readtracelist_timewin() to limit
+ * which data is read according to their timestamp. This program also shows
+ * how to traverse a trace list.
+ *
+ * This file is adapted from lm_read_selection.c.
+ *
+ * Usage: ./lm_read_timewin <mseedfile> <start> <endtime>
+ * For example, ./lm_read_timewin test.mseed 2010,058,06,00,00 2010,058,07,00,00
+ ***************************************************************************/
+
+#include <stdio.h>
+#include <sys/stat.h>
+#include <error.h>
+
+#include <libmseed.h>
+
+int main(int argc, char **argv)
+{
+  MS3TraceList *mstl = NULL;
+  MS3TraceID *tid = NULL;
+  MS3TraceSeg *seg = NULL;
+
+  char *mseedfile = NULL;
+  nstime_t starttime;
+  nstime_t endtime;
+  char starttimestr[30];
+  char endtimestr[30];
+  uint32_t flags = 0;
+  int8_t verbose = 0;
+  int rv;
+
+  /* Parse input parameters */
+  if(argc != 4)
+  {
+    ms_log(2, "Usage: %s <mseedfile> <starttime> <endtime>\n", argv[0]);
+    return -1;
+  }
+  mseedfile = argv[1];
+  starttime = ms_timestr2nstime(argv[2]);
+  endtime = ms_timestr2nstime(argv[3]);
+
+  /* Set bit flags to validate CRC and unpack data samples */
+  flags |= MSF_VALIDATECRC;
+  flags |= MSF_UNPACKDATA;
+
+  /* Read all miniSEED into a trace list, limiting from start time to end
+   * end time */
+  rv = ms3_readtracelist_timewin(&mstl, mseedfile, NULL,
+    starttime, endtime,
+    0, flags, verbose);
+  if(rv != MS_NOERROR)
+  {
+    ms_log (2, "Cannot read miniSEED from file: %s\n", ms_errorstr(rv));
+    return -1;
+  }
+
+  /* Traverse trace list structures and print summary information */
+  tid = mstl->traces;
+  while(tid)
+  {
+    if (!ms_nstime2timestr (tid->earliest, starttimestr, SEEDORDINAL, NANO_MICRO_NONE) ||
+        !ms_nstime2timestr (tid->latest, endtimestr, SEEDORDINAL, NANO_MICRO_NONE))
+    {
+      ms_log (2, "Cannot create time strings\n");
+      starttimestr[0] = endtimestr[0] = '\0';
+    }
+
+    ms_log (0, "TraceID for %s (%d), earliest: %s, latest: %s, segments: %u\n",
+            tid->sid, tid->pubversion, starttimestr, endtimestr, tid->numsegments);
+
+    seg = tid->first;
+    while (seg)
+    {
+      if (!ms_nstime2timestr (seg->starttime, starttimestr, SEEDORDINAL, NANO_MICRO_NONE) ||
+          !ms_nstime2timestr (seg->endtime, endtimestr, SEEDORDINAL, NANO_MICRO_NONE))
+      {
+        ms_log (2, "Cannot create time strings\n");
+        starttimestr[0] = endtimestr[0] = '\0';
+      }
+
+      ms_log (0, "  Segment %s - %s, samples: %" PRId64 ", sample rate: %g, sample type: %c\n",
+              starttimestr, endtimestr, seg->numsamples, seg->samprate,
+              (seg->sampletype) ? seg->sampletype : ' ');
+
+      seg = seg->next;
+    }
+
+    tid = tid->next;
+  }
+
+  /* Make sure everything is cleaned up */
+  if (mstl)
+    mstl3_free (&mstl, 0);
+
+  return 0;
+}

--- a/extraheaders.c
+++ b/extraheaders.c
@@ -18,24 +18,30 @@
  * limitations under the License.
  ***************************************************************************/
 
-#include "libmseed.h"
 #include "extraheaders.h"
+#include "libmseed.h"
 
 /* Private allocation wrappers for yyjson's allocator definition */
-void *_priv_malloc(void *ctx, size_t size) {
-    UNUSED(ctx);
-    return libmseed_memory.malloc(size);
+void *
+_priv_malloc (void *ctx, size_t size)
+{
+  UNUSED (ctx);
+  return libmseed_memory.malloc (size);
 }
 
-void *_priv_realloc(void *ctx, void *ptr, size_t oldsize, size_t size) {
-    UNUSED(ctx);
-    UNUSED(oldsize);
-    return libmseed_memory.realloc(ptr, size);
+void *
+_priv_realloc (void *ctx, void *ptr, size_t oldsize, size_t size)
+{
+  UNUSED (ctx);
+  UNUSED (oldsize);
+  return libmseed_memory.realloc (ptr, size);
 }
 
-void _priv_free(void *ctx, void *ptr) {
-    UNUSED(ctx);
-    libmseed_memory.free(ptr);
+void
+_priv_free (void *ctx, void *ptr)
+{
+  UNUSED (ctx);
+  libmseed_memory.free (ptr);
 }
 
 /***************************************************************************
@@ -50,7 +56,7 @@ void _priv_free(void *ctx, void *ptr) {
  *
  * \sa mseh_free_parsestate()
  ***************************************************************************/
-static LM_PARSED_JSON*
+static LM_PARSED_JSON *
 parse_json (char *jsonstring, size_t length, LM_PARSED_JSON *parsed)
 {
   yyjson_read_flag flg = YYJSON_READ_NOFLAG;
@@ -82,7 +88,7 @@ parse_json (char *jsonstring, size_t length, LM_PARSED_JSON *parsed)
   if (parsed->doc)
   {
     yyjson_doc_free (parsed->doc);
-    parsed->doc     = NULL;
+    parsed->doc = NULL;
   }
 
   /* Free existing mutable document */
@@ -104,54 +110,54 @@ parse_json (char *jsonstring, size_t length, LM_PARSED_JSON *parsed)
 }
 
 /**********************************************************************/ /**
- * @brief Search for and return an extra header value.
- *
- * The extra header value is specified as a JSON Pointer (RFC 6901), e.g.
- * \c '/objectA/objectB/header'.
- *
- * This routine can get used to test for the existence of a value
- * without returning the value by setting \a value to NULL.
- *
- * If the target item is found (and \a value parameter is set) the
- * value will be copied into the memory specified by \c value.  The
- * \a type value specifies the data type expected.
- *
- * If a \a parsestate pointer is supplied, the parsed (deserialized) JSON
- * data are stored here.  This value may be used in subsequent calls to
- * avoid re-parsing the JSON.  The data must be freed with
- * mseh_free_parsestate() when done reading the JSON.  If this value
- * is NULL the parse state will be created and destroyed on each call.
- *
- * @param[in] msr Parsed miniSEED record to query
- * @param[in] path Header value desired, specified in dot notation
- * @param[out] value Buffer for value, of type \c type
- * @param[in] type Type of value expected, one of:
- * @parblock
- * - \c 'n' - \a value is type \a double
- * - \c 'i' - \a value is type \a int64_t
- * - \c 's' - \a value is type \a char* (maximum length is: \c maxlength - 1)
- * - \c 'b' - \a value of type \a int (boolean value of 0 or 1)
- * @endparblock
- * @param[in] maxlength Maximum length of string value
- * @param[in] parsed Parsed state for multiple operations, can be NULL
- *
- * @retval 0 on success
- * @retval 1 when the value was not found
- * @retval 2 when the value is of a different type
- * @returns A (negative) libmseed error code on error
- *
- * \ref MessageOnError - this function logs a message on error
- *
- * \sa mseh_free_parsestate()
- ***************************************************************************/
+                                                                          * @brief Search for and return an extra header value.
+                                                                          *
+                                                                          * The extra header value is specified as a JSON Pointer (RFC 6901), e.g.
+                                                                          * \c '/objectA/objectB/header'.
+                                                                          *
+                                                                          * This routine can get used to test for the existence of a value
+                                                                          * without returning the value by setting \a value to NULL.
+                                                                          *
+                                                                          * If the target item is found (and \a value parameter is set) the
+                                                                          * value will be copied into the memory specified by \c value.  The
+                                                                          * \a type value specifies the data type expected.
+                                                                          *
+                                                                          * If a \a parsestate pointer is supplied, the parsed (deserialized) JSON
+                                                                          * data are stored here.  This value may be used in subsequent calls to
+                                                                          * avoid re-parsing the JSON.  The data must be freed with
+                                                                          * mseh_free_parsestate() when done reading the JSON.  If this value
+                                                                          * is NULL the parse state will be created and destroyed on each call.
+                                                                          *
+                                                                          * @param[in] msr Parsed miniSEED record to query
+                                                                          * @param[in] path Header value desired, specified in dot notation
+                                                                          * @param[out] value Buffer for value, of type \c type
+                                                                          * @param[in] type Type of value expected, one of:
+                                                                          * @parblock
+                                                                          * - \c 'n' - \a value is type \a double
+                                                                          * - \c 'i' - \a value is type \a int64_t
+                                                                          * - \c 's' - \a value is type \a char* (maximum length is: \c maxlength - 1)
+                                                                          * - \c 'b' - \a value of type \a int (boolean value of 0 or 1)
+                                                                          * @endparblock
+                                                                          * @param[in] maxlength Maximum length of string value
+                                                                          * @param[in] parsed Parsed state for multiple operations, can be NULL
+                                                                          *
+                                                                          * @retval 0 on success
+                                                                          * @retval 1 when the value was not found
+                                                                          * @retval 2 when the value is of a different type
+                                                                          * @returns A (negative) libmseed error code on error
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          *
+                                                                          * \sa mseh_free_parsestate()
+                                                                          ***************************************************************************/
 int
 mseh_get_path_r (MS3Record *msr, const char *path,
                  void *value, char type, size_t maxlength,
                  LM_PARSED_JSON **parsestate)
 {
-  LM_PARSED_JSON *parsed  = (parsestate) ? *parsestate : NULL;
+  LM_PARSED_JSON *parsed = (parsestate) ? *parsestate : NULL;
 
-  yyjson_alc alc = {_priv_malloc, _priv_realloc, _priv_free, NULL};
+  yyjson_alc alc          = {_priv_malloc, _priv_realloc, _priv_free, NULL};
   yyjson_val *extravalue  = NULL;
   const char *stringvalue = NULL;
 
@@ -186,7 +192,7 @@ mseh_get_path_r (MS3Record *msr, const char *path,
   if (parsed == NULL)
   {
     /* Parse to immutable state */
-    parsed = parse_json(msr->extra, msr->extralength, parsed);
+    parsed = parse_json (msr->extra, msr->extralength, parsed);
 
     if (parsed == NULL)
     {
@@ -217,7 +223,7 @@ mseh_get_path_r (MS3Record *msr, const char *path,
   }
 
   /* Get target value */
-  extravalue = yyjson_doc_get_pointer(parsed->doc, path);
+  extravalue = yyjson_doc_get_pointer (parsed->doc, path);
 
   if (extravalue == NULL)
   {
@@ -242,7 +248,7 @@ mseh_get_path_r (MS3Record *msr, const char *path,
       ((char *)value)[maxlength - 1] = '\0';
     }
   }
-  else if (type == 'b' && yyjson_is_bool(extravalue))
+  else if (type == 'b' && yyjson_is_bool (extravalue))
   {
     if (value)
       *((int *)value) = (unsafe_yyjson_get_bool (extravalue)) ? 1 : 0;
@@ -263,45 +269,45 @@ mseh_get_path_r (MS3Record *msr, const char *path,
 } /* End of mseh_get_path_r() */
 
 /**********************************************************************/ /**
- * @brief Set the value of a single extra header value
- *
- * The extra header value is specified as a JSON Pointer (RFC 6901), e.g.
- * \c '/objectA/objectB/header'.
- *
- * If the \a path or final header values do not exist they will be
- * created.  If the header value exists it will be replaced.
- *
- * The \a type value specifies the data type expected for \c value.
- *
- * If a \a parsestate pointer is supplied, the parsed (deserialized) JSON
- * data are stored here.  This value may be used in subsequent calls to
- * avoid re-parsing the JSON.  When done setting headers using this
- * functionality the following \a must be done:
- * 1. call mseh_serialize() to create the JSON headers before writing the record
- * 2. free the \a parsestate data with mseh_free_parsestate()
- * If this value is NULL the parse state will be created and destroyed
- * on each call.
- *
- * @param[in] msr Parsed miniSEED record to query
- * @param[in] path Header value desired, specified in dot notation
- * @param[in] value Buffer for value, of type \c type
- * @param[in] type Type of value expected, one of:
- * @parblock
- * - \c 'n' - \a value is type \a double
- * - \c 'i' - \a value is type \a int64_t
- * - \c 's' - \a value is type \a char*
- * - \c 'b' - \a value is type \a int (boolean value of 0 or 1)
- * - \c 'A' - \a value is an Array element to append, as yyjson_mut_val* (internal use)
- * @endparblock
- * @param[in] parsed Parsed state for multiple operations, can be NULL
- *
- * @retval 0 on success, otherwise a (negative) libmseed error code.
- *
- * \ref MessageOnError - this function logs a message on error
- *
- * \sa mseh_free_parsestate()
- * \sa mseh_serialize()
- ***************************************************************************/
+                                                                          * @brief Set the value of a single extra header value
+                                                                          *
+                                                                          * The extra header value is specified as a JSON Pointer (RFC 6901), e.g.
+                                                                          * \c '/objectA/objectB/header'.
+                                                                          *
+                                                                          * If the \a path or final header values do not exist they will be
+                                                                          * created.  If the header value exists it will be replaced.
+                                                                          *
+                                                                          * The \a type value specifies the data type expected for \c value.
+                                                                          *
+                                                                          * If a \a parsestate pointer is supplied, the parsed (deserialized) JSON
+                                                                          * data are stored here.  This value may be used in subsequent calls to
+                                                                          * avoid re-parsing the JSON.  When done setting headers using this
+                                                                          * functionality the following \a must be done:
+                                                                          * 1. call mseh_serialize() to create the JSON headers before writing the record
+                                                                          * 2. free the \a parsestate data with mseh_free_parsestate()
+                                                                          * If this value is NULL the parse state will be created and destroyed
+                                                                          * on each call.
+                                                                          *
+                                                                          * @param[in] msr Parsed miniSEED record to query
+                                                                          * @param[in] path Header value desired, specified in dot notation
+                                                                          * @param[in] value Buffer for value, of type \c type
+                                                                          * @param[in] type Type of value expected, one of:
+                                                                          * @parblock
+                                                                          * - \c 'n' - \a value is type \a double
+                                                                          * - \c 'i' - \a value is type \a int64_t
+                                                                          * - \c 's' - \a value is type \a char*
+                                                                          * - \c 'b' - \a value is type \a int (boolean value of 0 or 1)
+                                                                          * - \c 'A' - \a value is an Array element to append, as yyjson_mut_val* (internal use)
+                                                                          * @endparblock
+                                                                          * @param[in] parsed Parsed state for multiple operations, can be NULL
+                                                                          *
+                                                                          * @retval 0 on success, otherwise a (negative) libmseed error code.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          *
+                                                                          * \sa mseh_free_parsestate()
+                                                                          * \sa mseh_serialize()
+                                                                          ***************************************************************************/
 int
 mseh_set_path_r (MS3Record *msr, const char *path,
                  void *value, char type,
@@ -310,7 +316,7 @@ mseh_set_path_r (MS3Record *msr, const char *path,
 #define MAXPATHDEPTH 8
   LM_PARSED_JSON *parsed = (parsestate) ? *parsestate : NULL;
 
-  yyjson_alc alc = {_priv_malloc, _priv_realloc, _priv_free, NULL};
+  yyjson_alc alc           = {_priv_malloc, _priv_realloc, _priv_free, NULL};
   yyjson_mut_doc *new_doc  = NULL;
   yyjson_mut_val *new_root = NULL;
   yyjson_mut_val patch;
@@ -520,19 +526,19 @@ mseh_set_path_r (MS3Record *msr, const char *path,
 } /* End of mseh_set_path_r() */
 
 /**********************************************************************/ /**
- * @brief Add event detection to the extra headers of the given record.
- *
- * If \a path is NULL, the default is \c '/FDSN/Event/Detection'.
- *
- * @param[in] msr Parsed miniSEED record to query
- * @param[in] path Header value desired, specified in dot notation
- * @param[in] eventdetection Structure with event detection values
- * @param[in] parsed Parsed state for multiple operations, can be NULL
- *
- * @returns 0 on success, otherwise a (negative) libmseed error code.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Add event detection to the extra headers of the given record.
+                                                                          *
+                                                                          * If \a path is NULL, the default is \c '/FDSN/Event/Detection'.
+                                                                          *
+                                                                          * @param[in] msr Parsed miniSEED record to query
+                                                                          * @param[in] path Header value desired, specified in dot notation
+                                                                          * @param[in] eventdetection Structure with event detection values
+                                                                          * @param[in] parsed Parsed state for multiple operations, can be NULL
+                                                                          *
+                                                                          * @returns 0 on success, otherwise a (negative) libmseed error code.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 mseh_add_event_detection_r (MS3Record *msr, const char *path,
                             MSEHEventDetection *eventdetection,
@@ -610,7 +616,7 @@ mseh_add_event_detection_r (MS3Record *msr, const char *path,
     }
     else
     {
-      ms_log (2, "%s() Cannot create time string for %"PRId64"\n", __func__, eventdetection->onsettime);
+      ms_log (2, "%s() Cannot create time string for %" PRId64 "\n", __func__, eventdetection->onsettime);
       return MS_GENERROR;
     }
   }
@@ -656,19 +662,19 @@ mseh_add_event_detection_r (MS3Record *msr, const char *path,
 } /* End of mseh_add_event_detection_r() */
 
 /**********************************************************************/ /**
- * @brief Add calibration to the extra headers of the given record.
- *
- * If \a path is NULL, the default is \c '/FDSN/Calibration/Sequence'.
- *
- * @param[in] msr Parsed miniSEED record to query
- * @param[in] path Header value desired, specified in dot notation
- * @param[in] calibration Structure with calibration values
- * @param[in] parsed Parsed state for multiple operations, can be NULL
- *
- * @returns 0 on success, otherwise a (negative) libmseed error code.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Add calibration to the extra headers of the given record.
+                                                                          *
+                                                                          * If \a path is NULL, the default is \c '/FDSN/Calibration/Sequence'.
+                                                                          *
+                                                                          * @param[in] msr Parsed miniSEED record to query
+                                                                          * @param[in] path Header value desired, specified in dot notation
+                                                                          * @param[in] calibration Structure with calibration values
+                                                                          * @param[in] parsed Parsed state for multiple operations, can be NULL
+                                                                          *
+                                                                          * @returns 0 on success, otherwise a (negative) libmseed error code.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 mseh_add_calibration_r (MS3Record *msr, const char *path,
                         MSEHCalibration *calibration,
@@ -817,7 +823,8 @@ mseh_add_calibration_r (MS3Record *msr, const char *path,
   {
     yyjson_mut_set_str (&refamp_key, "ReferenceAmplitude");
     yyjson_mut_set_real (&refamp, calibration->refamplitude);
-    yyjson_mut_obj_add (&entry, &refamp_key, &refamp);;
+    yyjson_mut_obj_add (&entry, &refamp_key, &refamp);
+    ;
   }
   if (calibration->coupling[0])
   {
@@ -848,19 +855,19 @@ mseh_add_calibration_r (MS3Record *msr, const char *path,
 } /* End of mseh_add_calibration_r() */
 
 /**********************************************************************/ /**
- * @brief Add timing exception to the extra headers of the given record.
- *
- * If \a path is NULL, the default is \c '/FDSN/Time/Exception'.
- *
- * @param[in] msr Parsed miniSEED record to query
- * @param[in] path Header value desired, specified in dot notation
- * @param[in] exception Structure with timing exception values
- * @param[in] parsed Parsed state for multiple operations, can be NULL
- *
- * @returns 0 on success, otherwise a (negative) libmseed error code.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Add timing exception to the extra headers of the given record.
+                                                                          *
+                                                                          * If \a path is NULL, the default is \c '/FDSN/Time/Exception'.
+                                                                          *
+                                                                          * @param[in] msr Parsed miniSEED record to query
+                                                                          * @param[in] path Header value desired, specified in dot notation
+                                                                          * @param[in] exception Structure with timing exception values
+                                                                          * @param[in] parsed Parsed state for multiple operations, can be NULL
+                                                                          *
+                                                                          * @returns 0 on success, otherwise a (negative) libmseed error code.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 mseh_add_timing_exception_r (MS3Record *msr, const char *path,
                              MSEHTimingException *exception,
@@ -940,19 +947,19 @@ mseh_add_timing_exception_r (MS3Record *msr, const char *path,
 } /* End of mseh_add_timing_exception_r() */
 
 /**********************************************************************/ /**
- * @brief Add recenter event to the extra headers of the given record.
- *
- * If \a path is NULL, the default is \c '/FDSN/Recenter/Sequence'.
- *
- * @param[in] msr Parsed miniSEED record to query
- * @param[in] path Header value desired, specified in dot notation
- * @param[in] recenter Structure with recenter values
- * @param[in] parsed Parsed state for multiple operations, can be NULL
- *
- * @returns 0 on success, otherwise a (negative) libmseed error code.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Add recenter event to the extra headers of the given record.
+                                                                          *
+                                                                          * If \a path is NULL, the default is \c '/FDSN/Recenter/Sequence'.
+                                                                          *
+                                                                          * @param[in] msr Parsed miniSEED record to query
+                                                                          * @param[in] path Header value desired, specified in dot notation
+                                                                          * @param[in] recenter Structure with recenter values
+                                                                          * @param[in] parsed Parsed state for multiple operations, can be NULL
+                                                                          *
+                                                                          * @returns 0 on success, otherwise a (negative) libmseed error code.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 mseh_add_recenter_r (MS3Record *msr, const char *path, MSEHRecenter *recenter,
                      LM_PARSED_JSON **parsestate)
@@ -1025,18 +1032,18 @@ mseh_add_recenter_r (MS3Record *msr, const char *path, MSEHRecenter *recenter,
 } /* End of mseh_add_recenter_r() */
 
 /**********************************************************************/ /**
- * @brief Generate extra headers string (serialize) from internal state
- *
- * Generate the extra headers JSON string from the internal parse state
- * created by mseh_set_path_r().
- *
- * @param[in] msr ::MS3Record to generate extra headers for
- * @param[in] parsed Internal parsed state associated with \a msr
- *
- * @returns Length of extra headers on success, otherwise a (negative) libmseed error code
- *
- * \sa mseh_set_path_r()
- ***************************************************************************/
+                                                                          * @brief Generate extra headers string (serialize) from internal state
+                                                                          *
+                                                                          * Generate the extra headers JSON string from the internal parse state
+                                                                          * created by mseh_set_path_r().
+                                                                          *
+                                                                          * @param[in] msr ::MS3Record to generate extra headers for
+                                                                          * @param[in] parsed Internal parsed state associated with \a msr
+                                                                          *
+                                                                          * @returns Length of extra headers on success, otherwise a (negative) libmseed error code
+                                                                          *
+                                                                          * \sa mseh_set_path_r()
+                                                                          ***************************************************************************/
 int
 mseh_serialize (MS3Record *msr, LM_PARSED_JSON **parsestate)
 {
@@ -1045,8 +1052,8 @@ mseh_serialize (MS3Record *msr, LM_PARSED_JSON **parsestate)
   yyjson_alc alc = {_priv_malloc, _priv_realloc, _priv_free, NULL};
 
   LM_PARSED_JSON *parsed = NULL;
-  char *serialized    = NULL;
-  size_t serialsize   = 0;
+  char *serialized       = NULL;
+  size_t serialsize      = 0;
 
   if (!msr || !parsestate)
     return MS_GENERROR;
@@ -1070,7 +1077,7 @@ mseh_serialize (MS3Record *msr, LM_PARSED_JSON **parsestate)
   {
     ms_log (2, "%s() New serialization size exceeds limit of %d bytes: %" PRIu64 "\n",
             __func__, UINT16_MAX, (uint64_t)serialsize);
-    libmseed_memory.free(serialized);
+    libmseed_memory.free (serialized);
     return MS_GENERROR;
   }
 
@@ -1084,14 +1091,14 @@ mseh_serialize (MS3Record *msr, LM_PARSED_JSON **parsestate)
 }
 
 /**********************************************************************/ /**
- * @brief Free internally parsed (deserialized) JSON data
- *
- * Free the memory associated with JSON data parsed by mseh_get_path_r()
- * or mseh_set_path_r(), specifically the data at the \a parsestate pointer.
- *
- * \sa mseh_get_path_r()
- * \sa mseh_set_path_r()
- ***************************************************************************/
+                                                                          * @brief Free internally parsed (deserialized) JSON data
+                                                                          *
+                                                                          * Free the memory associated with JSON data parsed by mseh_get_path_r()
+                                                                          * or mseh_set_path_r(), specifically the data at the \a parsestate pointer.
+                                                                          *
+                                                                          * \sa mseh_get_path_r()
+                                                                          * \sa mseh_set_path_r()
+                                                                          ***************************************************************************/
 void
 mseh_free_parsestate (LM_PARSED_JSON **parsestate)
 {
@@ -1108,19 +1115,19 @@ mseh_free_parsestate (LM_PARSED_JSON **parsestate)
   if (parsed->mut_doc)
     yyjson_mut_doc_free (parsed->mut_doc);
 
-  libmseed_memory.free(parsed);
+  libmseed_memory.free (parsed);
 
   *parsestate = NULL;
 }
 
 /**********************************************************************/ /**
- * @brief Print the extra header structure for the specified MS3Record.
- *
- * Output is printed in a pretty, formatted form for readability and
- * the anonymous, root object container (the outer {}) is not printed.
- *
- * @returns 0 on success and a (negative) libmseed error code on error.
- ***************************************************************************/
+                                                                          * @brief Print the extra header structure for the specified MS3Record.
+                                                                          *
+                                                                          * Output is printed in a pretty, formatted form for readability and
+                                                                          * the anonymous, root object container (the outer {}) is not printed.
+                                                                          *
+                                                                          * @returns 0 on success and a (negative) libmseed error code on error.
+                                                                          ***************************************************************************/
 int
 mseh_print (MS3Record *msr, int indent)
 {

--- a/extraheaders.h
+++ b/extraheaders.h
@@ -22,7 +22,8 @@
 #define EXTRAHEADERS_H 1
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #include "libmseed.h"
@@ -31,17 +32,17 @@ extern "C" {
 /* Avoid unused parameter warnings in known cases */
 #define UNUSED(x) (void)(x)
 
-/* Private allocation wrappers for yyjson's allocator definition */
-void *_priv_malloc(void *ctx, size_t size);
-void *_priv_realloc(void *ctx, void *ptr, size_t oldsize, size_t size);
-void _priv_free(void *ctx, void *ptr);
+  /* Private allocation wrappers for yyjson's allocator definition */
+  void *_priv_malloc (void *ctx, size_t size);
+  void *_priv_realloc (void *ctx, void *ptr, size_t oldsize, size_t size);
+  void _priv_free (void *ctx, void *ptr);
 
-/* Internal structure for holding parsed JSON extra headers */
-typedef struct LM_PARSED_JSON
-{
-  yyjson_doc *doc;
-  yyjson_mut_doc *mut_doc;
-} LM_PARSED_JSON;
+  /* Internal structure for holding parsed JSON extra headers */
+  typedef struct LM_PARSED_JSON
+  {
+    yyjson_doc *doc;
+    yyjson_mut_doc *mut_doc;
+  } LM_PARSED_JSON;
 
 #ifdef __cplusplus
 }

--- a/fileutils.c
+++ b/fileutils.c
@@ -36,15 +36,15 @@
 MS3FileParam gMS3FileParam = MS3FileParam_INITIALIZER;
 
 /* Stream state flags */
-#define MSFP_RANGEAPPLIED 0x0001  //!< Byte ranging has been applied
+#define MSFP_RANGEAPPLIED 0x0001 //!< Byte ranging has been applied
 
 static char *parse_pathname_range (const char *string, int64_t *start, int64_t *end);
 
 /*****************************************************************/ /**
- * @brief Run-time test for URL support in libmseed.
- *
- * @returns 0 when no URL suported is included, non-zero otherwise.
- *********************************************************************/
+                                                                     * @brief Run-time test for URL support in libmseed.
+                                                                     *
+                                                                     * @returns 0 when no URL suported is included, non-zero otherwise.
+                                                                     *********************************************************************/
 int
 libmseed_url_support (void)
 {
@@ -56,18 +56,18 @@ libmseed_url_support (void)
 } /* End of libmseed_url_support() */
 
 /*****************************************************************/ /**
- * @brief Read miniSEED records from a file or URL
- *
- * This routine is a wrapper for ms3_readmsr_selection() that uses the
- * global file reading parameters.  This routine is _not_ thread safe
- * and cannot be used to read more than one stream at a time.
- *
- * See ms3_readmsr_selection() for a further description of arguments.
- *
- * @returns Return value from ms3_readmsr_selection()
- *
- * \ref MessageOnError - this function logs a message on error
- *********************************************************************/
+                                                                     * @brief Read miniSEED records from a file or URL
+                                                                     *
+                                                                     * This routine is a wrapper for ms3_readmsr_selection() that uses the
+                                                                     * global file reading parameters.  This routine is _not_ thread safe
+                                                                     * and cannot be used to read more than one stream at a time.
+                                                                     *
+                                                                     * See ms3_readmsr_selection() for a further description of arguments.
+                                                                     *
+                                                                     * @returns Return value from ms3_readmsr_selection()
+                                                                     *
+                                                                     * \ref MessageOnError - this function logs a message on error
+                                                                     *********************************************************************/
 int
 ms3_readmsr (MS3Record **ppmsr, const char *mspath, int64_t *fpos,
              int8_t *last, uint32_t flags, int8_t verbose)
@@ -79,22 +79,22 @@ ms3_readmsr (MS3Record **ppmsr, const char *mspath, int64_t *fpos,
 } /* End of ms3_readmsr() */
 
 /*****************************************************************/ /**
- * @brief Read miniSEED records from a file or URL in a thread-safe way
- *
- * This routine is a wrapper for ms3_readmsr_selection() that uses the
- * re-entrant capabilities.  This routine is thread safe and can be
- * used to read more than one stream at a time as long as separate
- * MS3FileParam containers are used for each stream.
- *
- * A ::MS3FileParam container will be allocated if \c *ppmsfp is \c
- * NULL.
- *
- * See ms3_readmsr_selection() for a further description of arguments.
- *
- * @returns Return value from ms3_readmsr_selection()
- *
- * \ref MessageOnError - this function logs a message on error
- *********************************************************************/
+                                                                     * @brief Read miniSEED records from a file or URL in a thread-safe way
+                                                                     *
+                                                                     * This routine is a wrapper for ms3_readmsr_selection() that uses the
+                                                                     * re-entrant capabilities.  This routine is thread safe and can be
+                                                                     * used to read more than one stream at a time as long as separate
+                                                                     * MS3FileParam containers are used for each stream.
+                                                                     *
+                                                                     * A ::MS3FileParam container will be allocated if \c *ppmsfp is \c
+                                                                     * NULL.
+                                                                     *
+                                                                     * See ms3_readmsr_selection() for a further description of arguments.
+                                                                     *
+                                                                     * @returns Return value from ms3_readmsr_selection()
+                                                                     *
+                                                                     * \ref MessageOnError - this function logs a message on error
+                                                                     *********************************************************************/
 int
 ms3_readmsr_r (MS3FileParam **ppmsfp, MS3Record **ppmsr, const char *mspath,
                int64_t *fpos, int8_t *last, uint32_t flags, int8_t verbose)
@@ -150,88 +150,88 @@ ms3_shift_msfp (MS3FileParam *msfp, int shift)
 #define MSFPREADPTR(MSFP) (MSFP->readbuffer + MSFP->readoffset)
 
 /*****************************************************************/ /**
- * @brief Read miniSEED records from a file or URL with optional selection
- *
- * This routine will open and read, with subsequent calls, all
- * miniSEED records in specified stream (file or URL).
- *
- * All stream reading parameters are stored in a ::MS3FileParam
- * container and returned (via a pointer to a pointer) for the calling
- * routine to use in subsequent calls.  A ::MS3FileParam container
- * will be allocated if \c *ppmsfp is \c NULL.  This routine is thread
- * safe and can be used to read multiple streams in parallel as long as
- * the stream reading parameters are managed appropriately.
- *
- * If \a *fpos is not NULL it will be updated to reflect the stream
- * position (offset from the beginning in bytes) from where the
- * returned record was read.  As a special case, if \a *fpos is not
- * NULL and the value it points to is less than 0 this will be
- * interpreted as a (positive) starting offset from which to begin
- * reading data allowing the caller to specify an initial read offset.
- *
- * If \a *last is not NULL it will be set to 1 when the last record in
- * the stream is being returned, otherwise it will be 0.
- *
- * The \a flags argument are bit flags used to control the reading
- * process.  The following flags are supported:
- *  - ::MSF_SKIPNOTDATA - skip input that cannot be identified as miniSEED
- *  - ::MSF_UNPACKDATA data samples will be unpacked
- *  - ::MSF_VALIDATECRC Validate CRC (if present in format)
- *  - ::MSF_PNAMERANGE Parse byte range suffix from \a mspath
- *
- * If ::MSF_PNAMERANGE is set in \a flags, the \a mspath will be
- * searched for start and end byte offsets for the file or URL in the
- * following format: '\c PATH@@\c START-\c END', where \c START and \c
- * END are both optional and specified in bytes.
- *
- * If \a selections is not NULL, the ::MS3Selections will be used to
- * limit what is returned to the caller.  Any data not matching the
- * selections will be skipped.
- *
- * After reading all the records in a stream the calling program should
- * call this routine one last time with \a mspath set to NULL.  This
- * will close the stream and free allocated memory.
- *
- * @param[out] ppmsfp Pointer-to-pointer of an ::MS3FileParam, which
- * contains the state of stream reading across iterative calls of this
- * function.
- *
- * @param[out] ppmsr Pointer-to-pointer of an ::MS3Record, which will
- * contain a parsed record on success.
- *
- * @param[in] mspath File or URL to read
- *
- * @param[in,out] fpos Position in stream of last returned record as a
- * byte offset.  On initial call, if the referenced value is negative
- * it will be used as a starting position.
- *
- * @param[out] last Flag to indicate when the returned record is the
- * last one in the stream.
- *
- * @param[in] flags Flags used to control parsing, see @ref
- * control-flags
- *
- * @param[in] selections Specify limits to which data should be
- * returned, see @ref data-selections
- *
- * @param[in] verbose Controls verbosity, 0 means no diagnostic output
- *
- * @returns ::MS_NOERROR and populates an ::MS3Record struct, at \a
- * *ppmsr, on successful read.  On error, a (negative) libmseed error
- * code is returned and *ppmsr is set to NULL.
- * @retval ::MS_ENDOFFILE on reaching the end of a stream
- *
- * \sa @ref data-selections
- *
- * \ref MessageOnError - this function logs a message on error
- *********************************************************************/
+                                                                     * @brief Read miniSEED records from a file or URL with optional selection
+                                                                     *
+                                                                     * This routine will open and read, with subsequent calls, all
+                                                                     * miniSEED records in specified stream (file or URL).
+                                                                     *
+                                                                     * All stream reading parameters are stored in a ::MS3FileParam
+                                                                     * container and returned (via a pointer to a pointer) for the calling
+                                                                     * routine to use in subsequent calls.  A ::MS3FileParam container
+                                                                     * will be allocated if \c *ppmsfp is \c NULL.  This routine is thread
+                                                                     * safe and can be used to read multiple streams in parallel as long as
+                                                                     * the stream reading parameters are managed appropriately.
+                                                                     *
+                                                                     * If \a *fpos is not NULL it will be updated to reflect the stream
+                                                                     * position (offset from the beginning in bytes) from where the
+                                                                     * returned record was read.  As a special case, if \a *fpos is not
+                                                                     * NULL and the value it points to is less than 0 this will be
+                                                                     * interpreted as a (positive) starting offset from which to begin
+                                                                     * reading data allowing the caller to specify an initial read offset.
+                                                                     *
+                                                                     * If \a *last is not NULL it will be set to 1 when the last record in
+                                                                     * the stream is being returned, otherwise it will be 0.
+                                                                     *
+                                                                     * The \a flags argument are bit flags used to control the reading
+                                                                     * process.  The following flags are supported:
+                                                                     *  - ::MSF_SKIPNOTDATA - skip input that cannot be identified as miniSEED
+                                                                     *  - ::MSF_UNPACKDATA data samples will be unpacked
+                                                                     *  - ::MSF_VALIDATECRC Validate CRC (if present in format)
+                                                                     *  - ::MSF_PNAMERANGE Parse byte range suffix from \a mspath
+                                                                     *
+                                                                     * If ::MSF_PNAMERANGE is set in \a flags, the \a mspath will be
+                                                                     * searched for start and end byte offsets for the file or URL in the
+                                                                     * following format: '\c PATH@@\c START-\c END', where \c START and \c
+                                                                     * END are both optional and specified in bytes.
+                                                                     *
+                                                                     * If \a selections is not NULL, the ::MS3Selections will be used to
+                                                                     * limit what is returned to the caller.  Any data not matching the
+                                                                     * selections will be skipped.
+                                                                     *
+                                                                     * After reading all the records in a stream the calling program should
+                                                                     * call this routine one last time with \a mspath set to NULL.  This
+                                                                     * will close the stream and free allocated memory.
+                                                                     *
+                                                                     * @param[out] ppmsfp Pointer-to-pointer of an ::MS3FileParam, which
+                                                                     * contains the state of stream reading across iterative calls of this
+                                                                     * function.
+                                                                     *
+                                                                     * @param[out] ppmsr Pointer-to-pointer of an ::MS3Record, which will
+                                                                     * contain a parsed record on success.
+                                                                     *
+                                                                     * @param[in] mspath File or URL to read
+                                                                     *
+                                                                     * @param[in,out] fpos Position in stream of last returned record as a
+                                                                     * byte offset.  On initial call, if the referenced value is negative
+                                                                     * it will be used as a starting position.
+                                                                     *
+                                                                     * @param[out] last Flag to indicate when the returned record is the
+                                                                     * last one in the stream.
+                                                                     *
+                                                                     * @param[in] flags Flags used to control parsing, see @ref
+                                                                     * control-flags
+                                                                     *
+                                                                     * @param[in] selections Specify limits to which data should be
+                                                                     * returned, see @ref data-selections
+                                                                     *
+                                                                     * @param[in] verbose Controls verbosity, 0 means no diagnostic output
+                                                                     *
+                                                                     * @returns ::MS_NOERROR and populates an ::MS3Record struct, at \a
+                                                                     * *ppmsr, on successful read.  On error, a (negative) libmseed error
+                                                                     * code is returned and *ppmsr is set to NULL.
+                                                                     * @retval ::MS_ENDOFFILE on reaching the end of a stream
+                                                                     *
+                                                                     * \sa @ref data-selections
+                                                                     *
+                                                                     * \ref MessageOnError - this function logs a message on error
+                                                                     *********************************************************************/
 int
 ms3_readmsr_selection (MS3FileParam **ppmsfp, MS3Record **ppmsr, const char *mspath,
                        int64_t *fpos, int8_t *last, uint32_t flags,
                        MS3Selections *selections, int8_t verbose)
 {
   MS3FileParam *msfp;
-  uint32_t pflags = flags;
+  uint32_t pflags      = flags;
   char *pathname_range = NULL;
 
   int parseval  = 0;
@@ -258,7 +258,7 @@ ms3_readmsr_selection (MS3FileParam **ppmsfp, MS3Record **ppmsr, const char *msp
       return MS_GENERROR;
     }
 
-    *msfp = (MS3FileParam) MS3FileParam_INITIALIZER;
+    *msfp = (MS3FileParam)MS3FileParam_INITIALIZER;
 
     /* Redirect the supplied pointer to the allocated params */
     *ppmsfp = msfp;
@@ -278,7 +278,7 @@ ms3_readmsr_selection (MS3FileParam **ppmsfp, MS3Record **ppmsr, const char *msp
     /* If the parameters are the global parameters reset them */
     if (*ppmsfp == &gMS3FileParam)
     {
-      gMS3FileParam = (struct MS3FileParam) MS3FileParam_INITIALIZER;
+      gMS3FileParam = (struct MS3FileParam)MS3FileParam_INITIALIZER;
     }
     /* Otherwise free the MS3FileParam */
     else
@@ -328,12 +328,12 @@ ms3_readmsr_selection (MS3FileParam **ppmsfp, MS3Record **ppmsr, const char *msp
 
     if (strcmp (mspath, "-") == 0)
     {
-      msfp->input.type = LMIO_FILE;
+      msfp->input.type   = LMIO_FILE;
       msfp->input.handle = stdin;
     }
     else
     {
-      if (msio_fopen(&msfp->input, msfp->path, "rb", &msfp->startoffset, &msfp->endoffset))
+      if (msio_fopen (&msfp->input, msfp->path, "rb", &msfp->startoffset, &msfp->endoffset))
       {
         msr3_free (ppmsr);
         return MS_GENERROR;
@@ -559,20 +559,20 @@ ms3_readmsr_selection (MS3FileParam **ppmsfp, MS3Record **ppmsr, const char *msp
 } /* End of ms3_readmsr_selection() */
 
 /****************************************************************/ /**
- * @brief Read miniSEED from a file into a trace list
- *
- * This is a simple wrapper for ms3_readtracelist_selection() that
- * uses no selections.
- *
- * See ms3_readtracelist_selection() for a further description of
- * arguments.
- *
- * @returns Return value from ms3_readtracelist_selection()
- *
- * \ref MessageOnError - this function logs a message on error
- *
- * \sa @ref trace-list
- *********************************************************************/
+                                                                    * @brief Read miniSEED from a file into a trace list
+                                                                    *
+                                                                    * This is a simple wrapper for ms3_readtracelist_selection() that
+                                                                    * uses no selections.
+                                                                    *
+                                                                    * See ms3_readtracelist_selection() for a further description of
+                                                                    * arguments.
+                                                                    *
+                                                                    * @returns Return value from ms3_readtracelist_selection()
+                                                                    *
+                                                                    * \ref MessageOnError - this function logs a message on error
+                                                                    *
+                                                                    * \sa @ref trace-list
+                                                                    *********************************************************************/
 int
 ms3_readtracelist (MS3TraceList **ppmstl, const char *mspath,
                    MS3Tolerance *tolerance, int8_t splitversion,
@@ -583,21 +583,21 @@ ms3_readtracelist (MS3TraceList **ppmstl, const char *mspath,
 } /* End of ms3_readtracelist() */
 
 /****************************************************************/ /**
- * @brief Read miniSEED from a file into a trace list, with time range
- * selection
- *
- * This is a wrapper for ms3_readtraces_selection() that creates a
- * simple selection for a specified time window.
- *
- * See ms3_readtracelist_selection() for a further description of
- * arguments.
- *
- * @returns Return value from ms3_readtracelist_selection()
- *
- * \ref MessageOnError - this function logs a message on error
- *
- * \sa @ref trace-list
- *********************************************************************/
+                                                                    * @brief Read miniSEED from a file into a trace list, with time range
+                                                                    * selection
+                                                                    *
+                                                                    * This is a wrapper for ms3_readtraces_selection() that creates a
+                                                                    * simple selection for a specified time window.
+                                                                    *
+                                                                    * See ms3_readtracelist_selection() for a further description of
+                                                                    * arguments.
+                                                                    *
+                                                                    * @returns Return value from ms3_readtracelist_selection()
+                                                                    *
+                                                                    * \ref MessageOnError - this function logs a message on error
+                                                                    *
+                                                                    * \sa @ref trace-list
+                                                                    *********************************************************************/
 int
 ms3_readtracelist_timewin (MS3TraceList **ppmstl, const char *mspath,
                            MS3Tolerance *tolerance,
@@ -612,6 +612,7 @@ ms3_readtracelist_timewin (MS3TraceList **ppmstl, const char *mspath,
   selection.timewindows   = &selecttime;
   selection.pubversion    = 0;
   selection.next          = NULL;
+  selection.pubversion    = 0;
 
   selecttime.starttime = starttime;
   selecttime.endtime   = endtime;
@@ -623,53 +624,53 @@ ms3_readtracelist_timewin (MS3TraceList **ppmstl, const char *mspath,
 } /* End of ms3_readtracelist_timewin() */
 
 /****************************************************************/ /**
- * @brief Read miniSEED from a file into a trace list, with selection
- * filtering
- *
- * This routine will open and read all miniSEED records in specified
- * file and populate a ::MS3TraceList, allocating this struture if
- * needed.  This routine is thread safe.
- *
- * If \a selections is not NULL, the ::MS3Selections will be used to
- * limit which records are added to the trace list.  Any data not
- * matching the selections will be skipped.
- *
- * As this routine reads miniSEED records it attempts to construct
- * continuous time series, merging segments when possible.  See
- * mstl3_addmsr() for details of \a tolerance.
- *
- * The \a splitversion flag controls whether data are grouped
- * according to data publication version (or quality for miniSEED
- * 2.x).  See mstl3_addmsr() for full details.
- *
- * If the ::MSF_RECORDLIST flag is set in \a flags, a ::MS3RecordList
- * will be built for each ::MS3TraceSeg.  The ::MS3RecordPtr entries
- * contain the location of the data record, bit flags, extra headers, etc.
- *
- * @param[out] ppmstl Pointer-to-pointer to a ::MS3TraceList to populate
- * @param[in] mspath File to read
- * @param[in] tolerance Tolerance function pointers as ::MS3Tolerance
- * @param[in] selections Pointer to ::MS3Selections for limiting data
- * @param[in] splitversion Flag to control splitting of version/quality
- * @param[in] flags Flags to control reading, see ms3_readmsr_selection()
- * @param[in] verbose Controls verbosity, 0 means no diagnostic output
- *
- * @returns ::MS_NOERROR and populates an ::MS3TraceList struct at *ppmstl
- * on success, otherwise returns a (negative) libmseed error code.
- *
- * \ref MessageOnError - this function logs a message on error
- *
- * \sa @ref trace-list
- * \sa @ref data-selections
- *********************************************************************/
+                                                                    * @brief Read miniSEED from a file into a trace list, with selection
+                                                                    * filtering
+                                                                    *
+                                                                    * This routine will open and read all miniSEED records in specified
+                                                                    * file and populate a ::MS3TraceList, allocating this struture if
+                                                                    * needed.  This routine is thread safe.
+                                                                    *
+                                                                    * If \a selections is not NULL, the ::MS3Selections will be used to
+                                                                    * limit which records are added to the trace list.  Any data not
+                                                                    * matching the selections will be skipped.
+                                                                    *
+                                                                    * As this routine reads miniSEED records it attempts to construct
+                                                                    * continuous time series, merging segments when possible.  See
+                                                                    * mstl3_addmsr() for details of \a tolerance.
+                                                                    *
+                                                                    * The \a splitversion flag controls whether data are grouped
+                                                                    * according to data publication version (or quality for miniSEED
+                                                                    * 2.x).  See mstl3_addmsr() for full details.
+                                                                    *
+                                                                    * If the ::MSF_RECORDLIST flag is set in \a flags, a ::MS3RecordList
+                                                                    * will be built for each ::MS3TraceSeg.  The ::MS3RecordPtr entries
+                                                                    * contain the location of the data record, bit flags, extra headers, etc.
+                                                                    *
+                                                                    * @param[out] ppmstl Pointer-to-pointer to a ::MS3TraceList to populate
+                                                                    * @param[in] mspath File to read
+                                                                    * @param[in] tolerance Tolerance function pointers as ::MS3Tolerance
+                                                                    * @param[in] selections Pointer to ::MS3Selections for limiting data
+                                                                    * @param[in] splitversion Flag to control splitting of version/quality
+                                                                    * @param[in] flags Flags to control reading, see ms3_readmsr_selection()
+                                                                    * @param[in] verbose Controls verbosity, 0 means no diagnostic output
+                                                                    *
+                                                                    * @returns ::MS_NOERROR and populates an ::MS3TraceList struct at *ppmstl
+                                                                    * on success, otherwise returns a (negative) libmseed error code.
+                                                                    *
+                                                                    * \ref MessageOnError - this function logs a message on error
+                                                                    *
+                                                                    * \sa @ref trace-list
+                                                                    * \sa @ref data-selections
+                                                                    *********************************************************************/
 int
 ms3_readtracelist_selection (MS3TraceList **ppmstl, const char *mspath,
                              MS3Tolerance *tolerance, MS3Selections *selections,
                              int8_t splitversion, uint32_t flags, int8_t verbose)
 {
-  MS3Record *msr     = NULL;
-  MS3FileParam *msfp = NULL;
-  MS3TraceSeg *seg   = NULL;
+  MS3Record *msr          = NULL;
+  MS3FileParam *msfp      = NULL;
+  MS3TraceSeg *seg        = NULL;
   MS3RecordPtr *recordptr = NULL;
   uint32_t dataoffset;
   uint32_t datasize;
@@ -738,23 +739,23 @@ ms3_readtracelist_selection (MS3TraceList **ppmstl, const char *mspath,
 } /* End of ms3_readtracelist_selection() */
 
 /*****************************************************************/ /**
- * @brief Set User-Agent header for URL-based requests.
- *
- * Configure global User-Agent header for URL-based requests
- * generated by the library.  The \a program and \a version values
- * will be combined into the form "program/version" along with
- * declarations of the library and URL-supporting dependency versions.
- *
- * An error will be returned when the library was not compiled with
- * URL support.
- *
- * @param[in] program Name of calling program
- * @param[in] version Version of calling program
- *
- * @returns 0 on succes and a negative library error code on error.
- *
- * \ref MessageOnError - this function logs a message on error
- *********************************************************************/
+                                                                     * @brief Set User-Agent header for URL-based requests.
+                                                                     *
+                                                                     * Configure global User-Agent header for URL-based requests
+                                                                     * generated by the library.  The \a program and \a version values
+                                                                     * will be combined into the form "program/version" along with
+                                                                     * declarations of the library and URL-supporting dependency versions.
+                                                                     *
+                                                                     * An error will be returned when the library was not compiled with
+                                                                     * URL support.
+                                                                     *
+                                                                     * @param[in] program Name of calling program
+                                                                     * @param[in] version Version of calling program
+                                                                     *
+                                                                     * @returns 0 on succes and a negative library error code on error.
+                                                                     *
+                                                                     * \ref MessageOnError - this function logs a message on error
+                                                                     *********************************************************************/
 int
 ms3_url_useragent (const char *program, const char *version)
 {
@@ -767,22 +768,22 @@ ms3_url_useragent (const char *program, const char *version)
 } /* End of ms3_url_useragent() */
 
 /*****************************************************************/ /**
- * @brief Set authentication credentials for URL-based requests.
- *
- * Sets global user and password for authentication for URL-based
- * requests generated by the library.  The expected format of the
- * credentials is: "[user name]:[password]" (without the square
- * brackets).
- *
- * An error will be returned when the library was not compiled with
- * URL support.
- *
- * @param[in] userpassword User and password as user:password
- *
- * @returns 0 on succes and a negative library error code on error.
- *
- * \ref MessageOnError - this function logs a message on error
- *********************************************************************/
+                                                                     * @brief Set authentication credentials for URL-based requests.
+                                                                     *
+                                                                     * Sets global user and password for authentication for URL-based
+                                                                     * requests generated by the library.  The expected format of the
+                                                                     * credentials is: "[user name]:[password]" (without the square
+                                                                     * brackets).
+                                                                     *
+                                                                     * An error will be returned when the library was not compiled with
+                                                                     * URL support.
+                                                                     *
+                                                                     * @param[in] userpassword User and password as user:password
+                                                                     *
+                                                                     * @returns 0 on succes and a negative library error code on error.
+                                                                     *
+                                                                     * \ref MessageOnError - this function logs a message on error
+                                                                     *********************************************************************/
 int
 ms3_url_userpassword (const char *userpassword)
 {
@@ -795,22 +796,22 @@ ms3_url_userpassword (const char *userpassword)
 } /* End of ms3_url_userpassword() */
 
 /*****************************************************************/ /**
- * @brief Add header to any URL-based requests.
- *
- * Sets global header to be included in URL-based requests generated
- * by the library.
- *
- * An error will be returned when the library was not compiled with
- * URL support.
- *
- * @sa ms3_url_freeheaders()
- *
- * @param[in] header Header in "key: value" format
- *
- * @returns 0 on succes and a negative library error code on error.
- *
- * \ref MessageOnError - this function logs a message on error
- *********************************************************************/
+                                                                     * @brief Add header to any URL-based requests.
+                                                                     *
+                                                                     * Sets global header to be included in URL-based requests generated
+                                                                     * by the library.
+                                                                     *
+                                                                     * An error will be returned when the library was not compiled with
+                                                                     * URL support.
+                                                                     *
+                                                                     * @sa ms3_url_freeheaders()
+                                                                     *
+                                                                     * @param[in] header Header in "key: value" format
+                                                                     *
+                                                                     * @returns 0 on succes and a negative library error code on error.
+                                                                     *
+                                                                     * \ref MessageOnError - this function logs a message on error
+                                                                     *********************************************************************/
 int
 ms3_url_addheader (const char *header)
 {
@@ -823,13 +824,13 @@ ms3_url_addheader (const char *header)
 } /* End of ms3_url_addheader() */
 
 /*****************************************************************/ /**
- * @brief Free all set headers for URL-based requests.
- *
- * Free all global headers for URL-based requests as set by
- * ms3_url_addheader().
- *
- * @sa ms3_url_addheader()
- *********************************************************************/
+                                                                     * @brief Free all set headers for URL-based requests.
+                                                                     *
+                                                                     * Free all global headers for URL-based requests as set by
+                                                                     * ms3_url_addheader().
+                                                                     *
+                                                                     * @sa ms3_url_addheader()
+                                                                     *********************************************************************/
 void
 ms3_url_freeheaders (void)
 {
@@ -840,7 +841,6 @@ ms3_url_freeheaders (void)
   msio_url_freeheaders ();
 #endif
 } /* End of ms3_url_freeheaders() */
-
 
 /***************************************************************************
  *
@@ -858,30 +858,30 @@ ms_record_handler_int (char *record, int reclen, void *ofp)
 } /* End of ms_record_handler_int() */
 
 /**********************************************************************/ /**
- * @brief Write miniSEED from an ::MS3Record container to a file
- *
- * Pack ::MS3Record data into miniSEED record(s) by calling
- * msr3_pack() and write to a specified file.  The ::MS3Record
- * container is used as a template for record(s) written to the file.
- *
- * The \a overwrite flag controls whether a existing file is
- * overwritten or not.  If true (non-zero) any existing file will be
- * replaced.  If false (zero) new records will be appended to an
- * existing file.  In either case, new files will be created if they
- * do not yet exist.
- *
- * @param[in,out] msr ::MS3Record containing data to write
- * @param[in] mspath File for output records
- * @param[in] overwrite Flag to control overwriting versus appending
- * @param[in] flags Flags controlling data packing, see msr3_pack()
- * @param[in] verbose Controls verbosity, 0 means no diagnostic output
- *
- * @returns the number of records written on success and -1 on error.
- *
- * \ref MessageOnError - this function logs a message on error
- *
- * \sa msr3_pack()
- ***************************************************************************/
+                                                                          * @brief Write miniSEED from an ::MS3Record container to a file
+                                                                          *
+                                                                          * Pack ::MS3Record data into miniSEED record(s) by calling
+                                                                          * msr3_pack() and write to a specified file.  The ::MS3Record
+                                                                          * container is used as a template for record(s) written to the file.
+                                                                          *
+                                                                          * The \a overwrite flag controls whether a existing file is
+                                                                          * overwritten or not.  If true (non-zero) any existing file will be
+                                                                          * replaced.  If false (zero) new records will be appended to an
+                                                                          * existing file.  In either case, new files will be created if they
+                                                                          * do not yet exist.
+                                                                          *
+                                                                          * @param[in,out] msr ::MS3Record containing data to write
+                                                                          * @param[in] mspath File for output records
+                                                                          * @param[in] overwrite Flag to control overwriting versus appending
+                                                                          * @param[in] flags Flags controlling data packing, see msr3_pack()
+                                                                          * @param[in] verbose Controls verbosity, 0 means no diagnostic output
+                                                                          *
+                                                                          * @returns the number of records written on success and -1 on error.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          *
+                                                                          * \sa msr3_pack()
+                                                                          ***************************************************************************/
 int64_t
 msr3_writemseed (MS3Record *msr, const char *mspath, int8_t overwrite,
                  uint32_t flags, int8_t verbose)
@@ -917,32 +917,32 @@ msr3_writemseed (MS3Record *msr, const char *mspath, int8_t overwrite,
 } /* End of msr3_writemseed() */
 
 /**********************************************************************/ /**
- * @brief Write miniSEED from an ::MS3TraceList container to a file
- *
- * Pack ::MS3TraceList data into miniSEED record(s) by calling
- * mstl3_pack() and write to a specified file.
- *
- * The \a overwrite flag controls whether a existing file is
- * overwritten or not.  If true (non-zero) any existing file will be
- * replaced.  If false (zero) new records will be appended to an
- * existing file.  In either case, new files will be created if they
- * do not yet exist.
- *
- * @param[in,out] mstl ::MS3TraceList containing data to write
- * @param[in] mspath File for output records
- * @param[in] overwrite Flag to control overwriting versus appending
- * @param[in] maxreclen The maximum record length to create
- * @param[in] encoding encoding Encoding for data samples, see msr3_pack()
- * @param[in] flags Flags controlling data packing, see mstl3_pack() and msr3_pack()
- * @param[in] verbose Controls verbosity, 0 means no diagnostic output
- *
- * @returns the number of records written on success and -1 on error.
- *
- * \ref MessageOnError - this function logs a message on error
- *
- * \sa mstl3_pack()
- * \sa msr3_pack()
- ***************************************************************************/
+                                                                          * @brief Write miniSEED from an ::MS3TraceList container to a file
+                                                                          *
+                                                                          * Pack ::MS3TraceList data into miniSEED record(s) by calling
+                                                                          * mstl3_pack() and write to a specified file.
+                                                                          *
+                                                                          * The \a overwrite flag controls whether a existing file is
+                                                                          * overwritten or not.  If true (non-zero) any existing file will be
+                                                                          * replaced.  If false (zero) new records will be appended to an
+                                                                          * existing file.  In either case, new files will be created if they
+                                                                          * do not yet exist.
+                                                                          *
+                                                                          * @param[in,out] mstl ::MS3TraceList containing data to write
+                                                                          * @param[in] mspath File for output records
+                                                                          * @param[in] overwrite Flag to control overwriting versus appending
+                                                                          * @param[in] maxreclen The maximum record length to create
+                                                                          * @param[in] encoding encoding Encoding for data samples, see msr3_pack()
+                                                                          * @param[in] flags Flags controlling data packing, see mstl3_pack() and msr3_pack()
+                                                                          * @param[in] verbose Controls verbosity, 0 means no diagnostic output
+                                                                          *
+                                                                          * @returns the number of records written on success and -1 on error.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          *
+                                                                          * \sa mstl3_pack()
+                                                                          * \sa msr3_pack()
+                                                                          ***************************************************************************/
 int64_t
 mstl3_writemseed (MS3TraceList *mstl, const char *mspath, int8_t overwrite,
                   int maxreclen, int8_t encoding, uint32_t flags, int8_t verbose)
@@ -983,19 +983,18 @@ mstl3_writemseed (MS3TraceList *mstl, const char *mspath, int8_t overwrite,
   return (packedrecords >= 0) ? packedrecords : -1;
 } /* End of mstl3_writemseed() */
 
-
 /*****************************************************************/ /**
- * Parse a range from the end of a string.
- *
- * Expected format is: 'PATH@START-END'
- * where START and END are optional but the dash must be included
- * for an END to be present.  The START and END values must contain
- * 20 or fewer digits (0-9).
- *
- * Expected variations: '@START', '@START-END', '@-END'
- *
- * @returns Pointer to '@' starting valid range on success, otherwise NULL.
- *********************************************************************/
+                                                                     * Parse a range from the end of a string.
+                                                                     *
+                                                                     * Expected format is: 'PATH@START-END'
+                                                                     * where START and END are optional but the dash must be included
+                                                                     * for an END to be present.  The START and END values must contain
+                                                                     * 20 or fewer digits (0-9).
+                                                                     *
+                                                                     * Expected variations: '@START', '@START-END', '@-END'
+                                                                     *
+                                                                     * @returns Pointer to '@' starting valid range on success, otherwise NULL.
+                                                                     *********************************************************************/
 char *
 parse_pathname_range (const char *string, int64_t *start, int64_t *end)
 {
@@ -1019,10 +1018,10 @@ parse_pathname_range (const char *string, int64_t *start, int64_t *end)
     while (*(++ptr) != '\0')
     {
       /* If a digit before dash, part of start */
-      if (isdigit(*ptr) && dash == NULL)
+      if (isdigit (*ptr) && dash == NULL)
         startstr[startdigits++] = *ptr;
       /* If a digit after dash, part of end */
-      else if (isdigit(*ptr) && dash != NULL)
+      else if (isdigit (*ptr) && dash != NULL)
         endstr[enddigits++] = *ptr;
       /* If a dash after a dash, not a valid range */
       else if (*ptr == '-' && dash != NULL)
@@ -1035,16 +1034,16 @@ parse_pathname_range (const char *string, int64_t *start, int64_t *end)
         return NULL;
 
       /* If digit sequences have exceeded limits, not a valid range */
-      if (startdigits >= sizeof(startstr) || enddigits >= sizeof(endstr))
+      if (startdigits >= sizeof (startstr) || enddigits >= sizeof (endstr))
         return NULL;
     }
 
     /* Convert start and end values to numbers if non-zero length */
     if (start && startdigits)
-      *start = (int64_t) strtoull (startstr, NULL, 10);
+      *start = (int64_t)strtoull (startstr, NULL, 10);
 
     if (end && enddigits)
-      *end = (int64_t) strtoull (endstr, NULL, 10);
+      *end = (int64_t)strtoull (endstr, NULL, 10);
   }
 
   return at;

--- a/genutils.c
+++ b/genutils.c
@@ -33,7 +33,7 @@ static nstime_t ms_time2nstime_int (int year, int day, int hour,
 /** @cond UNDOCUMENTED */
 
 /* Global set of allocation functions, defaulting to system malloc(), realloc() and free() */
-LIBMSEED_MEMORY libmseed_memory = { .malloc = malloc, .realloc = realloc, .free = free };
+LIBMSEED_MEMORY libmseed_memory = {.malloc = malloc, .realloc = realloc, .free = free};
 
 /* Global pre-allocation block size, default 1 MiB on Windows, disabled otherwise */
 #if defined(LMP_WIN)
@@ -143,42 +143,41 @@ static const int monthdays_leap[] = {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30,
 
 /** @endcond */
 
-
 /**********************************************************************/ /**
- * @brief Parse network, station, location and channel from an FDSN Source ID
- *
- * FDSN Source Identifiers are defined at:
- *   https://docs.fdsn.org/projects/source-identifiers/
- *
- * Parse a source identifier into separate components, expecting:
- *  \c "FDSN:NET_STA_LOC_CHAN", where \c CHAN="BAND_SOURCE_POSITION"
- *
- * The CHAN value will be converted to a SEED channel code if
- * possible.  Meaning, if the BAND, SOURCE, and POSITION are single
- * characters, the underscore delimiters will not be included in the
- * returned channel.
- *
- * Identifiers may contain additional namespace identifiers, e.g.:
- *  \c "FDSN:AGENCY:NET_STA_LOC_CHAN"
- *
- * Such additional namespaces are not part of the Source ID standard
- * as of this writing and support is included for specialized usage or
- * future identifier changes.
- *
- * Memory for each component must already be allocated.  If a specific
- * component is not desired set the appropriate argument to NULL.
- *
- * @param[in] sid Source identifier
- * @param[out] net Network code
- * @param[out] sta Station code
- * @param[out] loc Location code
- * @param[out] chan Channel code
- *
- * @retval 0 on success
- * @retval -1 on error
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Parse network, station, location and channel from an FDSN Source ID
+                                                                          *
+                                                                          * FDSN Source Identifiers are defined at:
+                                                                          *   https://docs.fdsn.org/projects/source-identifiers/
+                                                                          *
+                                                                          * Parse a source identifier into separate components, expecting:
+                                                                          *  \c "FDSN:NET_STA_LOC_CHAN", where \c CHAN="BAND_SOURCE_POSITION"
+                                                                          *
+                                                                          * The CHAN value will be converted to a SEED channel code if
+                                                                          * possible.  Meaning, if the BAND, SOURCE, and POSITION are single
+                                                                          * characters, the underscore delimiters will not be included in the
+                                                                          * returned channel.
+                                                                          *
+                                                                          * Identifiers may contain additional namespace identifiers, e.g.:
+                                                                          *  \c "FDSN:AGENCY:NET_STA_LOC_CHAN"
+                                                                          *
+                                                                          * Such additional namespaces are not part of the Source ID standard
+                                                                          * as of this writing and support is included for specialized usage or
+                                                                          * future identifier changes.
+                                                                          *
+                                                                          * Memory for each component must already be allocated.  If a specific
+                                                                          * component is not desired set the appropriate argument to NULL.
+                                                                          *
+                                                                          * @param[in] sid Source identifier
+                                                                          * @param[out] net Network code
+                                                                          * @param[out] sta Station code
+                                                                          * @param[out] loc Location code
+                                                                          * @param[out] chan Channel code
+                                                                          *
+                                                                          * @retval 0 on success
+                                                                          * @retval -1 on error
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 ms_sid2nslc (const char *sid, char *net, char *sta, char *loc, char *chan)
 {
@@ -259,7 +258,7 @@ ms_sid2nslc (const char *sid, char *net, char *sta, char *loc, char *chan)
     if (*top && chan)
     {
       /* Map extended channel to SEED channel if possible, otherwise direct copy */
-      if (ms_xchan2seedchan(chan, top))
+      if (ms_xchan2seedchan (chan, top))
       {
         strcpy (chan, top);
       }
@@ -279,44 +278,44 @@ ms_sid2nslc (const char *sid, char *net, char *sta, char *loc, char *chan)
 } /* End of ms_sid2nslc() */
 
 /**********************************************************************/ /**
- * @brief Convert network, station, location and channel to an FDSN Source ID
- *
- * FDSN Source Identifiers are defined at:
- *   https://docs.fdsn.org/projects/source-identifiers/
- *
- * Create a source identifier from individual network,
- * station, location and channel codes with the form:
- *  \c FDSN:NET_STA_LOC_CHAN, where \c CHAN="BAND_SOURCE_POSITION"
- *
- * Memory for the source identifier must already be allocated.  If a
- * specific component is NULL it will be empty in the resulting
- * identifier.
- *
- * The \a chan value will be converted to extended channel format if
- * it appears to be in SEED channel form.  Meaning, if the \a chan is
- * 3 characters with no delimiters, it will be converted to \c
- * "BAND_SOURCE_POSITION" form by adding delimiters between the codes.
- *
- * @param[out] sid Destination string for source identifier
- * @param sidlen Maximum length of \a sid
- * @param flags Currently unused, set to 0
- * @param[in] net Network code
- * @param[in] sta Station code
- * @param[in] loc Location code
- * @param[in] chan Channel code
- *
- * @returns length of source identifier
- * @retval -1 on error
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Convert network, station, location and channel to an FDSN Source ID
+                                                                          *
+                                                                          * FDSN Source Identifiers are defined at:
+                                                                          *   https://docs.fdsn.org/projects/source-identifiers/
+                                                                          *
+                                                                          * Create a source identifier from individual network,
+                                                                          * station, location and channel codes with the form:
+                                                                          *  \c FDSN:NET_STA_LOC_CHAN, where \c CHAN="BAND_SOURCE_POSITION"
+                                                                          *
+                                                                          * Memory for the source identifier must already be allocated.  If a
+                                                                          * specific component is NULL it will be empty in the resulting
+                                                                          * identifier.
+                                                                          *
+                                                                          * The \a chan value will be converted to extended channel format if
+                                                                          * it appears to be in SEED channel form.  Meaning, if the \a chan is
+                                                                          * 3 characters with no delimiters, it will be converted to \c
+                                                                          * "BAND_SOURCE_POSITION" form by adding delimiters between the codes.
+                                                                          *
+                                                                          * @param[out] sid Destination string for source identifier
+                                                                          * @param sidlen Maximum length of \a sid
+                                                                          * @param flags Currently unused, set to 0
+                                                                          * @param[in] net Network code
+                                                                          * @param[in] sta Station code
+                                                                          * @param[in] loc Location code
+                                                                          * @param[in] chan Channel code
+                                                                          *
+                                                                          * @returns length of source identifier
+                                                                          * @retval -1 on error
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 ms_nslc2sid (char *sid, int sidlen, uint16_t flags,
              const char *net, const char *sta, const char *loc, const char *chan)
 {
-  char *sptr = sid;
+  char *sptr    = sid;
   char xchan[6] = {0};
-  int needed = 0;
+  int needed    = 0;
 
   if (!sid)
   {
@@ -418,21 +417,21 @@ ms_nslc2sid (char *sid, int sidlen, uint16_t flags,
 } /* End of ms_nslc2sid() */
 
 /**********************************************************************/ /**
- * @brief Convert SEED 2.x channel to extended channel
- *
- * The SEED 2.x channel at \a seedchan must be a 3-character string.
- * The \a xchan buffer must be at least 6 bytes, for the extended
- * channel (band,source,position) and the terminating NULL.
- *
- * This functionality simply maps patterns, it does not check the
- * validity of any codes.
- *
- * @param[out] xchan Destination for extended channel string, must be at least 6 bytes
- * @param[in] seedchan Source string, must be a 3-character string
- *
- * @retval 0 on successful mapping of channel
- * @retval -1 on error
- ***************************************************************************/
+                                                                          * @brief Convert SEED 2.x channel to extended channel
+                                                                          *
+                                                                          * The SEED 2.x channel at \a seedchan must be a 3-character string.
+                                                                          * The \a xchan buffer must be at least 6 bytes, for the extended
+                                                                          * channel (band,source,position) and the terminating NULL.
+                                                                          *
+                                                                          * This functionality simply maps patterns, it does not check the
+                                                                          * validity of any codes.
+                                                                          *
+                                                                          * @param[out] xchan Destination for extended channel string, must be at least 6 bytes
+                                                                          * @param[in] seedchan Source string, must be a 3-character string
+                                                                          *
+                                                                          * @retval 0 on successful mapping of channel
+                                                                          * @retval -1 on error
+                                                                          ***************************************************************************/
 int
 ms_seedchan2xchan (char *xchan, const char *seedchan)
 {
@@ -458,26 +457,26 @@ ms_seedchan2xchan (char *xchan, const char *seedchan)
 } /* End of ms_seedchan2xchan() */
 
 /**********************************************************************/ /**
- * @brief Convert extended channel to SEED 2.x channel
- *
- * The extended channel at \a xchan must be a 5-character string.
- *
- * The \a seedchan buffer must be at least 4 bytes, for the SEED
- * channel and the terminating NULL.  Alternatively, \a seedchan may
- * be set to NULL in which case this function becomes a test for
- * whether the \a xchan _could_ be mapped without actually doing the
- * conversion.  Finally, \a seedchan can be the same buffer as \a
- * xchan for an in-place conversion.
- *
- * This routine simply maps patterns, it does not check the validity
- * of any specific codes.
- *
- * @param[out] seedchan Destination for SEED channel string, must be at least 4 bytes
- * @param[in] xchan Source string, must be a 5-character string
- *
- * @retval 0 on successful mapping of channel
- * @retval -1 on error
- ***************************************************************************/
+                                                                          * @brief Convert extended channel to SEED 2.x channel
+                                                                          *
+                                                                          * The extended channel at \a xchan must be a 5-character string.
+                                                                          *
+                                                                          * The \a seedchan buffer must be at least 4 bytes, for the SEED
+                                                                          * channel and the terminating NULL.  Alternatively, \a seedchan may
+                                                                          * be set to NULL in which case this function becomes a test for
+                                                                          * whether the \a xchan _could_ be mapped without actually doing the
+                                                                          * conversion.  Finally, \a seedchan can be the same buffer as \a
+                                                                          * xchan for an in-place conversion.
+                                                                          *
+                                                                          * This routine simply maps patterns, it does not check the validity
+                                                                          * of any specific codes.
+                                                                          *
+                                                                          * @param[out] seedchan Destination for SEED channel string, must be at least 4 bytes
+                                                                          * @param[in] xchan Source string, must be a 5-character string
+                                                                          *
+                                                                          * @retval 0 on successful mapping of channel
+                                                                          * @retval -1 on error
+                                                                          ***************************************************************************/
 int
 ms_xchan2seedchan (char *seedchan, const char *xchan)
 {
@@ -503,27 +502,27 @@ ms_xchan2seedchan (char *seedchan, const char *xchan)
   }
 
   return -1;
-}  /* End of ms_xchan2seedchan() */
+} /* End of ms_xchan2seedchan() */
 
 // For utf8d table and utf8length_int() basics:
 // Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
 // See http://bjoern.hoehrmann.de/utf-8/decoder/dfa/ for details.
 
 static const uint8_t utf8d[] = {
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 00..1f
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 20..3f
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 40..5f
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 60..7f
-  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, // 80..9f
-  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7, // a0..bf
-  8,8,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2, // c0..df
-  0xa,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x4,0x3,0x3, // e0..ef
-  0xb,0x6,0x6,0x6,0x5,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8, // f0..ff
-  0x0,0x1,0x2,0x3,0x5,0x8,0x7,0x1,0x1,0x1,0x4,0x6,0x1,0x1,0x1,0x1, // s0..s0
-  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,0,1,0,1,1,1,1,1,1, // s1..s2
-  1,2,1,1,1,1,1,2,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1, // s3..s4
-  1,2,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,3,1,3,1,1,1,1,1,1, // s5..s6
-  1,3,1,1,1,1,1,3,1,3,1,1,1,1,1,1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1, // s7..s8
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 00..1f
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 20..3f
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 40..5f
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 60..7f
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, // 80..9f
+    7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, // a0..bf
+    8, 8, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // c0..df
+    0xa, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x4, 0x3, 0x3,                 // e0..ef
+    0xb, 0x6, 0x6, 0x6, 0x5, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8,                 // f0..ff
+    0x0, 0x1, 0x2, 0x3, 0x5, 0x8, 0x7, 0x1, 0x1, 0x1, 0x4, 0x6, 0x1, 0x1, 0x1, 0x1,                 // s0..s0
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, // s1..s2
+    1, 2, 1, 1, 1, 1, 1, 2, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, // s3..s4
+    1, 2, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 1, 3, 1, 1, 1, 1, 1, 1, // s5..s6
+    1, 3, 1, 1, 1, 1, 1, 3, 1, 3, 1, 1, 1, 1, 1, 1, 1, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // s7..s8
 };
 
 /***************************************************************************
@@ -553,7 +552,7 @@ utf8length_int (const char *str, int maxlength)
 
   for (offset = 0; str[offset] && offset < maxlength; offset++)
   {
-    type = utf8d[(uint8_t)str[offset]];
+    type  = utf8d[(uint8_t)str[offset]];
     state = utf8d[256 + state * 16 + type];
 
     /* A valid codepoint was found, update length */
@@ -562,26 +561,26 @@ utf8length_int (const char *str, int maxlength)
   }
 
   return length;
-}  /* End of utf8length_int() */
+} /* End of utf8length_int() */
 
 /**********************************************************************/ /**
- * @brief Copy string, removing spaces, always terminated
- *
- * Copy up to \a length bytes of UTF-8 characters from \a source to \a
- * dest while removing all spaces.  The result is left justified and
- * always null terminated.
- *
- * The destination string must have enough room needed for the
- * non-space characters within \a length and the null terminator, a
- * maximum of \a length + 1.
- *
- * @param[out] dest Destination for terminated string
- * @param[in] source Source string
- * @param[in] length Length of characters for destination string in bytes
- *
- * @returns the number of characters (not including the null terminator) in
- * the destination string
- ***************************************************************************/
+                                                                          * @brief Copy string, removing spaces, always terminated
+                                                                          *
+                                                                          * Copy up to \a length bytes of UTF-8 characters from \a source to \a
+                                                                          * dest while removing all spaces.  The result is left justified and
+                                                                          * always null terminated.
+                                                                          *
+                                                                          * The destination string must have enough room needed for the
+                                                                          * non-space characters within \a length and the null terminator, a
+                                                                          * maximum of \a length + 1.
+                                                                          *
+                                                                          * @param[out] dest Destination for terminated string
+                                                                          * @param[in] source Source string
+                                                                          * @param[in] length Length of characters for destination string in bytes
+                                                                          *
+                                                                          * @returns the number of characters (not including the null terminator) in
+                                                                          * the destination string
+                                                                          ***************************************************************************/
 int
 ms_strncpclean (char *dest, const char *source, int length)
 {
@@ -619,23 +618,23 @@ ms_strncpclean (char *dest, const char *source, int length)
 } /* End of ms_strncpclean() */
 
 /**********************************************************************/ /**
- * @brief Copy string, removing trailing spaces, always terminated
- *
- * Copy up to \a length bytes of UTF-8 characters from \a source to \a
- * dest without any trailing spaces.  The result is left justified and
- * always null terminated.
- *
- * The destination string must have enough room needed for the
- * characters within \a length and the null terminator, a maximum of
- * \a length + 1.
- *
- * @param[out] dest Destination for terminated string
- * @param[in] source Source string
- * @param[in] length Length of characters for destination string in bytes
- *
- * @returns The number of characters (not including the null terminator) in
- * the destination string
- ***************************************************************************/
+                                                                          * @brief Copy string, removing trailing spaces, always terminated
+                                                                          *
+                                                                          * Copy up to \a length bytes of UTF-8 characters from \a source to \a
+                                                                          * dest without any trailing spaces.  The result is left justified and
+                                                                          * always null terminated.
+                                                                          *
+                                                                          * The destination string must have enough room needed for the
+                                                                          * characters within \a length and the null terminator, a maximum of
+                                                                          * \a length + 1.
+                                                                          *
+                                                                          * @param[out] dest Destination for terminated string
+                                                                          * @param[in] source Source string
+                                                                          * @param[in] length Length of characters for destination string in bytes
+                                                                          *
+                                                                          * @returns The number of characters (not including the null terminator) in
+                                                                          * the destination string
+                                                                          ***************************************************************************/
 int
 ms_strncpcleantail (char *dest, const char *source, int length)
 {
@@ -673,21 +672,21 @@ ms_strncpcleantail (char *dest, const char *source, int length)
 } /* End of ms_strncpcleantail() */
 
 /**********************************************************************/ /**
- * @brief Copy fixed number of characters into unterminated string
- *
- * Copy \a length bytes of UTF-8 characters from \a source to \a dest,
- * padding the right side with spaces and leave open-ended, aka
- * un-terminated.  The result is left justified and \e never null
- * terminated.
- *
- * The destination string must have enough room for \a length characters.
- *
- * @param[out] dest Destination for unterminated string
- * @param[in] source Source string
- * @param[in] length Length of characters for destination string in bytes
- *
- * @returns the number of characters copied from the source string
- ***************************************************************************/
+                                                                          * @brief Copy fixed number of characters into unterminated string
+                                                                          *
+                                                                          * Copy \a length bytes of UTF-8 characters from \a source to \a dest,
+                                                                          * padding the right side with spaces and leave open-ended, aka
+                                                                          * un-terminated.  The result is left justified and \e never null
+                                                                          * terminated.
+                                                                          *
+                                                                          * The destination string must have enough room for \a length characters.
+                                                                          *
+                                                                          * @param[out] dest Destination for unterminated string
+                                                                          * @param[in] source Source string
+                                                                          * @param[in] length Length of characters for destination string in bytes
+                                                                          *
+                                                                          * @returns the number of characters copied from the source string
+                                                                          ***************************************************************************/
 int
 ms_strncpopen (char *dest, const char *source, int length)
 {
@@ -727,23 +726,23 @@ ms_strncpopen (char *dest, const char *source, int length)
 } /* End of ms_strncpopen() */
 
 /**********************************************************************/ /**
- * @brief Compute the month and day-of-month from a year and day-of-year
- *
- * @param[in] year Year in range 1000-2262
- * @param[in] yday Day of year in range 1-365 or 366 for leap year
- * @param[out] month Month in range 1-12
- * @param[out] mday Day of month in range 1-31
- *
- * @retval 0 on success
- * @retval -1 on error
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Compute the month and day-of-month from a year and day-of-year
+                                                                          *
+                                                                          * @param[in] year Year in range 1000-2262
+                                                                          * @param[in] yday Day of year in range 1-365 or 366 for leap year
+                                                                          * @param[out] month Month in range 1-12
+                                                                          * @param[out] mday Day of month in range 1-31
+                                                                          *
+                                                                          * @retval 0 on success
+                                                                          * @retval -1 on error
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 ms_doy2md (int year, int yday, int *month, int *mday)
 {
   int idx;
-  const int(*days)[12];
+  const int (*days)[12];
 
   if (!month || !mday)
   {
@@ -781,23 +780,23 @@ ms_doy2md (int year, int yday, int *month, int *mday)
 } /* End of ms_doy2md() */
 
 /**********************************************************************/ /**
- * @brief Compute the day-of-year from a year, month and day-of-month
- *
- * @param[in] year Year in range 1000-2262
- * @param[in] month Month in range 1-12
- * @param[in] mday Day of month in range 1-31 (or appropriate last day)
- * @param[out] yday Day of year in range 1-366 or 366 for leap year
- *
- * @retval 0 on success
- * @retval -1 on error
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Compute the day-of-year from a year, month and day-of-month
+                                                                          *
+                                                                          * @param[in] year Year in range 1000-2262
+                                                                          * @param[in] month Month in range 1-12
+                                                                          * @param[in] mday Day of month in range 1-31 (or appropriate last day)
+                                                                          * @param[out] yday Day of year in range 1-366 or 366 for leap year
+                                                                          *
+                                                                          * @retval 0 on success
+                                                                          * @retval -1 on error
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 ms_md2doy (int year, int month, int mday, int *yday)
 {
   int idx;
-  const int(*days)[12];
+  const int (*days)[12];
 
   if (!yday)
   {
@@ -841,22 +840,22 @@ ms_md2doy (int year, int month, int mday, int *yday)
 } /* End of ms_md2doy() */
 
 /**********************************************************************/ /**
- * @brief Convert an ::nstime_t to individual date-time components
- *
- * Each of the destination date-time are optional, pass NULL if the
- * value is not desired.
- *
- * @param[in] nstime Time value to convert
- * @param[out] year Year with century, like 2018
- * @param[out] yday Day of year, 1 - 366
- * @param[out] hour Hour, 0 - 23
- * @param[out] min Minute, 0 - 59
- * @param[out] sec Second, 0 - 60, where 60 is a leap second
- * @param[out] nsec Nanoseconds, 0 - 999999999
- *
- * @retval 0 on success
- * @retval -1 on error
- ***************************************************************************/
+                                                                          * @brief Convert an ::nstime_t to individual date-time components
+                                                                          *
+                                                                          * Each of the destination date-time are optional, pass NULL if the
+                                                                          * value is not desired.
+                                                                          *
+                                                                          * @param[in] nstime Time value to convert
+                                                                          * @param[out] year Year with century, like 2018
+                                                                          * @param[out] yday Day of year, 1 - 366
+                                                                          * @param[out] hour Hour, 0 - 23
+                                                                          * @param[out] min Minute, 0 - 59
+                                                                          * @param[out] sec Second, 0 - 60, where 60 is a leap second
+                                                                          * @param[out] nsec Nanoseconds, 0 - 999999999
+                                                                          *
+                                                                          * @retval 0 on success
+                                                                          * @retval -1 on error
+                                                                          ***************************************************************************/
 int
 ms_nstime2time (nstime_t nstime, uint16_t *year, uint16_t *yday,
                 uint8_t *hour, uint8_t *min, uint8_t *sec, uint32_t *nsec)
@@ -901,29 +900,29 @@ ms_nstime2time (nstime_t nstime, uint16_t *year, uint16_t *yday,
 } /* End of ms_nstime2time() */
 
 /**********************************************************************/ /**
- * @brief Convert an ::nstime_t to a time string
- *
- * Create a time string representation of a high precision epoch time
- * in ISO 8601 and SEED formats.
- *
- * The provided \a timestr buffer must have enough room for the
- * resulting time string, a maximum of 36 characters + terminating NULL.
- *
- * The \a subseconds flag controls whether the subsecond portion of
- * the time is included or not.  The value of \a subseconds is ignored
- * when the \a format is \c NANOSECONDEPOCH.  When non-zero subseconds
- * are "trimmed" using these flags there is no rounding, instead it is
- * simple truncation.
- *
- * @param[in] nstime Time value to convert
- * @param[out] timestr Buffer for ISO time string
- * @param timeformat Time string format, one of @ref ms_timeformat_t
- * @param subseconds Inclusion of subseconds, one of @ref ms_subseconds_t
- *
- * @returns Pointer to the resulting string or NULL on error.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Convert an ::nstime_t to a time string
+                                                                          *
+                                                                          * Create a time string representation of a high precision epoch time
+                                                                          * in ISO 8601 and SEED formats.
+                                                                          *
+                                                                          * The provided \a timestr buffer must have enough room for the
+                                                                          * resulting time string, a maximum of 36 characters + terminating NULL.
+                                                                          *
+                                                                          * The \a subseconds flag controls whether the subsecond portion of
+                                                                          * the time is included or not.  The value of \a subseconds is ignored
+                                                                          * when the \a format is \c NANOSECONDEPOCH.  When non-zero subseconds
+                                                                          * are "trimmed" using these flags there is no rounding, instead it is
+                                                                          * simple truncation.
+                                                                          *
+                                                                          * @param[in] nstime Time value to convert
+                                                                          * @param[out] timestr Buffer for ISO time string
+                                                                          * @param timeformat Time string format, one of @ref ms_timeformat_t
+                                                                          * @param subseconds Inclusion of subseconds, one of @ref ms_subseconds_t
+                                                                          *
+                                                                          * @returns Pointer to the resulting string or NULL on error.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 char *
 ms_nstime2timestr (nstime_t nstime, char *timestr,
                    ms_timeformat_t timeformat, ms_subseconds_t subseconds)
@@ -999,7 +998,7 @@ ms_nstime2timestr (nstime_t nstime, char *timestr,
                            tms.tm_year + 1900, tms.tm_mon + 1, tms.tm_mday,
                            tms.tm_hour, tms.tm_min, tms.tm_sec,
                           (timeformat == ISOMONTHDAY_DOY_Z) ? "Z" : "",
-                          tms.tm_yday + 1);
+                           tms.tm_yday + 1);
       break;
     case SEEDORDINAL:
       expected = 17;
@@ -1043,7 +1042,7 @@ ms_nstime2timestr (nstime_t nstime, char *timestr,
                            tms.tm_year + 1900, tms.tm_mon + 1, tms.tm_mday,
                            tms.tm_hour, tms.tm_min, tms.tm_sec, microsec,
                           (timeformat == ISOMONTHDAY_DOY_Z) ? "Z" : "",
-                          tms.tm_yday + 1);
+                           tms.tm_yday + 1);
       break;
     case SEEDORDINAL:
       expected = 24;
@@ -1087,7 +1086,7 @@ ms_nstime2timestr (nstime_t nstime, char *timestr,
                            tms.tm_year + 1900, tms.tm_mon + 1, tms.tm_mday,
                            tms.tm_hour, tms.tm_min, tms.tm_sec, nanosec,
                           (timeformat == ISOMONTHDAY_DOY_Z) ? "Z" : "",
-                          tms.tm_yday + 1);
+                           tms.tm_yday + 1);
       break;
     case SEEDORDINAL:
       expected = 27;
@@ -1125,22 +1124,22 @@ ms_nstime2timestr (nstime_t nstime, char *timestr,
 } /* End of ms_nstime2timestr() */
 
 /**********************************************************************/ /**
- * @brief Convert an ::nstime_t to a time string with 'Z' suffix
- *
- * @deprecated This function should be replaced with desired use of
- * timeformat values with the '_Z' designator.
- *
- * This function is a thin wrapper of @ref ms_nstime2timestr
- *
- * @param[in] nstime Time value to convert
- * @param[out] timestr Buffer for ISO time string
- * @param timeformat Time string format, one of @ref ms_timeformat_t
- * @param subseconds Inclusion of subseconds, one of @ref ms_subseconds_t
- *
- * @returns Pointer to the resulting string or NULL on error.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Convert an ::nstime_t to a time string with 'Z' suffix
+                                                                          *
+                                                                          * @deprecated This function should be replaced with desired use of
+                                                                          * timeformat values with the '_Z' designator.
+                                                                          *
+                                                                          * This function is a thin wrapper of @ref ms_nstime2timestr
+                                                                          *
+                                                                          * @param[in] nstime Time value to convert
+                                                                          * @param[out] timestr Buffer for ISO time string
+                                                                          * @param timeformat Time string format, one of @ref ms_timeformat_t
+                                                                          * @param subseconds Inclusion of subseconds, one of @ref ms_subseconds_t
+                                                                          *
+                                                                          * @returns Pointer to the resulting string or NULL on error.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 char *
 ms_nstime2timestrz (nstime_t nstime, char *timestr,
                     ms_timeformat_t timeformat, ms_subseconds_t subseconds)
@@ -1182,26 +1181,25 @@ ms_time2nstime_int (int year, int yday, int hour, int min, int sec, uint32_t nse
 
   days = (365 * (shortyear - 70) + intervening_leap_days + (yday - 1));
 
-  nstime = (nstime_t) (60 * (60 * ((nstime_t)24 * days + hour) + min) + sec) * NSTMODULUS + nsec;
+  nstime = (nstime_t)(60 * (60 * ((nstime_t)24 * days + hour) + min) + sec) * NSTMODULUS + nsec;
 
   return nstime;
 } /* End of ms_time2nstime_int() */
 
-
 /**********************************************************************/ /**
- * @brief Convert specified date-time values to a high precision epoch time.
- *
- * @param[in] year Year with century, like 2018
- * @param[in] yday Day of year, 1 - 366
- * @param[in] hour Hour, 0 - 23
- * @param[in] min Minute, 0 - 59
- * @param[in] sec Second, 0 - 60, where 60 is a leap second
- * @param[in] nsec Nanoseconds, 0 - 999999999
- *
- * @returns epoch time on success and ::NSTERROR on error.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Convert specified date-time values to a high precision epoch time.
+                                                                          *
+                                                                          * @param[in] year Year with century, like 2018
+                                                                          * @param[in] yday Day of year, 1 - 366
+                                                                          * @param[in] hour Hour, 0 - 23
+                                                                          * @param[in] min Minute, 0 - 59
+                                                                          * @param[in] sec Second, 0 - 60, where 60 is a leap second
+                                                                          * @param[in] nsec Nanoseconds, 0 - 999999999
+                                                                          *
+                                                                          * @returns epoch time on success and ::NSTERROR on error.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 nstime_t
 ms_time2nstime (int year, int yday, int hour, int min, int sec, uint32_t nsec)
 {
@@ -1244,47 +1242,46 @@ ms_time2nstime (int year, int yday, int hour, int min, int sec, uint32_t nsec)
   return ms_time2nstime_int (year, yday, hour, min, sec, nsec);
 } /* End of ms_time2nstime() */
 
-
 /**********************************************************************/ /**
- * @brief Convert a time string to a high precision epoch time.
- *
- * Detected time formats:
- *   -# ISO month-day as \c "YYYY-MM-DD[THH:MM:SS.FFFFFFFFF]"
- *   -# ISO ordinal as \c "YYYY-DDD[THH:MM:SS.FFFFFFFFF]"
- *   -# SEED ordinal as \c "YYYY,DDD[,HH,MM,SS,FFFFFFFFF]"
- *   -# Year as \c "YYYY"
- *   -# Unix/POSIX epoch time value as \c "[+-]#########.#########"
- *
- * Following determination of the format, non-epoch value conversion
- * is performed by the ms_mdtimestr2nstime() and
- * ms_seedtimestr2nstime() routines.
- *
- * Four-digit values are treated as a year, unless a sign [+-] is
- * specified and then they are treated as epoch values.  For
- * consistency, a caller is recommened to always include a sign with
- * epoch values.
- *
- * Note that this routine does some sanity checking of the time string
- * contents, but does _not_ perform robust date-time validation.
- *
- * @param[in] timestr Time string to convert
- *
- * @returns epoch time on success and ::NSTERROR on error.
- *
- * \ref MessageOnError - this function logs a message on error
- *
- * @see ms_mdtimestr2nstime()
- * @see ms_seedtimestr2nstime()
- ***************************************************************************/
+                                                                          * @brief Convert a time string to a high precision epoch time.
+                                                                          *
+                                                                          * Detected time formats:
+                                                                          *   -# ISO month-day as \c "YYYY-MM-DD[THH:MM:SS.FFFFFFFFF]"
+                                                                          *   -# ISO ordinal as \c "YYYY-DDD[THH:MM:SS.FFFFFFFFF]"
+                                                                          *   -# SEED ordinal as \c "YYYY,DDD[,HH,MM,SS,FFFFFFFFF]"
+                                                                          *   -# Year as \c "YYYY"
+                                                                          *   -# Unix/POSIX epoch time value as \c "[+-]#########.#########"
+                                                                          *
+                                                                          * Following determination of the format, non-epoch value conversion
+                                                                          * is performed by the ms_mdtimestr2nstime() and
+                                                                          * ms_seedtimestr2nstime() routines.
+                                                                          *
+                                                                          * Four-digit values are treated as a year, unless a sign [+-] is
+                                                                          * specified and then they are treated as epoch values.  For
+                                                                          * consistency, a caller is recommened to always include a sign with
+                                                                          * epoch values.
+                                                                          *
+                                                                          * Note that this routine does some sanity checking of the time string
+                                                                          * contents, but does _not_ perform robust date-time validation.
+                                                                          *
+                                                                          * @param[in] timestr Time string to convert
+                                                                          *
+                                                                          * @returns epoch time on success and ::NSTERROR on error.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          *
+                                                                          * @see ms_mdtimestr2nstime()
+                                                                          * @see ms_seedtimestr2nstime()
+                                                                          ***************************************************************************/
 nstime_t
 ms_timestr2nstime (const char *timestr)
 {
   const char *cp;
   const char *firstdelimiter = NULL;
-  const char *separator = NULL;
-  int delimiters = 0;
-  int numberlike = 0;
-  int error = 0;
+  const char *separator      = NULL;
+  int delimiters             = 0;
+  int numberlike             = 0;
+  int error                  = 0;
   int length;
   int fields;
   int64_t sec = 0;
@@ -1332,7 +1329,7 @@ ms_timestr2nstime (const char *timestr)
       numberlike++;
     }
     /* Done if at trailing 'Z' designator */
-    else if ((*cp == 'Z' || *cp == 'z') && *(cp+1) == '\0')
+    else if ((*cp == 'Z' || *cp == 'z') && *(cp + 1) == '\0')
     {
       cp++;
       break;
@@ -1406,29 +1403,28 @@ ms_timestr2nstime (const char *timestr)
   return NSTERROR;
 } /* End of ms_timestr2nstime() */
 
-
 /**********************************************************************/ /**
- * @brief Convert a time string (year-month-day) to a high precision
- * epoch time.
- *
- * The time format expected is "YYYY[-MM-DD HH:MM:SS.FFFFFFFFF]", the
- * delimiter can be a dash [-], comma[,], slash [/], colon [:], or
- * period [.].  Additionally a 'T' or space may be used between the
- * date and time fields.  The fractional seconds ("FFFFFFFFF") must
- * begin with a period [.] if present.
- *
- * The time string can be "short" in which case the omitted values are
- * assumed to be zero (with the exception of month and day which are
- * assumed to be 1).  For example, specifying "YYYY-MM-DD" assumes HH,
- * MM, SS and FFFF are 0.  The year is required, otherwise there
- * wouldn't be much for a date.
- *
- * @param[in] timestr Time string in ISO-style, month-day format
- *
- * @returns epoch time on success and ::NSTERROR on error.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Convert a time string (year-month-day) to a high precision
+                                                                          * epoch time.
+                                                                          *
+                                                                          * The time format expected is "YYYY[-MM-DD HH:MM:SS.FFFFFFFFF]", the
+                                                                          * delimiter can be a dash [-], comma[,], slash [/], colon [:], or
+                                                                          * period [.].  Additionally a 'T' or space may be used between the
+                                                                          * date and time fields.  The fractional seconds ("FFFFFFFFF") must
+                                                                          * begin with a period [.] if present.
+                                                                          *
+                                                                          * The time string can be "short" in which case the omitted values are
+                                                                          * assumed to be zero (with the exception of month and day which are
+                                                                          * assumed to be 1).  For example, specifying "YYYY-MM-DD" assumes HH,
+                                                                          * MM, SS and FFFF are 0.  The year is required, otherwise there
+                                                                          * wouldn't be much for a date.
+                                                                          *
+                                                                          * @param[in] timestr Time string in ISO-style, month-day format
+                                                                          *
+                                                                          * @returns epoch time on success and ::NSTERROR on error.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 nstime_t
 ms_mdtimestr2nstime (const char *timestr)
 {
@@ -1515,28 +1511,27 @@ ms_mdtimestr2nstime (const char *timestr)
   return ms_time2nstime_int (year, yday, hour, min, sec, nsec);
 } /* End of ms_mdtimestr2nstime() */
 
-
 /**********************************************************************/ /**
- * @brief Convert an SEED-style (ordinate date, i.e. day-of-year) time
- * string to a high precision epoch time.
- *
- * The time format expected is "YYYY[,DDD,HH,MM,SS.FFFFFFFFF]", the
- * delimiter can be a dash [-], comma [,], colon [:] or period [.].
- * Additionally a [T] or space may be used to seprate the day and hour
- * fields.  The fractional seconds ("FFFFFFFFF") must begin with a
- * period [.] if present.
- *
- * The time string can be "short" in which case the omitted values are
- * assumed to be zero (with the exception of DDD which is assumed to
- * be 1): "YYYY,DDD,HH" assumes MM, SS and FFFFFFFF are 0.  The year
- * is required, otherwise there wouldn't be much for a date.
- *
- * @param[in] seedtimestr Time string in SEED-style, ordinal date format
- *
- * @returns epoch time on success and ::NSTERROR on error.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Convert an SEED-style (ordinate date, i.e. day-of-year) time
+                                                                          * string to a high precision epoch time.
+                                                                          *
+                                                                          * The time format expected is "YYYY[,DDD,HH,MM,SS.FFFFFFFFF]", the
+                                                                          * delimiter can be a dash [-], comma [,], colon [:] or period [.].
+                                                                          * Additionally a [T] or space may be used to seprate the day and hour
+                                                                          * fields.  The fractional seconds ("FFFFFFFFF") must begin with a
+                                                                          * period [.] if present.
+                                                                          *
+                                                                          * The time string can be "short" in which case the omitted values are
+                                                                          * assumed to be zero (with the exception of DDD which is assumed to
+                                                                          * be 1): "YYYY,DDD,HH" assumes MM, SS and FFFFFFFF are 0.  The year
+                                                                          * is required, otherwise there wouldn't be much for a date.
+                                                                          *
+                                                                          * @param[in] seedtimestr Time string in SEED-style, ordinal date format
+                                                                          *
+                                                                          * @returns epoch time on success and ::NSTERROR on error.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 nstime_t
 ms_seedtimestr2nstime (const char *seedtimestr)
 {
@@ -1609,47 +1604,46 @@ ms_seedtimestr2nstime (const char *seedtimestr)
   return ms_time2nstime_int (year, yday, hour, min, sec, nsec);
 } /* End of ms_seedtimestr2nstime() */
 
-
 /**********************************************************************/ /**
- * @brief Calculate the time of a sample in an array
- *
- * Given a time, sample offset and sample rate/period calculate the
- * time of the sample at the offset.
- *
- * If \a samprate is negative the negated value is interpreted as a
- * sample period in seconds, otherwise the value is assumed to be a
- * sample rate in Hertz.
- *
- * If leap seconds have been loaded into the internal library list:
- * when a time span, from start to offset, completely contains a leap
- * second, starts before and ends after, the calculated sample time
- * will be adjusted (reduced) by one second.
- * @note On the epoch time scale the value of a leap second is the
- * same as the second following the leap second, without external
- * information the values are ambiguous.
- * \sa ms_readleapsecondfile()
- *
- * @param[in] time Time value for first sample in array
- * @param[in] offset Offset of sample to calculate time of
- * @param[in] samprate Sample rate (when positive) or period (when negative)
- *
- * @returns Time of the sample at specified offset
- ***************************************************************************/
+                                                                          * @brief Calculate the time of a sample in an array
+                                                                          *
+                                                                          * Given a time, sample offset and sample rate/period calculate the
+                                                                          * time of the sample at the offset.
+                                                                          *
+                                                                          * If \a samprate is negative the negated value is interpreted as a
+                                                                          * sample period in seconds, otherwise the value is assumed to be a
+                                                                          * sample rate in Hertz.
+                                                                          *
+                                                                          * If leap seconds have been loaded into the internal library list:
+                                                                          * when a time span, from start to offset, completely contains a leap
+                                                                          * second, starts before and ends after, the calculated sample time
+                                                                          * will be adjusted (reduced) by one second.
+                                                                          * @note On the epoch time scale the value of a leap second is the
+                                                                          * same as the second following the leap second, without external
+                                                                          * information the values are ambiguous.
+                                                                          * \sa ms_readleapsecondfile()
+                                                                          *
+                                                                          * @param[in] time Time value for first sample in array
+                                                                          * @param[in] offset Offset of sample to calculate time of
+                                                                          * @param[in] samprate Sample rate (when positive) or period (when negative)
+                                                                          *
+                                                                          * @returns Time of the sample at specified offset
+                                                                          ***************************************************************************/
 nstime_t
 ms_sampletime (nstime_t time, int64_t offset, double samprate)
 {
-  nstime_t span = 0;
+  nstime_t span      = 0;
   LeapSecond *lslist = leapsecondlist;
 
   if (offset > 0)
   {
     /* Calculate time span using sample rate */
     if (samprate > 0.0)
-      span = (nstime_t) (((double)offset / samprate * NSTMODULUS) + 0.5);
+      span = (nstime_t)(((double)offset / samprate * NSTMODULUS) + 0.5);
 
     /* Calculate time span using sample period */
     else if (samprate < 0.0)
-      span = (nstime_t) (((double)offset * -samprate * NSTMODULUS) + 0.5);
+      span = (nstime_t)(((double)offset * -samprate * NSTMODULUS) + 0.5);
   }
 
   /* Check if the time range contains a leap second, if list is available */
@@ -1671,17 +1665,16 @@ ms_sampletime (nstime_t time, int64_t offset, double samprate)
   return (time + span);
 } /* End of ms_sampletime() */
 
-
 /**********************************************************************/ /**
- * @brief Determine the absolute value of an input double
- *
- * Actually just test if the input double is positive multiplying by
- * -1.0 if not and return it.
- *
- * @param[in] val Value for which to determine absolute value
- *
- * @returns the positive value of input double.
- ***************************************************************************/
+                                                                          * @brief Determine the absolute value of an input double
+                                                                          *
+                                                                          * Actually just test if the input double is positive multiplying by
+                                                                          * -1.0 if not and return it.
+                                                                          *
+                                                                          * @param[in] val Value for which to determine absolute value
+                                                                          *
+                                                                          * @returns the positive value of input double.
+                                                                          ***************************************************************************/
 double
 ms_dabs (double val)
 {
@@ -1690,11 +1683,10 @@ ms_dabs (double val)
   return val;
 } /* End of ms_dabs() */
 
-
 /**********************************************************************/ /**
- * @brief Runtime test for host endianess
- * @returns 0 if the host is little endian, otherwise 1.
- ***************************************************************************/
+                                                                          * @brief Runtime test for host endianess
+                                                                          * @returns 0 if the host is little endian, otherwise 1.
+                                                                          ***************************************************************************/
 inline int
 ms_bigendianhost (void)
 {
@@ -1702,20 +1694,19 @@ ms_bigendianhost (void)
   return *(const uint8_t *)&endian;
 } /* End of ms_bigendianhost() */
 
-
 /**********************************************************************/ /**
- * @brief Read leap second file specified by an environment variable
- *
- * Leap seconds are loaded into the library's global leapsecond list.
- *
- * @param[in] envvarname Environment variable that identifies the leap second file
- *
- * @returns positive number of leap seconds read
- * @retval -1 on file read error
- * @retval -2 when the environment variable is not set
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Read leap second file specified by an environment variable
+                                                                          *
+                                                                          * Leap seconds are loaded into the library's global leapsecond list.
+                                                                          *
+                                                                          * @param[in] envvarname Environment variable that identifies the leap second file
+                                                                          *
+                                                                          * @returns positive number of leap seconds read
+                                                                          * @retval -1 on file read error
+                                                                          * @retval -2 when the environment variable is not set
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 ms_readleapseconds (const char *envvarname)
 {
@@ -1729,23 +1720,22 @@ ms_readleapseconds (const char *envvarname)
   return -2;
 } /* End of ms_readleapseconds() */
 
-
 /**********************************************************************/ /**
- * @brief Read leap second from the specified file
- *
- * Leap seconds are loaded into the library's global leapsecond list.
- *
- * The file is expected to be standard IETF leap second list format.
- * The list is usually available from:
- * https://www.ietf.org/timezones/data/leap-seconds.list
- *
- * @param[in] filename File containing leap second list
- *
- * @returns positive number of leap seconds read on success
- * @retval -1 on error
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Read leap second from the specified file
+                                                                          *
+                                                                          * Leap seconds are loaded into the library's global leapsecond list.
+                                                                          *
+                                                                          * The file is expected to be standard IETF leap second list format.
+                                                                          * The list is usually available from:
+                                                                          * https://www.ietf.org/timezones/data/leap-seconds.list
+                                                                          *
+                                                                          * @param[in] filename File containing leap second list
+                                                                          *
+                                                                          * @returns positive number of leap seconds read on success
+                                                                          * @retval -1 on error
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 ms_readleapsecondfile (const char *filename)
 {

--- a/gmtime64.c
+++ b/gmtime64.c
@@ -34,8 +34,8 @@ THE SOFTWARE.
 
 */
 
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <time.h>
 
 static const char days_in_month[2][12] = {
@@ -76,7 +76,7 @@ ms_gmtime64_r (const int64_t *in_time, struct tm *p)
   int leap;
   int64_t m;
   int64_t time;
-  int64_t year = 70;
+  int64_t year   = 70;
   int64_t cycles = 0;
 
   if (!in_time || !p)
@@ -175,10 +175,10 @@ ms_gmtime64_r (const int64_t *in_time, struct tm *p)
   /* At this point m is less than a year so casting to an int is safe */
   p->tm_mday = (int)m + 1;
   p->tm_yday = julian_days_by_month[leap][v_tm_mon] + (int)m;
-  p->tm_sec = v_tm_sec;
-  p->tm_min = v_tm_min;
+  p->tm_sec  = v_tm_sec;
+  p->tm_min  = v_tm_min;
   p->tm_hour = v_tm_hour;
-  p->tm_mon = v_tm_mon;
+  p->tm_mon  = v_tm_mon;
   p->tm_wday = v_tm_wday;
 
   return p;

--- a/gmtime64.h
+++ b/gmtime64.h
@@ -8,12 +8,13 @@
 #define GMTIME64_H 1
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #include "libmseed.h"
 
-extern struct tm * ms_gmtime64_r (const int64_t *in_time, struct tm *p);
+  extern struct tm *ms_gmtime64_r (const int64_t *in_time, struct tm *p);
 
 #ifdef __cplusplus
 }

--- a/gswap.c
+++ b/gswap.c
@@ -53,7 +53,7 @@ ms_gswap4 (void *data4)
   memcpy (&dat, data4, 4);
 
   dat = ((dat & 0xff000000) >> 24) | ((dat & 0x000000ff) << 24) |
-        ((dat & 0x00ff0000) >>  8) | ((dat & 0x0000ff00) <<  8);
+        ((dat & 0x00ff0000) >> 8) | ((dat & 0x0000ff00) << 8);
 
   memcpy (data4, &dat, 4);
 }
@@ -63,14 +63,14 @@ ms_gswap8 (void *data8)
 {
   uint64_t dat;
 
-  memcpy (&dat, data8, sizeof(uint64_t));
+  memcpy (&dat, data8, sizeof (uint64_t));
 
   dat = ((dat & 0xff00000000000000) >> 56) | ((dat & 0x00000000000000ff) << 56) |
         ((dat & 0x00ff000000000000) >> 40) | ((dat & 0x000000000000ff00) << 40) |
         ((dat & 0x0000ff0000000000) >> 24) | ((dat & 0x0000000000ff0000) << 24) |
-        ((dat & 0x000000ff00000000) >>  8) | ((dat & 0x00000000ff000000) <<  8);
+        ((dat & 0x000000ff00000000) >> 8) | ((dat & 0x00000000ff000000) << 8);
 
-  memcpy (data8, &dat, sizeof(uint64_t));
+  memcpy (data8, &dat, sizeof (uint64_t));
 }
 
 /* The wrapper functions below exist for backwards compatibility. */

--- a/libmseed.h
+++ b/libmseed.h
@@ -1,35 +1,36 @@
 /**********************************************************************/ /**
- * @file libmseed.h
- *
- * Interface declarations for the miniSEED Library (libmseed).
- *
- * This file is part of the miniSEED Library.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * Copyright (C) 2023:
- * @author Chad Trabant, EarthScope Data Services
- ***************************************************************************/
+                                                                          * @file libmseed.h
+                                                                          *
+                                                                          * Interface declarations for the miniSEED Library (libmseed).
+                                                                          *
+                                                                          * This file is part of the miniSEED Library.
+                                                                          *
+                                                                          * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                          * you may not use this file except in compliance with the License.
+                                                                          * You may obtain a copy of the License at
+                                                                          *
+                                                                          *   http://www.apache.org/licenses/LICENSE-2.0
+                                                                          *
+                                                                          * Unless required by applicable law or agreed to in writing, software
+                                                                          * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                          * See the License for the specific language governing permissions and
+                                                                          * limitations under the License.
+                                                                          *
+                                                                          * Copyright (C) 2023:
+                                                                          * @author Chad Trabant, EarthScope Data Services
+                                                                          ***************************************************************************/
 
 #ifndef LIBMSEED_H
 #define LIBMSEED_H 1
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-#define LIBMSEED_VERSION "3.0.13"    //!< Library version
-#define LIBMSEED_RELEASE "2023.029"  //!< Library release date
+#define LIBMSEED_VERSION "3.0.13"   //!< Library version
+#define LIBMSEED_RELEASE "2023.029" //!< Library release date
 
 /** @defgroup io-functions File and URL I/O */
 /** @defgroup miniseed-record Record Handling */
@@ -57,92 +58,92 @@ extern "C" {
     @ingroup low-level */
 
 /* C99 standard headers */
-#include <stdlib.h>
-#include <stdio.h>
-#include <stdarg.h>
-#include <time.h>
-#include <string.h>
 #include <ctype.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
 
 /** @def PRIsize_t
     @brief A printf() macro for portably printing size_t values */
 #define PRIsize_t "zu"
 
 #if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
-  #define LMP_WIN 1
+#define LMP_WIN 1
 #endif
 
 /* Set platform specific features, Windows versus everything else */
 #if defined(LMP_WIN)
-  #include <windows.h>
-  #include <sys/types.h>
+#include <sys/types.h>
+#include <windows.h>
 
-  /* Re-define print conversion for size_t values */
-  #undef PRIsize_t
-  #if defined(WIN64) || defined(_WIN64)
-    #define PRIsize_t "I64u"
-  #else
-    #define PRIsize_t "I32u"
-  #endif
-
-  /* For MSVC 2012 and earlier define standard int types, otherwise use inttypes.h */
-  #if defined(_MSC_VER) && _MSC_VER <= 1700
-    typedef signed char int8_t;
-    typedef unsigned char uint8_t;
-    typedef signed short int int16_t;
-    typedef unsigned short int uint16_t;
-    typedef signed int int32_t;
-    typedef unsigned int uint32_t;
-    typedef signed __int64 int64_t;
-    typedef unsigned __int64 uint64_t;
-  #else
-    #include <inttypes.h>
-  #endif
-
-  /* For MSVC define PRId64 and SCNd64 and alternate functions */
-  #if defined(_MSC_VER)
-    #if !defined(PRId64)
-      #define PRId64 "I64d"
-    #endif
-    #if !defined(SCNd64)
-      #define SCNd64 "I64d"
-    #endif
-
-    #define snprintf _snprintf
-    #define vsnprintf _vsnprintf
-    #define strcasecmp _stricmp
-    #define strncasecmp _strnicmp
-    #define strtoull _strtoui64
-    #define fileno _fileno
-  #endif
-
-  /* Extras needed for MinGW */
-  #if defined(__MINGW32__) || defined(__MINGW64__)
-    #include <fcntl.h>
-
-    #define _fseeki64 fseeko64
-    #define _ftelli64 ftello64
-
-    #define fstat _fstat
-    #define stat _stat
-  #endif
+/* Re-define print conversion for size_t values */
+#undef PRIsize_t
+#if defined(WIN64) || defined(_WIN64)
+#define PRIsize_t "I64u"
 #else
-  /* All other platforms */
-  #include <inttypes.h>
+#define PRIsize_t "I32u"
 #endif
 
-#define MINRECLEN 40       //!< Minimum miniSEED record length supported
-#define MAXRECLEN 131172   //!< Maximum miniSEED record length supported
+/* For MSVC 2012 and earlier define standard int types, otherwise use inttypes.h */
+#if defined(_MSC_VER) && _MSC_VER <= 1700
+  typedef signed char int8_t;
+  typedef unsigned char uint8_t;
+  typedef signed short int int16_t;
+  typedef unsigned short int uint16_t;
+  typedef signed int int32_t;
+  typedef unsigned int uint32_t;
+  typedef signed __int64 int64_t;
+  typedef unsigned __int64 uint64_t;
+#else
+#include <inttypes.h>
+#endif
 
-#define LM_SIDLEN 64       //!< Length of source ID string
+/* For MSVC define PRId64 and SCNd64 and alternate functions */
+#if defined(_MSC_VER)
+#if !defined(PRId64)
+#define PRId64 "I64d"
+#endif
+#if !defined(SCNd64)
+#define SCNd64 "I64d"
+#endif
+
+#define snprintf _snprintf
+#define vsnprintf _vsnprintf
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
+#define strtoull _strtoui64
+#define fileno _fileno
+#endif
+
+/* Extras needed for MinGW */
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#include <fcntl.h>
+
+#define _fseeki64 fseeko64
+#define _ftelli64 ftello64
+
+#define fstat _fstat
+#define stat _stat
+#endif
+#else
+/* All other platforms */
+#include <inttypes.h>
+#endif
+
+#define MINRECLEN 40     //!< Minimum miniSEED record length supported
+#define MAXRECLEN 131172 //!< Maximum miniSEED record length supported
+
+#define LM_SIDLEN 64 //!< Length of source ID string
 
 /** @def MS_ISRATETOLERABLE
     @brief Macro to test default sample rate tolerance: abs(1-sr1/sr2) < 0.0001 */
-#define MS_ISRATETOLERABLE(A,B) (ms_dabs (1.0 - ((A) / (B))) < 0.0001)
+#define MS_ISRATETOLERABLE(A, B) (ms_dabs (1.0 - ((A) / (B))) < 0.0001)
 
 /** @def MS2_ISDATAINDICATOR
     @brief Macro to test a character for miniSEED 2.x data record/quality indicators */
-#define MS2_ISDATAINDICATOR(X) ((X)=='D' || (X)=='R' || (X)=='Q' || (X)=='M')
+#define MS2_ISDATAINDICATOR(X) ((X) == 'D' || (X) == 'R' || (X) == 'Q' || (X) == 'M')
 
 /** @def MS3_ISVALIDHEADER
  * @hideinitializer
@@ -160,11 +161,11 @@ extern "C" {
  *   MS3_ISVALIDHEADER ((char *)X)
  * @endcode
  */
-#define MS3_ISVALIDHEADER(X) (                                       \
-    *(X) == 'M' && *((X) + 1) == 'S' && *((X) + 2) == 3 &&           \
-    (uint8_t) (*((X) + 12)) >= 0 && (uint8_t) (*((X) + 12)) <= 23 && \
-    (uint8_t) (*((X) + 13)) >= 0 && (uint8_t) (*((X) + 13)) <= 59 && \
-    (uint8_t) (*((X) + 14)) >= 0 && (uint8_t) (*((X) + 14)) <= 60)
+#define MS3_ISVALIDHEADER(X) (                                     \
+    *(X) == 'M' && *((X) + 1) == 'S' && *((X) + 2) == 3 &&         \
+    (uint8_t)(*((X) + 12)) >= 0 && (uint8_t)(*((X) + 12)) <= 23 && \
+    (uint8_t)(*((X) + 13)) >= 0 && (uint8_t)(*((X) + 13)) <= 59 && \
+    (uint8_t)(*((X) + 14)) >= 0 && (uint8_t)(*((X) + 14)) <= 60)
 
 /** @def MS2_ISVALIDHEADER
  * @hideinitializer
@@ -191,35 +192,35 @@ extern "C" {
     (isdigit ((uint8_t) * ((X) + 5)) || *((X) + 5) == ' ' || !*((X) + 5)) && \
     MS2_ISDATAINDICATOR (*((X) + 6)) &&                                      \
     (*((X) + 7) == ' ' || *((X) + 7) == '\0') &&                             \
-    (uint8_t) (*((X) + 24)) >= 0 && (uint8_t) (*((X) + 24)) <= 23 &&         \
-    (uint8_t) (*((X) + 25)) >= 0 && (uint8_t) (*((X) + 25)) <= 59 &&         \
-    (uint8_t) (*((X) + 26)) >= 0 && (uint8_t) (*((X) + 26)) <= 60)
+    (uint8_t)(*((X) + 24)) >= 0 && (uint8_t)(*((X) + 24)) <= 23 &&           \
+    (uint8_t)(*((X) + 25)) >= 0 && (uint8_t)(*((X) + 25)) <= 59 &&           \
+    (uint8_t)(*((X) + 26)) >= 0 && (uint8_t)(*((X) + 26)) <= 60)
 
 /** A simple bitwise AND test to return 0 or 1 */
-#define bit(x,y) ((x)&(y)) ? 1 : 0
+#define bit(x, y) ((x) & (y)) ? 1 : 0
 
 /** Annotation for deprecated API components */
 #ifdef _MSC_VER
 #define DEPRECATED __declspec(deprecated)
 #elif defined(__GNUC__) | defined(__clang__)
-#define DEPRECATED __attribute__((__deprecated__))
+#define DEPRECATED __attribute__ ((__deprecated__))
 #else
 #define DEPRECATED
 #endif
 
-/** @addtogroup time-related
-    @brief Definitions and functions for related to library time values
+  /** @addtogroup time-related
+      @brief Definitions and functions for related to library time values
 
-    Internally the library uses an integer value to represent time as
-    the number of nanoseconds since the Unix/POSIX epoch (Jan 1 1970).
+      Internally the library uses an integer value to represent time as
+      the number of nanoseconds since the Unix/POSIX epoch (Jan 1 1970).
 
-    @{ */
+      @{ */
 
-/** @brief libmseed time type, integer nanoseconds since the Unix/POSIX epoch (00:00:00 Thursday, 1 January 1970)
+  /** @brief libmseed time type, integer nanoseconds since the Unix/POSIX epoch (00:00:00 Thursday, 1 January 1970)
 
-    This time scale can represent a range from before year 0 through mid-year 2262.
-*/
-typedef int64_t nstime_t;
+      This time scale can represent a range from before year 0 through mid-year 2262.
+  */
+  typedef int64_t nstime_t;
 
 /** @def NSTMODULUS
     @brief Define the high precision time tick interval as 1/modulus seconds
@@ -238,7 +239,7 @@ typedef int64_t nstime_t;
 
 /** @def MS_EPOCH2NSTIME
     @brief macro to convert Unix/POSIX epoch time to high precision epoch time */
-#define MS_EPOCH2NSTIME(X) (X) * (nstime_t) NSTMODULUS
+#define MS_EPOCH2NSTIME(X) (X) * (nstime_t)NSTMODULUS
 
 /** @def MS_NSTIME2EPOCH
     @brief Macro to convert high precision epoch time to Unix/POSIX epoch time */
@@ -251,7 +252,7 @@ typedef int64_t nstime_t;
     defines microsecond ticks.  An NSTIME/nstime_t value, used by this
     version of the library, defines nanosecond ticks.
 */
-#define MS_HPTIME2NSTIME(X) (X) * (nstime_t) 1000
+#define MS_HPTIME2NSTIME(X) (X) * (nstime_t)1000
 
 /** @def MS_NSTIME2HPTIME
     @brief Convert an nstime_t value to hptime_t (used by previous releases)
@@ -262,239 +263,242 @@ typedef int64_t nstime_t;
  */
 #define MS_NSTIME2HPTIME(X) (X) / 1000
 
-/** @enum ms_timeformat_t
-    @brief Time format identifiers
+  /** @enum ms_timeformat_t
+      @brief Time format identifiers
 
-    Formats values:
-    - \b ISOMONTHDAY - \c "YYYY-MM-DDThh:mm:ss.sssssssss", ISO 8601 in month-day format
-    - \b ISOMONTHDAY_Z - \c "YYYY-MM-DDThh:mm:ss.sssssssss", ISO 8601 in month-day format with trailing Z
-    - \b ISOMONTHDAY_DOY - \c "YYYY-MM-DD hh:mm:ss.sssssssss (doy)", ISOMONTHDAY with day-of-year
-    - \b ISOMONTHDAY_DOY_Z - \c "YYYY-MM-DD hh:mm:ss.sssssssss (doy)", ISOMONTHDAY with day-of-year and trailing Z
-    - \b ISOMONTHDAY_SPACE - \c "YYYY-MM-DD hh:mm:ss.sssssssss", same as ISOMONTHDAY with space separator
-    - \b ISOMONTHDAY_SPACE_Z - \c "YYYY-MM-DD hh:mm:ss.sssssssss", same as ISOMONTHDAY with space separator and trailing Z
-    - \b SEEDORDINAL - \c "YYYY,DDD,hh:mm:ss.sssssssss", SEED day-of-year format
-    - \b UNIXEPOCH - \c "ssssssssss.sssssssss", Unix epoch value
-    - \b NANOSECONDEPOCH - \c "sssssssssssssssssss", Nanosecond epoch value
- */
-typedef enum
-{
-  ISOMONTHDAY         = 0,
-  ISOMONTHDAY_Z       = 1,
-  ISOMONTHDAY_DOY     = 2,
-  ISOMONTHDAY_DOY_Z   = 3,
-  ISOMONTHDAY_SPACE   = 4,
-  ISOMONTHDAY_SPACE_Z = 5,
-  SEEDORDINAL         = 6,
-  UNIXEPOCH           = 7,
-  NANOSECONDEPOCH     = 8
-} ms_timeformat_t;
+      Formats values:
+      - \b ISOMONTHDAY - \c "YYYY-MM-DDThh:mm:ss.sssssssss", ISO 8601 in month-day format
+      - \b ISOMONTHDAY_Z - \c "YYYY-MM-DDThh:mm:ss.sssssssss", ISO 8601 in month-day format with trailing Z
+      - \b ISOMONTHDAY_DOY - \c "YYYY-MM-DD hh:mm:ss.sssssssss (doy)", ISOMONTHDAY with day-of-year
+      - \b ISOMONTHDAY_DOY_Z - \c "YYYY-MM-DD hh:mm:ss.sssssssss (doy)", ISOMONTHDAY with day-of-year and trailing Z
+      - \b ISOMONTHDAY_SPACE - \c "YYYY-MM-DD hh:mm:ss.sssssssss", same as ISOMONTHDAY with space separator
+      - \b ISOMONTHDAY_SPACE_Z - \c "YYYY-MM-DD hh:mm:ss.sssssssss", same as ISOMONTHDAY with space separator and trailing Z
+      - \b SEEDORDINAL - \c "YYYY,DDD,hh:mm:ss.sssssssss", SEED day-of-year format
+      - \b UNIXEPOCH - \c "ssssssssss.sssssssss", Unix epoch value
+      - \b NANOSECONDEPOCH - \c "sssssssssssssssssss", Nanosecond epoch value
+   */
+  typedef enum
+  {
+    ISOMONTHDAY         = 0,
+    ISOMONTHDAY_Z       = 1,
+    ISOMONTHDAY_DOY     = 2,
+    ISOMONTHDAY_DOY_Z   = 3,
+    ISOMONTHDAY_SPACE   = 4,
+    ISOMONTHDAY_SPACE_Z = 5,
+    SEEDORDINAL         = 6,
+    UNIXEPOCH           = 7,
+    NANOSECONDEPOCH     = 8
+  } ms_timeformat_t;
 
-/** @enum ms_subseconds_t
-    @brief Subsecond format identifiers
+  /** @enum ms_subseconds_t
+      @brief Subsecond format identifiers
 
-    Formats values:
-    - \b NONE - No subseconds
-    - \b MICRO - Microsecond resolution
-    - \b NANO - Nanosecond resolution
-    - \b MICRO_NONE - Microsecond resolution if subseconds are non-zero, otherwise no subseconds
-    - \b NANO_NONE - Nanosecond resolution if subseconds are non-zero, otherwise no subseconds
-    - \b NANO_MICRO - Nanosecond resolution if there are sub-microseconds, otherwise microseconds resolution
-    - \b NANO_MICRO_NONE - Nanosecond resolution if present, microsecond if present, otherwise no subseconds
- */
-typedef enum
-{
-  NONE            = 0,
-  MICRO           = 1,
-  NANO            = 2,
-  MICRO_NONE      = 3,
-  NANO_NONE       = 4,
-  NANO_MICRO      = 5,
-  NANO_MICRO_NONE = 6
-} ms_subseconds_t;
+      Formats values:
+      - \b NONE - No subseconds
+      - \b MICRO - Microsecond resolution
+      - \b NANO - Nanosecond resolution
+      - \b MICRO_NONE - Microsecond resolution if subseconds are non-zero, otherwise no subseconds
+      - \b NANO_NONE - Nanosecond resolution if subseconds are non-zero, otherwise no subseconds
+      - \b NANO_MICRO - Nanosecond resolution if there are sub-microseconds, otherwise microseconds resolution
+      - \b NANO_MICRO_NONE - Nanosecond resolution if present, microsecond if present, otherwise no subseconds
+   */
+  typedef enum
+  {
+    NONE            = 0,
+    MICRO           = 1,
+    NANO            = 2,
+    MICRO_NONE      = 3,
+    NANO_NONE       = 4,
+    NANO_MICRO      = 5,
+    NANO_MICRO_NONE = 6
+  } ms_subseconds_t;
 
-extern int ms_nstime2time (nstime_t nstime, uint16_t *year, uint16_t *yday,
-                           uint8_t *hour, uint8_t *min, uint8_t *sec, uint32_t *nsec);
-extern char* ms_nstime2timestr (nstime_t nstime, char *timestr,
-                                ms_timeformat_t timeformat, ms_subseconds_t subsecond);
-DEPRECATED extern char* ms_nstime2timestrz (nstime_t nstime, char *timestr,
-                                            ms_timeformat_t timeformat, ms_subseconds_t subsecond);
-extern nstime_t ms_time2nstime (int year, int yday, int hour, int min, int sec, uint32_t nsec);
-extern nstime_t ms_timestr2nstime (const char *timestr);
-extern nstime_t ms_mdtimestr2nstime (const char *timestr);
-extern nstime_t ms_seedtimestr2nstime (const char *seedtimestr);
-extern int ms_doy2md (int year, int yday, int *month, int *mday);
-extern int ms_md2doy (int year, int month, int mday, int *yday);
+  extern int ms_nstime2time (nstime_t nstime, uint16_t *year, uint16_t *yday,
+                             uint8_t *hour, uint8_t *min, uint8_t *sec, uint32_t *nsec);
+  extern char *ms_nstime2timestr (nstime_t nstime, char *timestr,
+                                  ms_timeformat_t timeformat, ms_subseconds_t subsecond);
+  DEPRECATED extern char *ms_nstime2timestrz (nstime_t nstime, char *timestr,
+                                              ms_timeformat_t timeformat, ms_subseconds_t subsecond);
+  extern nstime_t ms_time2nstime (int year, int yday, int hour, int min, int sec, uint32_t nsec);
+  extern nstime_t ms_timestr2nstime (const char *timestr);
+  extern nstime_t ms_mdtimestr2nstime (const char *timestr);
+  extern nstime_t ms_seedtimestr2nstime (const char *seedtimestr);
+  extern int ms_doy2md (int year, int yday, int *month, int *mday);
+  extern int ms_md2doy (int year, int month, int mday, int *yday);
 
-/** @} */
+  /** @} */
 
-/** @page sample-types Sample Types
-    @brief Data sample types used by the library.
+  /** @page sample-types Sample Types
+      @brief Data sample types used by the library.
 
-    Sample types are represented using a single character as follows:
-    - \c 'a' - Text (ASCII) data samples
-    - \c 'i' - 32-bit integer data samples
-    - \c 'f' - 32-bit float (IEEE) data samples
-    - \c 'd' - 64-bit float (IEEE) data samples
-*/
+      Sample types are represented using a single character as follows:
+      - \c 'a' - Text (ASCII) data samples
+      - \c 'i' - 32-bit integer data samples
+      - \c 'f' - 32-bit float (IEEE) data samples
+      - \c 'd' - 64-bit float (IEEE) data samples
+  */
 
-/** @addtogroup miniseed-record
-    @brief Definitions and functions related to individual miniSEED records
-    @{ */
+  /** @addtogroup miniseed-record
+      @brief Definitions and functions related to individual miniSEED records
+      @{ */
 
-/** @brief miniSEED record container */
-typedef struct MS3Record {
-  char           *record;            //!< Raw miniSEED record, if available
-  int32_t         reclen;            //!< Length of miniSEED record in bytes
-  uint8_t         swapflag;          //!< Byte swap indicator (bitmask), see @ref byte-swap-flags
+  /** @brief miniSEED record container */
+  typedef struct MS3Record
+  {
+    char *record;     //!< Raw miniSEED record, if available
+    int32_t reclen;   //!< Length of miniSEED record in bytes
+    uint8_t swapflag; //!< Byte swap indicator (bitmask), see @ref byte-swap-flags
 
-  /* Common header fields in accessible form */
-  char            sid[LM_SIDLEN];    //!< Source identifier as URN, max length @ref LM_SIDLEN
-  uint8_t         formatversion;     //!< Format major version
-  uint8_t         flags;             //!< Record-level bit flags
-  nstime_t        starttime;         //!< Record start time (first sample)
-  double          samprate;          //!< Nominal sample rate as samples/second (Hz) or period (s)
-  int8_t          encoding;          //!< Data encoding format, see @ref encoding-values
-  uint8_t         pubversion;        //!< Publication version
-  int64_t         samplecnt;         //!< Number of samples in record
-  uint32_t        crc;               //!< CRC of entire record
-  uint16_t        extralength;       //!< Length of extra headers in bytes
-  uint16_t        datalength;        //!< Length of data payload in bytes
-  char           *extra;             //!< Pointer to extra headers
+    /* Common header fields in accessible form */
+    char sid[LM_SIDLEN];   //!< Source identifier as URN, max length @ref LM_SIDLEN
+    uint8_t formatversion; //!< Format major version
+    uint8_t flags;         //!< Record-level bit flags
+    nstime_t starttime;    //!< Record start time (first sample)
+    double samprate;       //!< Nominal sample rate as samples/second (Hz) or period (s)
+    int8_t encoding;       //!< Data encoding format, see @ref encoding-values
+    uint8_t pubversion;    //!< Publication version
+    int64_t samplecnt;     //!< Number of samples in record
+    uint32_t crc;          //!< CRC of entire record
+    uint16_t extralength;  //!< Length of extra headers in bytes
+    uint16_t datalength;   //!< Length of data payload in bytes
+    char *extra;           //!< Pointer to extra headers
 
-  /* Data sample fields */
-  void           *datasamples;       //!< Data samples, \a numsamples of type \a sampletype
-  size_t          datasize;          //!< Size of datasamples buffer in bytes
-  int64_t         numsamples;        //!< Number of data samples in datasamples
-  char            sampletype;        //!< Sample type code: a, i, f, d @ref sample-types
-} MS3Record;
+    /* Data sample fields */
+    void *datasamples;  //!< Data samples, \a numsamples of type \a sampletype
+    size_t datasize;    //!< Size of datasamples buffer in bytes
+    int64_t numsamples; //!< Number of data samples in datasamples
+    char sampletype;    //!< Sample type code: a, i, f, d @ref sample-types
+  } MS3Record;
 
-extern int msr3_parse (char *record, uint64_t recbuflen, MS3Record **ppmsr,
-                       uint32_t flags, int8_t verbose);
+  extern int msr3_parse (char *record, uint64_t recbuflen, MS3Record **ppmsr,
+                         uint32_t flags, int8_t verbose);
 
-extern int msr3_pack (MS3Record *msr,
-                      void (*record_handler) (char *, int, void *),
-                      void *handlerdata, int64_t *packedsamples,
-                      uint32_t flags, int8_t verbose);
+  extern int msr3_pack (MS3Record *msr,
+                        void (*record_handler) (char *, int, void *),
+                        void *handlerdata, int64_t *packedsamples,
+                        uint32_t flags, int8_t verbose);
 
-extern int msr3_repack_mseed3 (MS3Record *msr, char *record, uint32_t recbuflen, int8_t verbose);
+  extern int msr3_repack_mseed3 (MS3Record *msr, char *record, uint32_t recbuflen, int8_t verbose);
 
-extern int msr3_pack_header3 (MS3Record *msr, char *record, uint32_t recbuflen, int8_t verbose);
+  extern int msr3_pack_header3 (MS3Record *msr, char *record, uint32_t recbuflen, int8_t verbose);
 
-extern int msr3_pack_header2 (MS3Record *msr, char *record, uint32_t recbuflen, int8_t verbose);
+  extern int msr3_pack_header2 (MS3Record *msr, char *record, uint32_t recbuflen, int8_t verbose);
 
-extern int64_t msr3_unpack_data (MS3Record *msr, int8_t verbose);
+  extern int64_t msr3_unpack_data (MS3Record *msr, int8_t verbose);
 
-extern int msr3_data_bounds (MS3Record *msr, uint32_t *dataoffset, uint32_t *datasize);
+  extern int msr3_data_bounds (MS3Record *msr, uint32_t *dataoffset, uint32_t *datasize);
 
-extern int64_t ms_decode_data (const void *input, size_t inputsize, uint8_t encoding,
-                               int64_t samplecount, void *output, size_t outputsize,
-                               char *sampletype, int8_t swapflag, char *sid, int8_t verbose);
+  extern int64_t ms_decode_data (const void *input, size_t inputsize, uint8_t encoding,
+                                 int64_t samplecount, void *output, size_t outputsize,
+                                 char *sampletype, int8_t swapflag, char *sid, int8_t verbose);
 
-extern MS3Record* msr3_init (MS3Record *msr);
-extern void       msr3_free (MS3Record **ppmsr);
-extern MS3Record* msr3_duplicate (MS3Record *msr, int8_t datadup);
-extern nstime_t   msr3_endtime (MS3Record *msr);
-extern void       msr3_print (MS3Record *msr, int8_t details);
-extern int        msr3_resize_buffer (MS3Record *msr);
-extern double     msr3_sampratehz (MS3Record *msr);
-extern double     msr3_host_latency (MS3Record *msr);
+  extern MS3Record *msr3_init (MS3Record *msr);
+  extern void msr3_free (MS3Record **ppmsr);
+  extern MS3Record *msr3_duplicate (MS3Record *msr, int8_t datadup);
+  extern nstime_t msr3_endtime (MS3Record *msr);
+  extern void msr3_print (MS3Record *msr, int8_t details);
+  extern int msr3_resize_buffer (MS3Record *msr);
+  extern double msr3_sampratehz (MS3Record *msr);
+  extern double msr3_host_latency (MS3Record *msr);
 
-extern int ms3_detect (const char *record, uint64_t recbuflen, uint8_t *formatversion);
-extern int ms_parse_raw3 (char *record, int maxreclen, int8_t details);
-extern int ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag);
-/** @} */
+  extern int ms3_detect (const char *record, uint64_t recbuflen, uint8_t *formatversion);
+  extern int ms_parse_raw3 (char *record, int maxreclen, int8_t details);
+  extern int ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag);
+  /** @} */
 
-/** @addtogroup data-selections
-    @brief Data selections to be used as filters
+  /** @addtogroup data-selections
+      @brief Data selections to be used as filters
 
-    Selections are the identification of data, by source identifier
-    and time ranges, that are desired.  Capability is included to read
-    selections from files and to match data against a selection list.
+      Selections are the identification of data, by source identifier
+      and time ranges, that are desired.  Capability is included to read
+      selections from files and to match data against a selection list.
 
-    For data to be selected it must only match one of the selection
-    entries.  In other words, multiple selection entries are treated
-    with OR logic.
+      For data to be selected it must only match one of the selection
+      entries.  In other words, multiple selection entries are treated
+      with OR logic.
 
-    The ms3_readmsr_selection() and ms3_readtracelist_selection()
-    routines accept ::MS3Selections and allow selective (and
-    efficient) reading of data from files.
-    @{ */
+      The ms3_readmsr_selection() and ms3_readtracelist_selection()
+      routines accept ::MS3Selections and allow selective (and
+      efficient) reading of data from files.
+      @{ */
 
-/** @brief Data selection structure time window definition containers */
-typedef struct MS3SelectTime {
-  nstime_t starttime;                //!< Earliest data for matching channels, use ::NSTUNSET for open
-  nstime_t endtime;                  //!< Latest data for matching channels, use ::NSTUNSET for open
-  struct MS3SelectTime *next;        //!< Pointer to next selection time, NULL if the last
-} MS3SelectTime;
+  /** @brief Data selection structure time window definition containers */
+  typedef struct MS3SelectTime
+  {
+    nstime_t starttime;         //!< Earliest data for matching channels, use ::NSTUNSET for open
+    nstime_t endtime;           //!< Latest data for matching channels, use ::NSTUNSET for open
+    struct MS3SelectTime *next; //!< Pointer to next selection time, NULL if the last
+  } MS3SelectTime;
 
-/** @brief Data selection structure definition containers */
-typedef struct MS3Selections {
-  char sidpattern[100];              //!< Matching (globbing) pattern for source ID
-  struct MS3SelectTime *timewindows; //!< Pointer to time window list for this source ID
-  struct MS3Selections *next;        //!< Pointer to next selection, NULL if the last
-  uint8_t pubversion;                //!< Selected publication version, use 0 for any
-} MS3Selections;
+  /** @brief Data selection structure definition containers */
+  typedef struct MS3Selections
+  {
+    char sidpattern[100];              //!< Matching (globbing) pattern for source ID
+    struct MS3SelectTime *timewindows; //!< Pointer to time window list for this source ID
+    struct MS3Selections *next;        //!< Pointer to next selection, NULL if the last
+    uint8_t pubversion;                //!< Selected publication version, use 0 for any
+  } MS3Selections;
 
-extern MS3Selections* ms3_matchselect (MS3Selections *selections, char *sid,
-                                       nstime_t starttime, nstime_t endtime,
-                                       int pubversion, MS3SelectTime **ppselecttime);
-extern MS3Selections* msr3_matchselect (MS3Selections *selections, MS3Record *msr,
-                                        MS3SelectTime **ppselecttime);
-extern int ms3_addselect (MS3Selections **ppselections, char *sidpattern,
-                          nstime_t starttime, nstime_t endtime, uint8_t pubversion);
-extern int ms3_addselect_comp (MS3Selections **ppselections,
-                               char *network, char* station, char *location, char *channel,
-                               nstime_t starttime, nstime_t endtime, uint8_t pubversion);
-extern int ms3_readselectionsfile (MS3Selections **ppselections, char *filename);
-extern void ms3_freeselections (MS3Selections *selections);
-extern void ms3_printselections (MS3Selections *selections);
-/** @} */
+  extern MS3Selections *ms3_matchselect (MS3Selections *selections, char *sid,
+                                         nstime_t starttime, nstime_t endtime,
+                                         int pubversion, MS3SelectTime **ppselecttime);
+  extern MS3Selections *msr3_matchselect (MS3Selections *selections, MS3Record *msr,
+                                          MS3SelectTime **ppselecttime);
+  extern int ms3_addselect (MS3Selections **ppselections, char *sidpattern,
+                            nstime_t starttime, nstime_t endtime, uint8_t pubversion);
+  extern int ms3_addselect_comp (MS3Selections **ppselections,
+                                 char *network, char *station, char *location, char *channel,
+                                 nstime_t starttime, nstime_t endtime, uint8_t pubversion);
+  extern int ms3_readselectionsfile (MS3Selections **ppselections, char *filename);
+  extern void ms3_freeselections (MS3Selections *selections);
+  extern void ms3_printselections (MS3Selections *selections);
+  /** @} */
 
-/** @addtogroup record-list
-    @{ */
+  /** @addtogroup record-list
+      @{ */
 
-/** @brief A miniSEED record pointer and metadata
- *
- * Used to construct a list of data records that contributed to a
- * trace segment.
- *
- * The location of the record is identified at a memory address (\a
- * bufferptr), the location in an open file (\a fileptr and \a
- * fileoffset), or the location in a file (\a filename and \a
- * fileoffset).
- *
- * A ::MS3Record is stored with and contains the bit flags, extra
- * headers, etc. for the record.
- *
- * The \a dataoffset to the encoded data is stored to enable direct
- * decoding of data samples without re-parsing the header, used by
- * mstl3_unpack_recordlist().
- *
- * Note: the list is stored in the time order that the entries
- * contributed to the segment.
- *
- * @see mstl3_unpack_recordlist()
- */
-typedef struct MS3RecordPtr
-{
-  const char *bufferptr;     //!< Pointer in buffer to record, NULL if not used
-  FILE *fileptr;             //!< Pointer to open FILE containing record, NULL if not used
-  const char *filename;      //!< Pointer to file name containing record, NULL if not used
-  int64_t fileoffset;        //!< Offset into file to record for \a fileptr or \a filename
-  MS3Record *msr;            //!< Pointer to ::MS3Record for this record
-  nstime_t endtime;          //!< End time of record, time of last sample
-  uint32_t dataoffset;       //!< Offset from start of record to encoded data
-  void *prvtptr;             //!< Private pointer, will not be populated by library but will be free'd
-  struct MS3RecordPtr *next; //!< Pointer to next entry, NULL if the last
-} MS3RecordPtr;
+  /** @brief A miniSEED record pointer and metadata
+   *
+   * Used to construct a list of data records that contributed to a
+   * trace segment.
+   *
+   * The location of the record is identified at a memory address (\a
+   * bufferptr), the location in an open file (\a fileptr and \a
+   * fileoffset), or the location in a file (\a filename and \a
+   * fileoffset).
+   *
+   * A ::MS3Record is stored with and contains the bit flags, extra
+   * headers, etc. for the record.
+   *
+   * The \a dataoffset to the encoded data is stored to enable direct
+   * decoding of data samples without re-parsing the header, used by
+   * mstl3_unpack_recordlist().
+   *
+   * Note: the list is stored in the time order that the entries
+   * contributed to the segment.
+   *
+   * @see mstl3_unpack_recordlist()
+   */
+  typedef struct MS3RecordPtr
+  {
+    const char *bufferptr;     //!< Pointer in buffer to record, NULL if not used
+    FILE *fileptr;             //!< Pointer to open FILE containing record, NULL if not used
+    const char *filename;      //!< Pointer to file name containing record, NULL if not used
+    int64_t fileoffset;        //!< Offset into file to record for \a fileptr or \a filename
+    MS3Record *msr;            //!< Pointer to ::MS3Record for this record
+    nstime_t endtime;          //!< End time of record, time of last sample
+    uint32_t dataoffset;       //!< Offset from start of record to encoded data
+    void *prvtptr;             //!< Private pointer, will not be populated by library but will be free'd
+    struct MS3RecordPtr *next; //!< Pointer to next entry, NULL if the last
+  } MS3RecordPtr;
 
-/** @brief Record list, holds ::MS3RecordPtr entries that contribute to a given ::MS3TraceSeg */
-typedef struct MS3RecordList
-{
-  uint64_t recordcnt;  //!< Count of records in the list (for convenience)
-  MS3RecordPtr *first; //!< Pointer to first entry, NULL if the none
-  MS3RecordPtr *last;  //!< Pointer to last entry, NULL if the none
-} MS3RecordList;
+  /** @brief Record list, holds ::MS3RecordPtr entries that contribute to a given ::MS3TraceSeg */
+  typedef struct MS3RecordList
+  {
+    uint64_t recordcnt;  //!< Count of records in the list (for convenience)
+    MS3RecordPtr *first; //!< Pointer to first entry, NULL if the none
+    MS3RecordPtr *last;  //!< Pointer to last entry, NULL if the none
+  } MS3RecordList;
 
 /** @} */
 
@@ -532,153 +536,156 @@ typedef struct MS3RecordList
 /** @brief Maximum skip list height for MSTraceIDs */
 #define MSTRACEID_SKIPLIST_HEIGHT 8
 
-/** @brief Container for a continuous trace segment, linkable */
-typedef struct MS3TraceSeg {
-  nstime_t        starttime;         //!< Time of first sample
-  nstime_t        endtime;           //!< Time of last sample
-  double          samprate;          //!< Nominal sample rate (Hz)
-  int64_t         samplecnt;         //!< Number of samples in trace coverage
-  void           *datasamples;       //!< Data samples, \a numsamples of type \a sampletype
-  size_t          datasize;          //!< Size of datasamples buffer in bytes
-  int64_t         numsamples;        //!< Number of data samples in datasamples
-  char            sampletype;        //!< Sample type code, see @ref sample-types
-  void           *prvtptr;           //!< Private pointer for general use, unused by library
-  struct MS3RecordList *recordlist;  //!< List of pointers to records that contributed
-  struct MS3TraceSeg *prev;          //!< Pointer to previous segment
-  struct MS3TraceSeg *next;          //!< Pointer to next segment, NULL if the last
-} MS3TraceSeg;
+  /** @brief Container for a continuous trace segment, linkable */
+  typedef struct MS3TraceSeg
+  {
+    nstime_t starttime;               //!< Time of first sample
+    nstime_t endtime;                 //!< Time of last sample
+    double samprate;                  //!< Nominal sample rate (Hz)
+    int64_t samplecnt;                //!< Number of samples in trace coverage
+    void *datasamples;                //!< Data samples, \a numsamples of type \a sampletype
+    size_t datasize;                  //!< Size of datasamples buffer in bytes
+    int64_t numsamples;               //!< Number of data samples in datasamples
+    char sampletype;                  //!< Sample type code, see @ref sample-types
+    void *prvtptr;                    //!< Private pointer for general use, unused by library
+    struct MS3RecordList *recordlist; //!< List of pointers to records that contributed
+    struct MS3TraceSeg *prev;         //!< Pointer to previous segment
+    struct MS3TraceSeg *next;         //!< Pointer to next segment, NULL if the last
+  } MS3TraceSeg;
 
-/** @brief Container for a trace ID, linkable */
-typedef struct MS3TraceID {
-  char            sid[LM_SIDLEN];    //!< Source identifier as URN, max length @ref LM_SIDLEN
-  uint8_t         pubversion;        //!< Largest contributing publication version
-  nstime_t        earliest;          //!< Time of earliest sample
-  nstime_t        latest;            //!< Time of latest sample
-  void           *prvtptr;           //!< Private pointer for general use, unused by library
-  uint32_t        numsegments;       //!< Number of segments for this ID
-  struct MS3TraceSeg *first;         //!< Pointer to first of list of segments
-  struct MS3TraceSeg *last;          //!< Pointer to last of list of segments
-  struct MS3TraceID *next[MSTRACEID_SKIPLIST_HEIGHT];   //!< Next trace ID at first pointer, NULL if the last
-  uint8_t         height;            //!< Height of skip list at \a next
-} MS3TraceID;
+  /** @brief Container for a trace ID, linkable */
+  typedef struct MS3TraceID
+  {
+    char sid[LM_SIDLEN];                                //!< Source identifier as URN, max length @ref LM_SIDLEN
+    uint8_t pubversion;                                 //!< Largest contributing publication version
+    nstime_t earliest;                                  //!< Time of earliest sample
+    nstime_t latest;                                    //!< Time of latest sample
+    void *prvtptr;                                      //!< Private pointer for general use, unused by library
+    uint32_t numsegments;                               //!< Number of segments for this ID
+    struct MS3TraceSeg *first;                          //!< Pointer to first of list of segments
+    struct MS3TraceSeg *last;                           //!< Pointer to last of list of segments
+    struct MS3TraceID *next[MSTRACEID_SKIPLIST_HEIGHT]; //!< Next trace ID at first pointer, NULL if the last
+    uint8_t height;                                     //!< Height of skip list at \a next
+  } MS3TraceID;
 
-/** @brief Container for a collection of continuous trace segment, linkable */
-typedef struct MS3TraceList {
-  uint32_t           numtraces;      //!< Number of traces in list
-  struct MS3TraceID  traces;         //!< Head node of trace skip list, first entry at \a traces.next[0]
-  uint64_t           prngstate;      //!< INTERNAL: State for Pseudo RNG
-} MS3TraceList;
+  /** @brief Container for a collection of continuous trace segment, linkable */
+  typedef struct MS3TraceList
+  {
+    uint32_t numtraces;       //!< Number of traces in list
+    struct MS3TraceID traces; //!< Head node of trace skip list, first entry at \a traces.next[0]
+    uint64_t prngstate;       //!< INTERNAL: State for Pseudo RNG
+  } MS3TraceList;
 
-/** @brief Callback functions that return time and sample rate tolerances
- *
- * A container for function pointers that return time and sample rate
- * tolerances that are used for merging data into ::MS3TraceList
- * containers. The functions are provided with a ::MS3Record and must
- * return the acceptable tolerances to merge this with other data.
- *
- * The \c time(MS3Record) function must return a time tolerance in seconds.
- *
- * The \c samprate(MS3Record) function must return a sampling rate tolerance in Hertz.
- *
- * For any function pointer set to NULL a default tolerance will be used.
- *
- * Illustrated usage:
- * @code
- * MS3Tolerance tolerance;
- *
- * tolerance.time = my_time_tolerance_function;
- * tolerance.samprate = my_samprate_tolerance_function;
- *
- * mstl3_addmsr (mstl, msr, 0, 1, &tolerance);
- * @endcode
- *
- * \sa mstl3_addmsr()
- */
-typedef struct MS3Tolerance
-{
-  double (*time) (MS3Record *msr);     //!< Pointer to function that returns time tolerance
-  double (*samprate) (MS3Record *msr); //!< Pointer to function that returns sample rate tolerance
-} MS3Tolerance;
+  /** @brief Callback functions that return time and sample rate tolerances
+   *
+   * A container for function pointers that return time and sample rate
+   * tolerances that are used for merging data into ::MS3TraceList
+   * containers. The functions are provided with a ::MS3Record and must
+   * return the acceptable tolerances to merge this with other data.
+   *
+   * The \c time(MS3Record) function must return a time tolerance in seconds.
+   *
+   * The \c samprate(MS3Record) function must return a sampling rate tolerance in Hertz.
+   *
+   * For any function pointer set to NULL a default tolerance will be used.
+   *
+   * Illustrated usage:
+   * @code
+   * MS3Tolerance tolerance;
+   *
+   * tolerance.time = my_time_tolerance_function;
+   * tolerance.samprate = my_samprate_tolerance_function;
+   *
+   * mstl3_addmsr (mstl, msr, 0, 1, &tolerance);
+   * @endcode
+   *
+   * \sa mstl3_addmsr()
+   */
+  typedef struct MS3Tolerance
+  {
+    double (*time) (MS3Record *msr);     //!< Pointer to function that returns time tolerance
+    double (*samprate) (MS3Record *msr); //!< Pointer to function that returns sample rate tolerance
+  } MS3Tolerance;
 
-extern MS3TraceList* mstl3_init (MS3TraceList *mstl);
-extern void          mstl3_free (MS3TraceList **ppmstl, int8_t freeprvtptr);
-extern MS3TraceID*   mstl3_findID (MS3TraceList *mstl, const char *sid, uint8_t pubversion, MS3TraceID **prev);
+  extern MS3TraceList *mstl3_init (MS3TraceList *mstl);
+  extern void mstl3_free (MS3TraceList **ppmstl, int8_t freeprvtptr);
+  extern MS3TraceID *mstl3_findID (MS3TraceList *mstl, const char *sid, uint8_t pubversion, MS3TraceID **prev);
 
 /** @def mstl3_addmsr
     @brief Add a ::MS3Record to a ::MS3TraceList @see mstl3_addmsr_recordptr() */
 #define mstl3_addmsr(mstl, msr, splitversion, autoheal, flags, tolerance) \
   mstl3_addmsr_recordptr (mstl, msr, NULL, splitversion, autoheal, flags, tolerance)
 
-extern MS3TraceSeg*  mstl3_addmsr_recordptr (MS3TraceList *mstl, MS3Record *msr, MS3RecordPtr **pprecptr,
-                                             int8_t splitversion, int8_t autoheal, uint32_t flags,
-                                             MS3Tolerance *tolerance);
-extern int64_t       mstl3_readbuffer (MS3TraceList **ppmstl, char *buffer, uint64_t bufferlength,
-                                       int8_t splitversion, uint32_t flags,
-                                       MS3Tolerance *tolerance, int8_t verbose);
-extern int64_t       mstl3_readbuffer_selection (MS3TraceList **ppmstl, char *buffer, uint64_t bufferlength,
-                                                 int8_t splitversion, uint32_t flags,
-                                                 MS3Tolerance *tolerance, MS3Selections *selections,
-                                                 int8_t verbose);
-extern int64_t mstl3_unpack_recordlist (MS3TraceID *id, MS3TraceSeg *seg, void *output,
-                                        size_t outputsize, int8_t verbose);
-extern int mstl3_convertsamples (MS3TraceSeg *seg, char type, int8_t truncate);
-extern int mstl3_resize_buffers (MS3TraceList *mstl);
-extern int64_t mstl3_pack (MS3TraceList *mstl, void (*record_handler) (char *, int, void *),
-                           void *handlerdata, int reclen, int8_t encoding,
-                           int64_t *packedsamples, uint32_t flags, int8_t verbose, char *extra);
-extern void mstl3_printtracelist (MS3TraceList *mstl, ms_timeformat_t timeformat,
-                                  int8_t details, int8_t gaps, int8_t versions);
-extern void mstl3_printsynclist (MS3TraceList *mstl, char *dccid, ms_subseconds_t subseconds);
-extern void mstl3_printgaplist (MS3TraceList *mstl, ms_timeformat_t timeformat,
-                                double *mingap, double *maxgap);
-/** @} */
+  extern MS3TraceSeg *mstl3_addmsr_recordptr (MS3TraceList *mstl, MS3Record *msr, MS3RecordPtr **pprecptr,
+                                              int8_t splitversion, int8_t autoheal, uint32_t flags,
+                                              MS3Tolerance *tolerance);
+  extern int64_t mstl3_readbuffer (MS3TraceList **ppmstl, char *buffer, uint64_t bufferlength,
+                                   int8_t splitversion, uint32_t flags,
+                                   MS3Tolerance *tolerance, int8_t verbose);
+  extern int64_t mstl3_readbuffer_selection (MS3TraceList **ppmstl, char *buffer, uint64_t bufferlength,
+                                             int8_t splitversion, uint32_t flags,
+                                             MS3Tolerance *tolerance, MS3Selections *selections,
+                                             int8_t verbose);
+  extern int64_t mstl3_unpack_recordlist (MS3TraceID *id, MS3TraceSeg *seg, void *output,
+                                          size_t outputsize, int8_t verbose);
+  extern int mstl3_convertsamples (MS3TraceSeg *seg, char type, int8_t truncate);
+  extern int mstl3_resize_buffers (MS3TraceList *mstl);
+  extern int64_t mstl3_pack (MS3TraceList *mstl, void (*record_handler) (char *, int, void *),
+                             void *handlerdata, int reclen, int8_t encoding,
+                             int64_t *packedsamples, uint32_t flags, int8_t verbose, char *extra);
+  extern void mstl3_printtracelist (MS3TraceList *mstl, ms_timeformat_t timeformat,
+                                    int8_t details, int8_t gaps, int8_t versions);
+  extern void mstl3_printsynclist (MS3TraceList *mstl, char *dccid, ms_subseconds_t subseconds);
+  extern void mstl3_printgaplist (MS3TraceList *mstl, ms_timeformat_t timeformat,
+                                  double *mingap, double *maxgap);
+  /** @} */
 
-/** @addtogroup io-functions
-    @brief Reading and writing interfaces for miniSEED to/from files or URLs
+  /** @addtogroup io-functions
+      @brief Reading and writing interfaces for miniSEED to/from files or URLs
 
-    The miniSEED reading interfaces read from either regular files or
-    URLs (if optional support is included).  The miniSEED writing
-    interfaces write to regular files.
+      The miniSEED reading interfaces read from either regular files or
+      URLs (if optional support is included).  The miniSEED writing
+      interfaces write to regular files.
 
-    URL support for reading is included by building the library with the
-    \b LIBMSEED_URL variable defined, see the
-<a class="el" href="https://github.com/earthscope/libmseed/tree/master/INSTALL.md">INSTALL instructions</a>
-    for more information.  Only URL path-specified resources can be read,
-    e.g. HTTP GET requests.  More advanced POST or form-based requests are not supported.
+      URL support for reading is included by building the library with the
+      \b LIBMSEED_URL variable defined, see the
+  <a class="el" href="https://github.com/earthscope/libmseed/tree/master/INSTALL.md">INSTALL instructions</a>
+      for more information.  Only URL path-specified resources can be read,
+      e.g. HTTP GET requests.  More advanced POST or form-based requests are not supported.
 
-    The function @ref libmseed_url_support() can be used as a run-time test
-    to determine if URL support is included in the library.
+      The function @ref libmseed_url_support() can be used as a run-time test
+      to determine if URL support is included in the library.
 
-    Some parameters can be set that affect the reading of data from URLs, including:
-    - set the User-Agent header with @ref ms3_url_useragent()
-    - set username and password for authentication with @ref ms3_url_userpassword()
-    - set arbitrary headers with @ref ms3_url_addheader()
-    - disable SSL peer and host verficiation by setting **LIBMSEED_SSL_NOVERIFY** environment variable
+      Some parameters can be set that affect the reading of data from URLs, including:
+      - set the User-Agent header with @ref ms3_url_useragent()
+      - set username and password for authentication with @ref ms3_url_userpassword()
+      - set arbitrary headers with @ref ms3_url_addheader()
+      - disable SSL peer and host verficiation by setting **LIBMSEED_SSL_NOVERIFY** environment variable
 
-    Diagnostics: Setting environment variable **LIBMSEED_URL_DEBUG** enables
-    detailed verbosity of URL protocol exchanges.
+      Diagnostics: Setting environment variable **LIBMSEED_URL_DEBUG** enables
+      detailed verbosity of URL protocol exchanges.
 
-    \sa ms3_readmsr()
-    \sa ms3_readmsr_selection()
-    \sa ms3_readtracelist()
-    \sa ms3_readtracelist_selection()
-    \sa msr3_writemseed()
-    \sa mstl3_writemseed()
-    @{ */
+      \sa ms3_readmsr()
+      \sa ms3_readmsr_selection()
+      \sa ms3_readtracelist()
+      \sa ms3_readtracelist_selection()
+      \sa msr3_writemseed()
+      \sa mstl3_writemseed()
+      @{ */
 
-/** @brief Type definition for data source I/O: file-system versus URL */
-typedef struct LMIO
-{
-  enum
+  /** @brief Type definition for data source I/O: file-system versus URL */
+  typedef struct LMIO
   {
-    LMIO_NULL = 0,   //!< IO handle type is undefined
-    LMIO_FILE = 1,   //!< IO handle is FILE-type
-    LMIO_URL  = 2    //!< IO handle is URL-type
-  } type;            //!< IO handle type
-  void *handle;      //!< Primary IO handle, either file or URL
-  void *handle2;     //!< Secondary IO handle for URL
-  int still_running; //!< Fetch status flag for URL transmissions
-} LMIO;
+    enum
+    {
+      LMIO_NULL = 0,   //!< IO handle type is undefined
+      LMIO_FILE = 1,   //!< IO handle is FILE-type
+      LMIO_URL  = 2    //!< IO handle is URL-type
+    } type;            //!< IO handle type
+    void *handle;      //!< Primary IO handle, either file or URL
+    void *handle2;     //!< Secondary IO handle for URL
+    int still_running; //!< Fetch status flag for URL transmissions
+  } LMIO;
 
 /** @def LMIO_INITIALIZER
     @brief Initialializer for the internal stream handle ::LMIO */
@@ -687,27 +694,27 @@ typedef struct LMIO
     .type = LMIO_NULL, .handle = NULL, .handle2 = NULL, .still_running = 0 \
   }
 
-/** @brief State container for reading miniSEED records from files or URLs.
+  /** @brief State container for reading miniSEED records from files or URLs.
 
-    In general these values should not be directly set or accessed.  It is
-    possible to allocate a structure and set the \c path, \c startoffset,
-    and \c endoffset values for advanced usage.  Note that file/URL start
-    and end offsets can also be parsed from the path name as well.
-*/
-typedef struct MS3FileParam
-{
-  char path[512];      //!< INPUT: File name or URL
-  int64_t startoffset; //!< INPUT: Start position in input stream
-  int64_t endoffset;   //!< INPUT: End position in input stream, 0 == unknown (e.g. pipe)
-  int64_t streampos;   //!< OUTPUT: Read position of input stream
-  int64_t recordcount; //!< OUTPUT: Count of records read from this file so far
+      In general these values should not be directly set or accessed.  It is
+      possible to allocate a structure and set the \c path, \c startoffset,
+      and \c endoffset values for advanced usage.  Note that file/URL start
+      and end offsets can also be parsed from the path name as well.
+  */
+  typedef struct MS3FileParam
+  {
+    char path[512];      //!< INPUT: File name or URL
+    int64_t startoffset; //!< INPUT: Start position in input stream
+    int64_t endoffset;   //!< INPUT: End position in input stream, 0 == unknown (e.g. pipe)
+    int64_t streampos;   //!< OUTPUT: Read position of input stream
+    int64_t recordcount; //!< OUTPUT: Count of records read from this file so far
 
-  char *readbuffer;    //!< INTERNAL: Read buffer, allocated internally
-  int readlength;      //!< INTERNAL: Length of data in read buffer
-  int readoffset;      //!< INTERNAL: Read offset in read buffer
-  uint32_t flags;      //!< INTERNAL: Stream reading state flags
-  LMIO input;          //!< INTERNAL: IO handle, file or URL
-} MS3FileParam;
+    char *readbuffer; //!< INTERNAL: Read buffer, allocated internally
+    int readlength;   //!< INTERNAL: Length of data in read buffer
+    int readoffset;   //!< INTERNAL: Read offset in read buffer
+    uint32_t flags;   //!< INTERNAL: Stream reading state flags
+    LMIO input;       //!< INTERNAL: IO handle, file or URL
+  } MS3FileParam;
 
 /** @def MS3FileParam_INITIALIZER
     @brief Initialializer for the internal file or URL I/O parameters ::MS3FileParam */
@@ -718,177 +725,176 @@ typedef struct MS3FileParam
     .readoffset = 0, .flags = 0, .input = LMIO_INITIALIZER        \
   }
 
-extern int ms3_readmsr (MS3Record **ppmsr, const char *mspath, int64_t *fpos, int8_t *last,
-                        uint32_t flags, int8_t verbose);
-extern int ms3_readmsr_r (MS3FileParam **ppmsfp, MS3Record **ppmsr, const char *mspath,
-                          int64_t *fpos, int8_t *last, uint32_t flags, int8_t verbose);
-extern int ms3_readmsr_selection (MS3FileParam **ppmsfp, MS3Record **ppmsr, const char *mspath,
-                                  int64_t *fpos, int8_t *last, uint32_t flags,
-                                  MS3Selections *selections, int8_t verbose);
-extern int ms3_readtracelist (MS3TraceList **ppmstl, const char *mspath, MS3Tolerance *tolerance,
-                              int8_t splitversion, uint32_t flags, int8_t verbose);
-extern int ms3_readtracelist_timewin (MS3TraceList **ppmstl, const char *mspath, MS3Tolerance *tolerance,
-                                      nstime_t starttime, nstime_t endtime, int8_t splitversion, uint32_t flags,
-                                      int8_t verbose);
-extern int ms3_readtracelist_selection (MS3TraceList **ppmstl, const char *mspath, MS3Tolerance *tolerance,
-                                        MS3Selections *selections, int8_t splitversion, uint32_t flags, int8_t verbose);
-extern int ms3_url_useragent (const char *program, const char *version);
-extern int ms3_url_userpassword (const char *userpassword);
-extern int ms3_url_addheader (const char *header);
-extern void ms3_url_freeheaders (void);
-extern int64_t msr3_writemseed (MS3Record *msr, const char *mspath, int8_t overwrite,
-                                uint32_t flags, int8_t verbose);
-extern int64_t mstl3_writemseed (MS3TraceList *mst, const char *mspath, int8_t overwrite,
-                                 int maxreclen, int8_t encoding, uint32_t flags, int8_t verbose);
-extern int libmseed_url_support (void);
-/** @} */
+  extern int ms3_readmsr (MS3Record **ppmsr, const char *mspath, int64_t *fpos, int8_t *last,
+                          uint32_t flags, int8_t verbose);
+  extern int ms3_readmsr_r (MS3FileParam **ppmsfp, MS3Record **ppmsr, const char *mspath,
+                            int64_t *fpos, int8_t *last, uint32_t flags, int8_t verbose);
+  extern int ms3_readmsr_selection (MS3FileParam **ppmsfp, MS3Record **ppmsr, const char *mspath,
+                                    int64_t *fpos, int8_t *last, uint32_t flags,
+                                    MS3Selections *selections, int8_t verbose);
+  extern int ms3_readtracelist (MS3TraceList **ppmstl, const char *mspath, MS3Tolerance *tolerance,
+                                int8_t splitversion, uint32_t flags, int8_t verbose);
+  extern int ms3_readtracelist_timewin (MS3TraceList **ppmstl, const char *mspath, MS3Tolerance *tolerance,
+                                        nstime_t starttime, nstime_t endtime, int8_t splitversion, uint32_t flags,
+                                        int8_t verbose);
+  extern int ms3_readtracelist_selection (MS3TraceList **ppmstl, const char *mspath, MS3Tolerance *tolerance,
+                                          MS3Selections *selections, int8_t splitversion, uint32_t flags, int8_t verbose);
+  extern int ms3_url_useragent (const char *program, const char *version);
+  extern int ms3_url_userpassword (const char *userpassword);
+  extern int ms3_url_addheader (const char *header);
+  extern void ms3_url_freeheaders (void);
+  extern int64_t msr3_writemseed (MS3Record *msr, const char *mspath, int8_t overwrite,
+                                  uint32_t flags, int8_t verbose);
+  extern int64_t mstl3_writemseed (MS3TraceList *mst, const char *mspath, int8_t overwrite,
+                                   int maxreclen, int8_t encoding, uint32_t flags, int8_t verbose);
+  extern int libmseed_url_support (void);
+  /** @} */
 
-/** @addtogroup string-functions
-    @brief Source identifier (SID) and string manipulation functions
+  /** @addtogroup string-functions
+      @brief Source identifier (SID) and string manipulation functions
 
-    A source identifier uniquely identifies the generator of data in a
-    record.  This is a small string, usually in the form of a URI.
-    For data identified with FDSN codes, the SID is usally a simple
-    combination of the codes.
+      A source identifier uniquely identifies the generator of data in a
+      record.  This is a small string, usually in the form of a URI.
+      For data identified with FDSN codes, the SID is usally a simple
+      combination of the codes.
 
-    @{ */
-extern int ms_sid2nslc (const char *sid, char *net, char *sta, char *loc, char *chan);
-extern int ms_nslc2sid (char *sid, int sidlen, uint16_t flags,
-                        const char *net, const char *sta, const char *loc, const char *chan);
-extern int ms_seedchan2xchan (char *xchan, const char *seedchan);
-extern int ms_xchan2seedchan (char *seedchan, const char *xchan);
-extern int ms_strncpclean (char *dest, const char *source, int length);
-extern int ms_strncpcleantail (char *dest, const char *source, int length);
-extern int ms_strncpopen (char *dest, const char *source, int length);
-/** @} */
+      @{ */
+  extern int ms_sid2nslc (const char *sid, char *net, char *sta, char *loc, char *chan);
+  extern int ms_nslc2sid (char *sid, int sidlen, uint16_t flags,
+                          const char *net, const char *sta, const char *loc, const char *chan);
+  extern int ms_seedchan2xchan (char *xchan, const char *seedchan);
+  extern int ms_xchan2seedchan (char *seedchan, const char *xchan);
+  extern int ms_strncpclean (char *dest, const char *source, int length);
+  extern int ms_strncpcleantail (char *dest, const char *source, int length);
+  extern int ms_strncpopen (char *dest, const char *source, int length);
+  /** @} */
 
-/** @addtogroup extra-headers
-    @brief Structures and funtions to support extra headers
+  /** @addtogroup extra-headers
+      @brief Structures and funtions to support extra headers
 
-    Extra headers are stored as JSON within a data record header using
-    an anonymous, root object as a container for all extra headers.
-    For a full description consult the format specification.
+      Extra headers are stored as JSON within a data record header using
+      an anonymous, root object as a container for all extra headers.
+      For a full description consult the format specification.
 
-    The library functions supporting extra headers allow specific
-    header identification using JSON Pointer identification.  In this
-    notation each path element is an object until the final element
-    which is a key to specified header value.
+      The library functions supporting extra headers allow specific
+      header identification using JSON Pointer identification.  In this
+      notation each path element is an object until the final element
+      which is a key to specified header value.
 
-    For example, a \a path specified as:
-    \code
-    "/objectA/objectB/header"
-    \endcode
+      For example, a \a path specified as:
+      \code
+      "/objectA/objectB/header"
+      \endcode
 
-    would correspond to the single JSON value in:
-    \code
-    {
-       "objectA": {
-         "objectB": {
-           "header":VALUE
-          }
-       }
-    }
-    \endcode
-    @{ */
+      would correspond to the single JSON value in:
+      \code
+      {
+         "objectA": {
+           "objectB": {
+             "header":VALUE
+            }
+         }
+      }
+      \endcode
+      @{ */
 
-/**
- * @brief Container for event detection parameters for use in extra headers
- *
- * Actual values are optional, with special values indicating an unset
- * state.
- *
- * @see mseh_add_event_detection_r
- */
-typedef struct MSEHEventDetection
-{
-  char type[30]; /**< Detector type (e.g. "MURDOCK"), zero length = not included */
-  char detector[30]; /**< Detector name, zero length = not included  */
-  double signalamplitude; /**< SignalAmplitude, 0.0 = not included */
-  double signalperiod; /**< Signal period, 0.0 = not included */
-  double backgroundestimate; /**< Background estimate, 0.0 = not included */
-  char wave[30]; /**< Detection wave (e.g. "DILATATION"), zero length = not included */
-  char units[30]; /**< Units of amplitude and background estimate (e.g. "COUNTS"), zero length = not included */
-  nstime_t onsettime; /**< Onset time, NSTUNSET = not included */
-  uint8_t medsnr[6]; /**< Signal to noise ratio for Murdock event detection, all zeros = not included */
-  int medlookback; /**< Murdock event detection lookback value, -1 = not included */
-  int medpickalgorithm; /**< Murdock event detection pick algoritm, -1 = not included */
-  struct MSEHEventDetection *next; /**< Pointer to next, NULL if none */
-} MSEHEventDetection;
+  /**
+   * @brief Container for event detection parameters for use in extra headers
+   *
+   * Actual values are optional, with special values indicating an unset
+   * state.
+   *
+   * @see mseh_add_event_detection_r
+   */
+  typedef struct MSEHEventDetection
+  {
+    char type[30];                   /**< Detector type (e.g. "MURDOCK"), zero length = not included */
+    char detector[30];               /**< Detector name, zero length = not included  */
+    double signalamplitude;          /**< SignalAmplitude, 0.0 = not included */
+    double signalperiod;             /**< Signal period, 0.0 = not included */
+    double backgroundestimate;       /**< Background estimate, 0.0 = not included */
+    char wave[30];                   /**< Detection wave (e.g. "DILATATION"), zero length = not included */
+    char units[30];                  /**< Units of amplitude and background estimate (e.g. "COUNTS"), zero length = not included */
+    nstime_t onsettime;              /**< Onset time, NSTUNSET = not included */
+    uint8_t medsnr[6];               /**< Signal to noise ratio for Murdock event detection, all zeros = not included */
+    int medlookback;                 /**< Murdock event detection lookback value, -1 = not included */
+    int medpickalgorithm;            /**< Murdock event detection pick algoritm, -1 = not included */
+    struct MSEHEventDetection *next; /**< Pointer to next, NULL if none */
+  } MSEHEventDetection;
 
-/**
- * @brief Container for calibration parameters for use in extra headers
- *
- * Actual values are optional, with special values indicating an unset
- * state.
- *
- * @see mseh_add_calibration
- */
-typedef struct MSEHCalibration
-{
-  char type[30]; /**< Calibration type  (e.g. "STEP", "SINE", "PSEUDORANDOM"), zero length = not included */
-  nstime_t begintime; /**< Begin time, NSTUNSET = not included */
-  nstime_t endtime; /**< End time, NSTUNSET = not included */
-  int steps; /**< Number of step calibrations, -1 = not included */
-  int firstpulsepositive; /**< Boolean, step cal. first pulse, -1 = not included */
-  int alternatesign; /**< Boolean, step cal. alt. sign, -1 = not included */
-  char trigger[30]; /**< Trigger, e.g. AUTOMATIC or MANUAL, zero length = not included */
-  int continued; /**< Boolean, continued from prev. record, -1 = not included */
-  double amplitude; /**< Amp. of calibration signal, 0.0 = not included */
-  char inputunits[30]; /**< Units of input (e.g. volts, amps), zero length = not included */
-  char amplituderange[30]; /**< E.g PEAKTOPTEAK, ZEROTOPEAK, RMS, RANDOM, zero length = not included */
-  double duration; /**< Duration in seconds, 0.0 = not included */
-  double sineperiod; /**< Period of sine, 0.0 = not included */
-  double stepbetween; /**< Interval bewteen steps, 0.0 = not included */
-  char inputchannel[30]; /**< Channel of input, zero length = not included */
-  double refamplitude; /**< Reference amplitude, 0.0 = not included */
-  char coupling[30]; /**< Coupling, e.g. Resistive, Capacitive, zero length = not included */
-  char rolloff[30]; /**< Rolloff of filters, zero length = not included */
-  char noise[30]; /**< Noise for PR cals, e.g. White or Red, zero length = not included */
-  struct MSEHCalibration *next; /**< Pointer to next, NULL if none */
-} MSEHCalibration;
+  /**
+   * @brief Container for calibration parameters for use in extra headers
+   *
+   * Actual values are optional, with special values indicating an unset
+   * state.
+   *
+   * @see mseh_add_calibration
+   */
+  typedef struct MSEHCalibration
+  {
+    char type[30];                /**< Calibration type  (e.g. "STEP", "SINE", "PSEUDORANDOM"), zero length = not included */
+    nstime_t begintime;           /**< Begin time, NSTUNSET = not included */
+    nstime_t endtime;             /**< End time, NSTUNSET = not included */
+    int steps;                    /**< Number of step calibrations, -1 = not included */
+    int firstpulsepositive;       /**< Boolean, step cal. first pulse, -1 = not included */
+    int alternatesign;            /**< Boolean, step cal. alt. sign, -1 = not included */
+    char trigger[30];             /**< Trigger, e.g. AUTOMATIC or MANUAL, zero length = not included */
+    int continued;                /**< Boolean, continued from prev. record, -1 = not included */
+    double amplitude;             /**< Amp. of calibration signal, 0.0 = not included */
+    char inputunits[30];          /**< Units of input (e.g. volts, amps), zero length = not included */
+    char amplituderange[30];      /**< E.g PEAKTOPTEAK, ZEROTOPEAK, RMS, RANDOM, zero length = not included */
+    double duration;              /**< Duration in seconds, 0.0 = not included */
+    double sineperiod;            /**< Period of sine, 0.0 = not included */
+    double stepbetween;           /**< Interval bewteen steps, 0.0 = not included */
+    char inputchannel[30];        /**< Channel of input, zero length = not included */
+    double refamplitude;          /**< Reference amplitude, 0.0 = not included */
+    char coupling[30];            /**< Coupling, e.g. Resistive, Capacitive, zero length = not included */
+    char rolloff[30];             /**< Rolloff of filters, zero length = not included */
+    char noise[30];               /**< Noise for PR cals, e.g. White or Red, zero length = not included */
+    struct MSEHCalibration *next; /**< Pointer to next, NULL if none */
+  } MSEHCalibration;
 
-/**
- * @brief Container for timing exception parameters for use in extra headers
- *
- * Actual values are optional, with special values indicating an unset
- * state.
- *
- * @see mseh_add_timing_exception
- */
-typedef struct MSEHTimingException
-{
-  nstime_t time; /**< Time of exception, NSTUNSET = not included */
-  float vcocorrection; /**< VCO correction, from 0 to 100%, <0 = not included */
-  int usec; /**< [DEPRECATED] microsecond time offset, 0 = not included */
-  int receptionquality; /**< Reception quality, 0 to 100% clock accurracy, <0 = not included */
-  uint32_t count; /**< The count thereof, 0 = not included */
-  char type[16]; /**< E.g. "MISSING" or "UNEXPECTED", zero length = not included */
-  char clockstatus[128]; /**< Description of clock-specific parameters, zero length = not included */
-} MSEHTimingException;
+  /**
+   * @brief Container for timing exception parameters for use in extra headers
+   *
+   * Actual values are optional, with special values indicating an unset
+   * state.
+   *
+   * @see mseh_add_timing_exception
+   */
+  typedef struct MSEHTimingException
+  {
+    nstime_t time;         /**< Time of exception, NSTUNSET = not included */
+    float vcocorrection;   /**< VCO correction, from 0 to 100%, <0 = not included */
+    int usec;              /**< [DEPRECATED] microsecond time offset, 0 = not included */
+    int receptionquality;  /**< Reception quality, 0 to 100% clock accurracy, <0 = not included */
+    uint32_t count;        /**< The count thereof, 0 = not included */
+    char type[16];         /**< E.g. "MISSING" or "UNEXPECTED", zero length = not included */
+    char clockstatus[128]; /**< Description of clock-specific parameters, zero length = not included */
+  } MSEHTimingException;
 
-/**
- * @brief Container for recenter parameters for use in extra headers
- *
- * Actual values are optional, with special values indicating an unset
- * state.
- *
- * @see mseh_add_recenter
- */
-typedef struct MSEHRecenter
-{
-  char type[30]; /**< Recenter type  (e.g. "MASS", "GIMBAL"), zero length = not included */
-  nstime_t begintime; /**< Begin time, NSTUNSET = not included */
-  nstime_t endtime; /**< Estimated end time, NSTUNSET = not included */
-  char trigger[30]; /**< Trigger, e.g. AUTOMATIC or MANUAL, zero length = not included */
-} MSEHRecenter;
+  /**
+   * @brief Container for recenter parameters for use in extra headers
+   *
+   * Actual values are optional, with special values indicating an unset
+   * state.
+   *
+   * @see mseh_add_recenter
+   */
+  typedef struct MSEHRecenter
+  {
+    char type[30];      /**< Recenter type  (e.g. "MASS", "GIMBAL"), zero length = not included */
+    nstime_t begintime; /**< Begin time, NSTUNSET = not included */
+    nstime_t endtime;   /**< Estimated end time, NSTUNSET = not included */
+    char trigger[30];   /**< Trigger, e.g. AUTOMATIC or MANUAL, zero length = not included */
+  } MSEHRecenter;
 
-
-/**
- * @brief Internal structure for holding parsed JSON extra headers.
- * @see mseh_get_path_r()
- * @see mseh_set_path_r()
- */
-typedef struct LM_PARSED_JSON LM_PARSED_JSON;
+  /**
+   * @brief Internal structure for holding parsed JSON extra headers.
+   * @see mseh_get_path_r()
+   * @see mseh_set_path_r()
+   */
+  typedef struct LM_PARSED_JSON LM_PARSED_JSON;
 
 /** @def mseh_get
     @brief A simple wrapper to access any type of extra header */
@@ -897,32 +903,32 @@ typedef struct LM_PARSED_JSON LM_PARSED_JSON;
 
 /** @def mseh_get_number
     @brief A simple wrapper to access a number type extra header */
-#define mseh_get_number(msr, path, valueptr)    \
+#define mseh_get_number(msr, path, valueptr) \
   mseh_get_path_r (msr, path, valueptr, 'n', 0, NULL)
 
 /** @def mseh_get_int64
     @brief A simple wrapper to access a number type extra header */
-#define mseh_get_int64(msr, path, valueptr)    \
+#define mseh_get_int64(msr, path, valueptr) \
   mseh_get_path_r (msr, path, valueptr, 'i', 0, NULL)
 
 /** @def mseh_get_string
     @brief A simple wrapper to access a string type extra header */
-#define mseh_get_string(msr, path, buffer, maxlength)   \
+#define mseh_get_string(msr, path, buffer, maxlength) \
   mseh_get_path_r (msr, path, buffer, 's', maxlength, NULL)
 
 /** @def mseh_get_boolean
     @brief A simple wrapper to access a boolean type extra header */
-#define mseh_get_boolean(msr, path, valueptr)   \
+#define mseh_get_boolean(msr, path, valueptr) \
   mseh_get_path_r (msr, path, valueptr, 'b', 0, NULL)
 
 /** @def mseh_exists
     @brief A simple wrapper to test existence of an extra header */
-#define mseh_exists(msr, path)                  \
+#define mseh_exists(msr, path) \
   (!mseh_get_path_r (msr, path, NULL, 0, 0, NULL))
 
-extern int mseh_get_path_r (MS3Record *msr, const char *path,
-                            void *value, char type, size_t maxlength,
-                            LM_PARSED_JSON **parsestate);
+  extern int mseh_get_path_r (MS3Record *msr, const char *path,
+                              void *value, char type, size_t maxlength,
+                              LM_PARSED_JSON **parsestate);
 
 /** @def mseh_set
     @brief A simple wrapper to set any type of extra header */
@@ -946,45 +952,45 @@ extern int mseh_get_path_r (MS3Record *msr, const char *path,
 
 /** @def mseh_set_boolean
     @brief A simple wrapper to set a boolean type extra header */
-#define mseh_set_boolean(msr, path, valueptr)   \
+#define mseh_set_boolean(msr, path, valueptr) \
   mseh_set_path_r (msr, path, valueptr, 'b', NULL)
 
-extern int mseh_set_path_r (MS3Record *msr, const char *path,
-                            void *value, char type,
-                            LM_PARSED_JSON **parsestate);
+  extern int mseh_set_path_r (MS3Record *msr, const char *path,
+                              void *value, char type,
+                              LM_PARSED_JSON **parsestate);
 
 #define mseh_add_event_detection(msr, path, eventdetection) \
   mseh_add_event_detection_r (msr, path, eventdetection, NULL)
 
-extern int mseh_add_event_detection_r (MS3Record *msr, const char *path,
-                                       MSEHEventDetection *eventdetection,
-                                       LM_PARSED_JSON **parsestate);
+  extern int mseh_add_event_detection_r (MS3Record *msr, const char *path,
+                                         MSEHEventDetection *eventdetection,
+                                         LM_PARSED_JSON **parsestate);
 
 #define mseh_add_calibration(msr, path, calibration) \
   mseh_add_calibration_r (msr, path, calibration, NULL)
 
-extern int mseh_add_calibration_r (MS3Record *msr, const char *path,
-                                   MSEHCalibration *calibration,
-                                   LM_PARSED_JSON **parsestate);
+  extern int mseh_add_calibration_r (MS3Record *msr, const char *path,
+                                     MSEHCalibration *calibration,
+                                     LM_PARSED_JSON **parsestate);
 
 #define mseh_add_timing_exception(msr, path, exception) \
   mseh_add_timing_exception_r (msr, path, exception, NULL)
 
-extern int mseh_add_timing_exception_r (MS3Record *msr, const char *path,
-                                        MSEHTimingException *exception,
-                                        LM_PARSED_JSON **parsestate);
+  extern int mseh_add_timing_exception_r (MS3Record *msr, const char *path,
+                                          MSEHTimingException *exception,
+                                          LM_PARSED_JSON **parsestate);
 
 #define mseh_add_recenter(msr, path, recenter) \
   mseh_add_recenter_r (msr, path, recenter, NULL)
 
-extern int mseh_add_recenter_r (MS3Record *msr, const char *path,
-                                MSEHRecenter *recenter,
-                                LM_PARSED_JSON **parsestate);
+  extern int mseh_add_recenter_r (MS3Record *msr, const char *path,
+                                  MSEHRecenter *recenter,
+                                  LM_PARSED_JSON **parsestate);
 
-extern int mseh_serialize (MS3Record *msr, LM_PARSED_JSON **parsestate);
-extern void mseh_free_parsestate (LM_PARSED_JSON **parsestate);
+  extern int mseh_serialize (MS3Record *msr, LM_PARSED_JSON **parsestate);
+  extern void mseh_free_parsestate (LM_PARSED_JSON **parsestate);
 
-extern int mseh_print (MS3Record *msr, int indent);
+  extern int mseh_print (MS3Record *msr, int indent);
 /** @} */
 
 /** @addtogroup record-list
@@ -1093,49 +1099,49 @@ extern int mseh_print (MS3Record *msr, int indent);
     @{ */
 
 /** Maximum length of log messages in bytes */
-#define MAX_LOG_MSG_LENGTH  200
+#define MAX_LOG_MSG_LENGTH 200
 
-/** @brief Log registry entry.
-    \sa ms_rlog()
-    \sa ms_rlog_l() */
-typedef struct MSLogEntry
-{
-  int level;                        //!< Message level
-  char function[30];                //!< Function generating the message
-  char message[MAX_LOG_MSG_LENGTH]; //!< Log, warning or error message
-  struct MSLogEntry *next;
-} MSLogEntry;
+  /** @brief Log registry entry.
+      \sa ms_rlog()
+      \sa ms_rlog_l() */
+  typedef struct MSLogEntry
+  {
+    int level;                        //!< Message level
+    char function[30];                //!< Function generating the message
+    char message[MAX_LOG_MSG_LENGTH]; //!< Log, warning or error message
+    struct MSLogEntry *next;
+  } MSLogEntry;
 
-/** @brief Log message registry.
-    \sa ms_rlog()
-    \sa ms_rlog_l() */
-typedef struct MSLogRegistry
-{
-  int maxmessages;
-  int messagecnt;
-  MSLogEntry *messages;
-} MSLogRegistry;
+  /** @brief Log message registry.
+      \sa ms_rlog()
+      \sa ms_rlog_l() */
+  typedef struct MSLogRegistry
+  {
+    int maxmessages;
+    int messagecnt;
+    MSLogEntry *messages;
+  } MSLogRegistry;
 
 /** @def MSLogRegistry_INITIALIZER
     @brief Initialializer for ::MSLogRegistry */
-#define MSLogRegistry_INITIALIZER                        \
-  {                                                      \
-    .maxmessages = 0, .messagecnt = 0, .messages = NULL  \
+#define MSLogRegistry_INITIALIZER                       \
+  {                                                     \
+    .maxmessages = 0, .messagecnt = 0, .messages = NULL \
   }
 
-/** @brief Logging parameters.
-    __Callers should not modify these values directly and generally
-    should not need to access them.__
+  /** @brief Logging parameters.
+      __Callers should not modify these values directly and generally
+      should not need to access them.__
 
-    \sa ms_loginit() */
-typedef struct MSLogParam
-{
-  void (*log_print)(const char*);  //!< Function to call for regular messages
-  const char *logprefix;           //!< Message prefix for regular and diagnostic messages
-  void (*diag_print)(const char*); //!< Function to call for diagnostic and error messages
-  const char *errprefix;           //!< Message prefix for error messages
-  MSLogRegistry registry;          //!< Message registry
-} MSLogParam;
+      \sa ms_loginit() */
+  typedef struct MSLogParam
+  {
+    void (*log_print) (const char *);  //!< Function to call for regular messages
+    const char *logprefix;             //!< Message prefix for regular and diagnostic messages
+    void (*diag_print) (const char *); //!< Function to call for diagnostic and error messages
+    const char *errprefix;             //!< Message prefix for error messages
+    MSLogRegistry registry;            //!< Message registry
+  } MSLogParam;
 
 /** @def MSLogParam_INITIALIZER
     @brief Initialializer for ::MSLogParam */
@@ -1149,205 +1155,201 @@ typedef struct MSLogParam
 /** @def ms_log
     @brief Wrapper for ms_rlog(), call as __ms_log (level, format, ...)__
 */
-#define ms_log(level, ...)                      \
-  ms_rlog(__func__, level, __VA_ARGS__)
+#define ms_log(level, ...) \
+  ms_rlog (__func__, level, __VA_ARGS__)
 
 /** @def ms_log_l
     @brief Wrapper for ms_rlog_l(), call as __ms_log_l (logp, level, format, ...)__
 */
-#define ms_log_l(logp, level, ...)              \
-  ms_rlog_l(logp, __func__, level, __VA_ARGS__)
+#define ms_log_l(logp, level, ...) \
+  ms_rlog_l (logp, __func__, level, __VA_ARGS__)
 
 #if defined(__GNUC__) || defined(__clang__)
-__attribute__((__format__ (__printf__, 3, 4)))
+  __attribute__ ((__format__ (__printf__, 3, 4)))
 #endif
-extern int ms_rlog (const char *function, int level, const char *format, ...);
+  extern int
+  ms_rlog (const char *function, int level, const char *format, ...);
 #if defined(__GNUC__) || defined(__clang__)
-__attribute__ ((__format__ (__printf__, 4, 5)))
+  __attribute__ ((__format__ (__printf__, 4, 5)))
 #endif
-extern int ms_rlog_l (MSLogParam *logp, const char *function, int level, const char *format, ...);
+  extern int
+  ms_rlog_l (MSLogParam *logp, const char *function, int level, const char *format, ...);
 
 /** @def ms_loginit
     @brief Convenience wrapper for ms_rloginit(), omitting max messages, disabling registry */
 #define ms_loginit(log_print, logprefix, diag_print, errprefix) \
-  ms_rloginit(log_print, logprefix, diag_print, errprefix, 0)
+  ms_rloginit (log_print, logprefix, diag_print, errprefix, 0)
 
 /** @def ms_loginit_l
     @brief Convenience wrapper for ms_rloginit_l(), omitting max messages, disabling registry */
 #define ms_loginit_l(logp, log_print, logprefix, diag_print, errprefix) \
-  ms_rloginit_l(logp, log_print, logprefix, diag_print, errprefix, 0)
+  ms_rloginit_l (logp, log_print, logprefix, diag_print, errprefix, 0)
 
-extern void ms_rloginit (void (*log_print)(const char*), const char *logprefix,
-                         void (*diag_print)(const char*), const char *errprefix,
-                         int maxmessages);
-extern MSLogParam *ms_rloginit_l (MSLogParam *logp,
-                                  void (*log_print)(const char*), const char *logprefix,
-                                  void (*diag_print)(const char*), const char *errprefix,
-                                  int maxmessages);
-extern int ms_rlog_emit (MSLogParam *logp, int count, int context);
-extern int ms_rlog_free (MSLogParam *logp);
+  extern void ms_rloginit (void (*log_print) (const char *), const char *logprefix,
+                           void (*diag_print) (const char *), const char *errprefix,
+                           int maxmessages);
+  extern MSLogParam *ms_rloginit_l (MSLogParam *logp,
+                                    void (*log_print) (const char *), const char *logprefix,
+                                    void (*diag_print) (const char *), const char *errprefix,
+                                    int maxmessages);
+  extern int ms_rlog_emit (MSLogParam *logp, int count, int context);
+  extern int ms_rlog_free (MSLogParam *logp);
 
-/** @} */
+  /** @} */
 
-/** @addtogroup leapsecond
-    @brief Utilities for handling leap seconds
+  /** @addtogroup leapsecond
+      @brief Utilities for handling leap seconds
 
-    The library contains functionality to load a list of leap seconds
-    into a global list, which is then used to determine when leap
-    seconds occurred, ignoring any flags in the data itself regarding
-    leap seconds.  This is useful as past leap seconds are well known
-    and leap second indicators in data are, historically, more often
-    wrong than otherwise.
+      The library contains functionality to load a list of leap seconds
+      into a global list, which is then used to determine when leap
+      seconds occurred, ignoring any flags in the data itself regarding
+      leap seconds.  This is useful as past leap seconds are well known
+      and leap second indicators in data are, historically, more often
+      wrong than otherwise.
 
-    The library uses the leap second list (and any flags in the data,
-    if no list is provided) to adjust the calculated time of the last
-    sample in a record.  This allows proper merging of continuous
-    series generated through leap seconds.
+      The library uses the leap second list (and any flags in the data,
+      if no list is provided) to adjust the calculated time of the last
+      sample in a record.  This allows proper merging of continuous
+      series generated through leap seconds.
 
-    Normally, calling programs do not need to do any particular
-    handling of leap seconds after loading the leap second list.
+      Normally, calling programs do not need to do any particular
+      handling of leap seconds after loading the leap second list.
 
-    @note The library's internal, epoch-based time representation
-    cannot distinguish a leap second.  On the epoch time scale a leap
-    second appears as repeat of the second that follows it, an
-    apparent duplicated second.  Since the library does not know if
-    this value is a leap second or not, when converted to a time
-    string, the non-leap second representation is used, i.e. no second
-    values of "60" are generated.
-
-  @{ */
-/** @brief Leap second list container */
-typedef struct LeapSecond
-{
-  nstime_t leapsecond;       //!< Time of leap second as epoch since 1 January 1900
-  int32_t TAIdelta;          //!< TAI-UTC difference in seconds
-  struct LeapSecond *next;   //!< Pointer to next entry, NULL if the last
-} LeapSecond;
-
-/** Global leap second list */
-extern LeapSecond *leapsecondlist;
-extern int ms_readleapseconds (const char *envvarname);
-extern int ms_readleapsecondfile (const char *filename);
-/** @} */
-
-/** @addtogroup utility-functions
-  @brief General utilities
-  @{ */
-
-extern uint8_t ms_samplesize (const char sampletype);
-extern int ms_encoding_sizetype (const uint8_t encoding, uint8_t *samplesize, char *sampletype);
-extern const char *ms_encodingstr (const uint8_t encoding);
-extern const char *ms_errorstr (int errorcode);
-
-extern nstime_t ms_sampletime (nstime_t time, int64_t offset, double samprate);
-extern double ms_dabs (double val);
-extern int ms_bigendianhost (void);
-
-/** Portable version of POSIX ftello() to get file position in large files */
-extern int64_t lmp_ftell64 (FILE *stream);
-/** Portable version of POSIX fseeko() to set position in large files */
-extern int lmp_fseek64 (FILE *stream, int64_t offset, int whence);
-/** Portable version of POSIX nanosleep() to sleep for nanoseconds */
-extern uint64_t lmp_nanosleep (uint64_t nanoseconds);
-
-/** Return CRC32C value of supplied buffer, with optional starting CRC32C value */
-extern uint32_t ms_crc32c (const uint8_t *input, int length, uint32_t previousCRC32C);
-
-/** In-place byte swapping of 2 byte quantity */
-extern void ms_gswap2 (void *data2);
-/** In-place byte swapping of 4 byte quantity */
-extern void ms_gswap4 (void *data4);
-/** In-place byte swapping of 8 byte quantity */
-extern void ms_gswap8 (void *data8);
-
-#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5) || defined (__clang__)
-/** Deprecated: In-place byte swapping of 2 byte, memory-aligned, quantity */
-__attribute__ ((deprecated("Use ms_gswap2 instead.")))
-extern void     ms_gswap2a ( void *data2 );
-/** Deprecated: In-place byte swapping of 4 byte, memory-aligned, quantity */
-__attribute__ ((deprecated("Use ms_gswap4 instead.")))
-extern void     ms_gswap4a ( void *data4 );
-/** Deprecated: In-place byte swapping of 8 byte, memory-aligned, quantity */
-__attribute__ ((deprecated("Use ms_gswap8 instead.")))
-extern void     ms_gswap8a ( void *data8 );
-#elif defined(_MSC_FULL_VER) && (_MSC_FULL_VER > 140050320)
-/** Deprecated: In-place byte swapping of 2 byte, memory-aligned, quantity */
-__declspec(deprecated("Use ms_gswap2 instead."))
-extern void     ms_gswap2a ( void *data2 );
-/** Deprecated: In-place byte swapping of 4 byte, memory-aligned, quantity */
-__declspec(deprecated("Use ms_gswap4 instead."))
-extern void     ms_gswap4a ( void *data4 );
-/** Deprecated: In-place byte swapping of 8 byte, memory-aligned, quantity */
-__declspec(deprecated("Use ms_gswap8 instead."))
-extern void     ms_gswap8a ( void *data8 );
-#else
-/** Deprecated: In-place byte swapping of 2 byte, memory-aligned, quantity */
-extern void     ms_gswap2a ( void *data2 );
-/** Deprecated: In-place byte swapping of 4 byte, memory-aligned, quantity */
-extern void     ms_gswap4a ( void *data4 );
-/** Deprecated: In-place byte swapping of 8 byte, memory-aligned, quantity */
-extern void     ms_gswap8a ( void *data8 );
-#endif
-
-/** @} */
-
-/** Single byte flag type, for legacy use */
-typedef int8_t flag;
-
-/** @addtogroup memory-allocators
-    @brief User-definable memory allocators used by library
-
-    The global structure \b libmseed_memory contains three function
-    pointers that are used for all memory allocation and freeing done
-    by the library.
-
-    The following function pointers are available:
-    - \b libmseed_memory.malloc - requires a malloc()-like function
-    - \b libmseed_memory.realloc - requires a realloc()-like function
-    - \b libmseed_memory.free - requires a free()-like function
-
-    By default the system malloc(), realloc(), and free() are used.
-    Equivalent to setting:
-
-    \code
-    libmseed_memory.malloc = malloc;
-    libmseed_memory.realloc = realloc;
-    libmseed_memory.free = free;
-    \endcode
+      @note The library's internal, epoch-based time representation
+      cannot distinguish a leap second.  On the epoch time scale a leap
+      second appears as repeat of the second that follows it, an
+      apparent duplicated second.  Since the library does not know if
+      this value is a leap second or not, when converted to a time
+      string, the non-leap second representation is used, i.e. no second
+      values of "60" are generated.
 
     @{ */
+  /** @brief Leap second list container */
+  typedef struct LeapSecond
+  {
+    nstime_t leapsecond;     //!< Time of leap second as epoch since 1 January 1900
+    int32_t TAIdelta;        //!< TAI-UTC difference in seconds
+    struct LeapSecond *next; //!< Pointer to next entry, NULL if the last
+  } LeapSecond;
 
-/** Container for memory management function pointers */
-typedef struct LIBMSEED_MEMORY
-{
-  void *(*malloc) (size_t);           //!< Pointer to desired malloc()
-  void *(*realloc) (void *, size_t);  //!< Pointer to desired realloc()
-  void (*free) (void *);              //!< Pointer to desired free()
-} LIBMSEED_MEMORY;
+  /** Global leap second list */
+  extern LeapSecond *leapsecondlist;
+  extern int ms_readleapseconds (const char *envvarname);
+  extern int ms_readleapsecondfile (const char *filename);
+  /** @} */
 
-/** Global memory management function list */
-extern LIBMSEED_MEMORY libmseed_memory;
+  /** @addtogroup utility-functions
+    @brief General utilities
+    @{ */
 
-/** Global pre-allocation block size.
- *
- * When non-zero, memory re-allocations will be increased in blocks of this
- * size.  This is useful on platforms where the system realloc() is slow
- * such as Windows.
- *
- * Default on Windows is 1 MiB, otherwise disabled.
- *
- * Set to 0 to disable pre-allocation.
- *
- * @see msr3_resize_buffer
- * @see mstl3_resize_buffers
- */
-extern size_t libmseed_prealloc_block_size;
+  extern uint8_t ms_samplesize (const char sampletype);
+  extern int ms_encoding_sizetype (const uint8_t encoding, uint8_t *samplesize, char *sampletype);
+  extern const char *ms_encodingstr (const uint8_t encoding);
+  extern const char *ms_errorstr (int errorcode);
 
-/** Internal realloc() wrapper that allocates in ::libmseed_prealloc_block_size blocks
- *
- * Preallocation is used by default on Windows and disabled otherwise.
- * */
-extern void *libmseed_memory_prealloc (void *ptr, size_t size, size_t *currentsize);
+  extern nstime_t ms_sampletime (nstime_t time, int64_t offset, double samprate);
+  extern double ms_dabs (double val);
+  extern int ms_bigendianhost (void);
+
+  /** Portable version of POSIX ftello() to get file position in large files */
+  extern int64_t lmp_ftell64 (FILE *stream);
+  /** Portable version of POSIX fseeko() to set position in large files */
+  extern int lmp_fseek64 (FILE *stream, int64_t offset, int whence);
+  /** Portable version of POSIX nanosleep() to sleep for nanoseconds */
+  extern uint64_t lmp_nanosleep (uint64_t nanoseconds);
+
+  /** Return CRC32C value of supplied buffer, with optional starting CRC32C value */
+  extern uint32_t ms_crc32c (const uint8_t *input, int length, uint32_t previousCRC32C);
+
+  /** In-place byte swapping of 2 byte quantity */
+  extern void ms_gswap2 (void *data2);
+  /** In-place byte swapping of 4 byte quantity */
+  extern void ms_gswap4 (void *data4);
+  /** In-place byte swapping of 8 byte quantity */
+  extern void ms_gswap8 (void *data8);
+
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5) || defined(__clang__)
+  /** Deprecated: In-place byte swapping of 2 byte, memory-aligned, quantity */
+  __attribute__ ((deprecated ("Use ms_gswap2 instead."))) extern void ms_gswap2a (void *data2);
+  /** Deprecated: In-place byte swapping of 4 byte, memory-aligned, quantity */
+  __attribute__ ((deprecated ("Use ms_gswap4 instead."))) extern void ms_gswap4a (void *data4);
+  /** Deprecated: In-place byte swapping of 8 byte, memory-aligned, quantity */
+  __attribute__ ((deprecated ("Use ms_gswap8 instead."))) extern void ms_gswap8a (void *data8);
+#elif defined(_MSC_FULL_VER) && (_MSC_FULL_VER > 140050320)
+/** Deprecated: In-place byte swapping of 2 byte, memory-aligned, quantity */
+__declspec(deprecated ("Use ms_gswap2 instead.")) extern void ms_gswap2a (void *data2);
+/** Deprecated: In-place byte swapping of 4 byte, memory-aligned, quantity */
+__declspec(deprecated ("Use ms_gswap4 instead.")) extern void ms_gswap4a (void *data4);
+/** Deprecated: In-place byte swapping of 8 byte, memory-aligned, quantity */
+__declspec(deprecated ("Use ms_gswap8 instead.")) extern void ms_gswap8a (void *data8);
+#else
+/** Deprecated: In-place byte swapping of 2 byte, memory-aligned, quantity */
+extern void ms_gswap2a (void *data2);
+/** Deprecated: In-place byte swapping of 4 byte, memory-aligned, quantity */
+extern void ms_gswap4a (void *data4);
+/** Deprecated: In-place byte swapping of 8 byte, memory-aligned, quantity */
+extern void ms_gswap8a (void *data8);
+#endif
+
+  /** @} */
+
+  /** Single byte flag type, for legacy use */
+  typedef int8_t flag;
+
+  /** @addtogroup memory-allocators
+      @brief User-definable memory allocators used by library
+
+      The global structure \b libmseed_memory contains three function
+      pointers that are used for all memory allocation and freeing done
+      by the library.
+
+      The following function pointers are available:
+      - \b libmseed_memory.malloc - requires a malloc()-like function
+      - \b libmseed_memory.realloc - requires a realloc()-like function
+      - \b libmseed_memory.free - requires a free()-like function
+
+      By default the system malloc(), realloc(), and free() are used.
+      Equivalent to setting:
+
+      \code
+      libmseed_memory.malloc = malloc;
+      libmseed_memory.realloc = realloc;
+      libmseed_memory.free = free;
+      \endcode
+
+      @{ */
+
+  /** Container for memory management function pointers */
+  typedef struct LIBMSEED_MEMORY
+  {
+    void *(*malloc) (size_t);          //!< Pointer to desired malloc()
+    void *(*realloc) (void *, size_t); //!< Pointer to desired realloc()
+    void (*free) (void *);             //!< Pointer to desired free()
+  } LIBMSEED_MEMORY;
+
+  /** Global memory management function list */
+  extern LIBMSEED_MEMORY libmseed_memory;
+
+  /** Global pre-allocation block size.
+   *
+   * When non-zero, memory re-allocations will be increased in blocks of this
+   * size.  This is useful on platforms where the system realloc() is slow
+   * such as Windows.
+   *
+   * Default on Windows is 1 MiB, otherwise disabled.
+   *
+   * Set to 0 to disable pre-allocation.
+   *
+   * @see msr3_resize_buffer
+   * @see mstl3_resize_buffers
+   */
+  extern size_t libmseed_prealloc_block_size;
+
+  /** Internal realloc() wrapper that allocates in ::libmseed_prealloc_block_size blocks
+   *
+   * Preallocation is used by default on Windows and disabled otherwise.
+   * */
+  extern void *libmseed_memory_prealloc (void *ptr, size_t size, size_t *currentsize);
 
 /** @} */
 
@@ -1359,19 +1361,19 @@ extern void *libmseed_memory_prealloc (void *ptr, size_t size, size_t *currentsi
     be used anywhere and encoding value is needed.
 
     @{ */
-#define DE_ASCII       0            //!< ASCII (text) encoding
-#define DE_INT16       1            //!< 16-bit integer
-#define DE_INT32       3            //!< 32-bit integer
-#define DE_FLOAT32     4            //!< 32-bit float (IEEE)
-#define DE_FLOAT64     5            //!< 64-bit float (IEEE)
-#define DE_STEIM1      10           //!< Steim-1 compressed integers
-#define DE_STEIM2      11           //!< Steim-2 compressed integers
-#define DE_GEOSCOPE24  12           //!< [Legacy] GEOSCOPE 24-bit integer
-#define DE_GEOSCOPE163 13           //!< [Legacy] GEOSCOPE 16-bit gain ranged, 3-bit exponent
-#define DE_GEOSCOPE164 14           //!< [Legacy] GEOSCOPE 16-bit gain ranged, 4-bit exponent
-#define DE_CDSN        16           //!< [Legacy] CDSN 16-bit gain ranged
-#define DE_SRO         30           //!< [Legacy] SRO 16-bit gain ranged
-#define DE_DWWSSN      32           //!< [Legacy] DWWSSN 16-bit gain ranged
+#define DE_ASCII 0        //!< ASCII (text) encoding
+#define DE_INT16 1        //!< 16-bit integer
+#define DE_INT32 3        //!< 32-bit integer
+#define DE_FLOAT32 4      //!< 32-bit float (IEEE)
+#define DE_FLOAT64 5      //!< 64-bit float (IEEE)
+#define DE_STEIM1 10      //!< Steim-1 compressed integers
+#define DE_STEIM2 11      //!< Steim-2 compressed integers
+#define DE_GEOSCOPE24 12  //!< [Legacy] GEOSCOPE 24-bit integer
+#define DE_GEOSCOPE163 13 //!< [Legacy] GEOSCOPE 16-bit gain ranged, 3-bit exponent
+#define DE_GEOSCOPE164 14 //!< [Legacy] GEOSCOPE 16-bit gain ranged, 4-bit exponent
+#define DE_CDSN 16        //!< [Legacy] CDSN 16-bit gain ranged
+#define DE_SRO 30         //!< [Legacy] SRO 16-bit gain ranged
+#define DE_DWWSSN 32      //!< [Legacy] DWWSSN 16-bit gain ranged
 /** @} */
 
 /** @addtogroup byte-swap-flags
@@ -1380,8 +1382,8 @@ extern void *libmseed_memory_prealloc (void *ptr, size_t size, size_t *currentsi
     These are bit flags normally used to set/test the ::MS3Record.swapflag value.
 
     @{ */
-#define MSSWAP_HEADER   0x01    //!< Header needed byte swapping
-#define MSSWAP_PAYLOAD  0x02    //!< Data payload needed byte swapping
+#define MSSWAP_HEADER 0x01  //!< Header needed byte swapping
+#define MSSWAP_PAYLOAD 0x02 //!< Data payload needed byte swapping
 /** @} */
 
 /** @addtogroup return-values
@@ -1389,15 +1391,15 @@ extern void *libmseed_memory_prealloc (void *ptr, size_t size, size_t *currentsi
 
     \sa ms_errorstr()
     @{ */
-#define MS_ENDOFFILE        1        //!< End of file reached return value
-#define MS_NOERROR          0        //!< No error
-#define MS_GENERROR        -1        //!< Generic unspecified error
-#define MS_NOTSEED         -2        //!< Data not SEED
-#define MS_WRONGLENGTH     -3        //!< Length of data read was not correct
-#define MS_OUTOFRANGE      -4        //!< SEED record length out of range
-#define MS_UNKNOWNFORMAT   -5        //!< Unknown data encoding format
-#define MS_STBADCOMPFLAG   -6        //!< Steim, invalid compression flag(s)
-#define MS_INVALIDCRC      -7        //!< Invalid CRC
+#define MS_ENDOFFILE 1      //!< End of file reached return value
+#define MS_NOERROR 0        //!< No error
+#define MS_GENERROR -1      //!< Generic unspecified error
+#define MS_NOTSEED -2       //!< Data not SEED
+#define MS_WRONGLENGTH -3   //!< Length of data read was not correct
+#define MS_OUTOFRANGE -4    //!< SEED record length out of range
+#define MS_UNKNOWNFORMAT -5 //!< Unknown data encoding format
+#define MS_STBADCOMPFLAG -6 //!< Steim, invalid compression flag(s)
+#define MS_INVALIDCRC -7    //!< Invalid CRC
 /** @} */
 
 /** @addtogroup control-flags
@@ -1407,17 +1409,17 @@ extern void *libmseed_memory_prealloc (void *ptr, size_t size, size_t *currentsi
     aspects of the library's parsing, packing and trace managment routines.
 
     @{ */
-#define MSF_UNPACKDATA    0x0001  //!< [Parsing] Unpack data samples
-#define MSF_SKIPNOTDATA   0x0002  //!< [Parsing] Skip input that cannot be identified as miniSEED
-#define MSF_VALIDATECRC   0x0004  //!< [Parsing] Validate CRC (if version 3)
-#define MSF_PNAMERANGE    0x0008  //!< [Parsing] Parse and utilize byte range from path name suffix
-#define MSF_ATENDOFFILE   0x0010  //!< [Parsing] Reading routine is at the end of the file
-#define MSF_SEQUENCE      0x0020  //!< [Packing] UNSUPPORTED: Maintain a record-level sequence number
-#define MSF_FLUSHDATA     0x0040  //!< [Packing] Pack all available data even if final record would not be filled
-#define MSF_PACKVER2      0x0080  //!< [Packing] Pack as miniSEED version 2 instead of 3
-#define MSF_RECORDLIST    0x0100  //!< [TraceList] Build a ::MS3RecordList for each ::MS3TraceSeg
-#define MSF_MAINTAINMSTL  0x0200  //!< [TraceList] Do not modify a trace list when packing
-/** @} */
+#define MSF_UNPACKDATA 0x0001   //!< [Parsing] Unpack data samples
+#define MSF_SKIPNOTDATA 0x0002  //!< [Parsing] Skip input that cannot be identified as miniSEED
+#define MSF_VALIDATECRC 0x0004  //!< [Parsing] Validate CRC (if version 3)
+#define MSF_PNAMERANGE 0x0008   //!< [Parsing] Parse and utilize byte range from path name suffix
+#define MSF_ATENDOFFILE 0x0010  //!< [Parsing] Reading routine is at the end of the file
+#define MSF_SEQUENCE 0x0020     //!< [Packing] UNSUPPORTED: Maintain a record-level sequence number
+#define MSF_FLUSHDATA 0x0040    //!< [Packing] Pack all available data even if final record would not be filled
+#define MSF_PACKVER2 0x0080     //!< [Packing] Pack as miniSEED version 2 instead of 3
+#define MSF_RECORDLIST 0x0100   //!< [TraceList] Build a ::MS3RecordList for each ::MS3TraceSeg
+#define MSF_MAINTAINMSTL 0x0200 //!< [TraceList] Do not modify a trace list when packing
+  /** @} */
 
 #ifdef __cplusplus
 }

--- a/logging.c
+++ b/logging.c
@@ -51,11 +51,11 @@ void print_message_int (MSLogParam *logp, int level, const char *message,
  */
 #if !defined(LIBMSEED_NO_THREADING)
 #if defined(LMP_WIN)
-  #define lm_thread_local __declspec( thread )
+#define lm_thread_local __declspec(thread)
 #elif __STDC_VERSION__ >= 201112L
-  #define lm_thread_local _Thread_local
+#define lm_thread_local _Thread_local
 #else
-  #define lm_thread_local __thread
+#define lm_thread_local __thread
 #endif
 lm_thread_local MSLogParam gMSLogParam = MSLogParam_INITIALIZER;
 #else
@@ -63,31 +63,31 @@ MSLogParam gMSLogParam = MSLogParam_INITIALIZER;
 #endif
 
 /**********************************************************************/ /**
- * @brief Initialize the global logging parameters.
- *
- * Any message printing functions indicated must except a single
- * argument, namely a string \c (const char *) that will contain the log
- * message.  If the function pointers are NULL, defaults will be used.
- *
- * If the log and error prefixes have been set they will be pre-pended
- * to the message.  If the prefixes are NULL, defaults will be used.
- *
- * If \a maxmessages is greater than zero, warning and error (level >=
- * 1) messages will be accumulated in a message registry.  Once the
- * maximum number of messages have accumulated, the oldest messages
- * are discarded.  Messages in the registry can be printed using
- * ms_rlog_emit() or cleared using ms_rlog_free().
- *
- * @param[in] log_print Function to print log messages
- * @param[in] logprefix Prefix to add to log and diagnostic messages
- * @param[in] diag_print Function to print diagnostic and error messages
- * @param[in] errprefix Prefix to add to error messages
- * @param[in] maxmessages Maximum number of error/warning messages to store in registry
- *
- * \sa ms_rlog()
- * \sa ms_rlog_emit()
- * \sa ms_rlog_free()
- ***************************************************************************/
+                                                                          * @brief Initialize the global logging parameters.
+                                                                          *
+                                                                          * Any message printing functions indicated must except a single
+                                                                          * argument, namely a string \c (const char *) that will contain the log
+                                                                          * message.  If the function pointers are NULL, defaults will be used.
+                                                                          *
+                                                                          * If the log and error prefixes have been set they will be pre-pended
+                                                                          * to the message.  If the prefixes are NULL, defaults will be used.
+                                                                          *
+                                                                          * If \a maxmessages is greater than zero, warning and error (level >=
+                                                                          * 1) messages will be accumulated in a message registry.  Once the
+                                                                          * maximum number of messages have accumulated, the oldest messages
+                                                                          * are discarded.  Messages in the registry can be printed using
+                                                                          * ms_rlog_emit() or cleared using ms_rlog_free().
+                                                                          *
+                                                                          * @param[in] log_print Function to print log messages
+                                                                          * @param[in] logprefix Prefix to add to log and diagnostic messages
+                                                                          * @param[in] diag_print Function to print diagnostic and error messages
+                                                                          * @param[in] errprefix Prefix to add to error messages
+                                                                          * @param[in] maxmessages Maximum number of error/warning messages to store in registry
+                                                                          *
+                                                                          * \sa ms_rlog()
+                                                                          * \sa ms_rlog_emit()
+                                                                          * \sa ms_rlog_free()
+                                                                          ***************************************************************************/
 void
 ms_rloginit (void (*log_print) (const char *), const char *logprefix,
              void (*diag_print) (const char *), const char *errprefix,
@@ -98,38 +98,38 @@ ms_rloginit (void (*log_print) (const char *), const char *logprefix,
 } /* End of ms_rloginit() */
 
 /**********************************************************************/ /**
- * @brief Initialize specified ::MSLogParam logging parameters.
- *
- * If the logging parameters have not been initialized (logp == NULL),
- * new parameter space will be allocated.
- *
- * Any message printing functions indicated must except a single
- * argument, namely a string \c (const char *) that will contain the log
- * message.  If the function pointers are NULL, defaults will be used.
- *
- * If the log and error prefixes have been set they will be pre-pended
- * to the message.  If the prefixes are NULL, defaults will be used.
- *
- * If \a maxmessages is greater than zero, warning and error (level >=
- * 1) messages will be accumulated in a message registry.  Once the
- * maximum number of messages have accumulated, the oldest messages
- * are discarded.  Messages in the registry can be printed using
- * ms_rlog_emit() or cleared using ms_rlog_free().
- *
- * @param[in] logp ::MSLogParam logging parameters
- * @param[in] log_print Function to print log messages
- * @param[in] logprefix Prefix to add to log and diagnostic messages
- * @param[in] diag_print Function to print diagnostic and error messages
- * @param[in] errprefix Prefix to add to error messages
- * @param[in] maxmessages Maximum number of error/warning messages to store in registry
- *
- * @returns a pointer to the created/re-initialized MSLogParam struct
- * on success and NULL on error.
- *
- * \sa ms_rlog()
- * \sa ms_rlog_emit()
- * \sa ms_rlog_free()
- ***************************************************************************/
+                                                                          * @brief Initialize specified ::MSLogParam logging parameters.
+                                                                          *
+                                                                          * If the logging parameters have not been initialized (logp == NULL),
+                                                                          * new parameter space will be allocated.
+                                                                          *
+                                                                          * Any message printing functions indicated must except a single
+                                                                          * argument, namely a string \c (const char *) that will contain the log
+                                                                          * message.  If the function pointers are NULL, defaults will be used.
+                                                                          *
+                                                                          * If the log and error prefixes have been set they will be pre-pended
+                                                                          * to the message.  If the prefixes are NULL, defaults will be used.
+                                                                          *
+                                                                          * If \a maxmessages is greater than zero, warning and error (level >=
+                                                                          * 1) messages will be accumulated in a message registry.  Once the
+                                                                          * maximum number of messages have accumulated, the oldest messages
+                                                                          * are discarded.  Messages in the registry can be printed using
+                                                                          * ms_rlog_emit() or cleared using ms_rlog_free().
+                                                                          *
+                                                                          * @param[in] logp ::MSLogParam logging parameters
+                                                                          * @param[in] log_print Function to print log messages
+                                                                          * @param[in] logprefix Prefix to add to log and diagnostic messages
+                                                                          * @param[in] diag_print Function to print diagnostic and error messages
+                                                                          * @param[in] errprefix Prefix to add to error messages
+                                                                          * @param[in] maxmessages Maximum number of error/warning messages to store in registry
+                                                                          *
+                                                                          * @returns a pointer to the created/re-initialized MSLogParam struct
+                                                                          * on success and NULL on error.
+                                                                          *
+                                                                          * \sa ms_rlog()
+                                                                          * \sa ms_rlog_emit()
+                                                                          * \sa ms_rlog_free()
+                                                                          ***************************************************************************/
 MSLogParam *
 ms_rloginit_l (MSLogParam *logp,
                void (*log_print) (const char *), const char *logprefix,
@@ -148,13 +148,13 @@ ms_rloginit_l (MSLogParam *logp,
       return NULL;
     }
 
-    llog->log_print = NULL;
-    llog->logprefix = NULL;
-    llog->diag_print = NULL;
-    llog->errprefix = NULL;
+    llog->log_print            = NULL;
+    llog->logprefix            = NULL;
+    llog->diag_print           = NULL;
+    llog->errprefix            = NULL;
     llog->registry.maxmessages = 0;
-    llog->registry.messagecnt = 0;
-    llog->registry.messages = NULL;
+    llog->registry.messagecnt  = 0;
+    llog->registry.messages    = NULL;
   }
   else
   {
@@ -168,13 +168,13 @@ ms_rloginit_l (MSLogParam *logp,
 } /* End of ms_rloginit_l() */
 
 /**********************************************************************/ /**
- * @brief Initialize the logging subsystem.
- *
- * This function modifies the logging parameters in the supplied
- * ::MSLogParam. Use NULL for the function pointers or the prefixes if
- * they should not be changed from previously set or default values.
- *
- ***************************************************************************/
+                                                                          * @brief Initialize the logging subsystem.
+                                                                          *
+                                                                          * This function modifies the logging parameters in the supplied
+                                                                          * ::MSLogParam. Use NULL for the function pointers or the prefixes if
+                                                                          * they should not be changed from previously set or default values.
+                                                                          *
+                                                                          ***************************************************************************/
 void
 rloginit_int (MSLogParam *logp,
               void (*log_print) (const char *), const char *logprefix,
@@ -223,37 +223,37 @@ rloginit_int (MSLogParam *logp,
 } /* End of rloginit_int() */
 
 /**********************************************************************/ /**
- * @brief Register log message using global logging parameters.
- *
- * It is convenient to call this function via the ms_log() macro,
- * which sets the calling function automatically.
- *
- * Three message levels are recognized, see @ref logging-levels for
- * more information.
- *
- * This function builds the log/error message and passes to it to the
- * appropriate print function.  If custom printing functions have not
- * been defined, messages will be printed with \c fprintf(), log
- * messages to \c stdout and error messages to \c stderr.
- *
- * If the log/error prefixes have been set they will be pre-pended to
- * the message.  If no custom log prefix is set none will be included.
- * If no custom error prefix is set \c "Error: " will be included.
- *
- * A trailing newline character is for error messages is removed if
- * the message is added to the log registry.
- *
- * All messages will be truncated at the ::MAX_LOG_MSG_LENGTH, this
- * includes any prefix.
- *
- * @param[in] function Name of function registering log message
- * @param[in] level Message level
- * @param[in] format Message format in printf() style
- * @param[in] ... Message format variables
- *
- * @returns The number of characters formatted on success, and a
- * negative value on error..
- ***************************************************************************/
+                                                                          * @brief Register log message using global logging parameters.
+                                                                          *
+                                                                          * It is convenient to call this function via the ms_log() macro,
+                                                                          * which sets the calling function automatically.
+                                                                          *
+                                                                          * Three message levels are recognized, see @ref logging-levels for
+                                                                          * more information.
+                                                                          *
+                                                                          * This function builds the log/error message and passes to it to the
+                                                                          * appropriate print function.  If custom printing functions have not
+                                                                          * been defined, messages will be printed with \c fprintf(), log
+                                                                          * messages to \c stdout and error messages to \c stderr.
+                                                                          *
+                                                                          * If the log/error prefixes have been set they will be pre-pended to
+                                                                          * the message.  If no custom log prefix is set none will be included.
+                                                                          * If no custom error prefix is set \c "Error: " will be included.
+                                                                          *
+                                                                          * A trailing newline character is for error messages is removed if
+                                                                          * the message is added to the log registry.
+                                                                          *
+                                                                          * All messages will be truncated at the ::MAX_LOG_MSG_LENGTH, this
+                                                                          * includes any prefix.
+                                                                          *
+                                                                          * @param[in] function Name of function registering log message
+                                                                          * @param[in] level Message level
+                                                                          * @param[in] format Message format in printf() style
+                                                                          * @param[in] ... Message format variables
+                                                                          *
+                                                                          * @returns The number of characters formatted on success, and a
+                                                                          * negative value on error..
+                                                                          ***************************************************************************/
 int
 ms_rlog (const char *function, int level, const char *format, ...)
 {
@@ -270,42 +270,42 @@ ms_rlog (const char *function, int level, const char *format, ...)
 } /* End of ms_rlog() */
 
 /**********************************************************************/ /**
- * @brief Register log message using specified logging parameters.
- *
- * It is convenient to call this function via the ms_log_l() macro,
- * which sets the calling function automatically.
- *
- * The function uses logging parameters specified in the supplied
- * ::MSLogParam.  This reentrant capability allows using different
- * parameters in different parts of a program or different threads.
- *
- * Three message levels are recognized, see @ref logging-levels for
- * more information.
- *
- * This function builds the log/error message and passes to it to the
- * appropriate print function.  If custom printing functions have not
- * been defined, messages will be printed with \c fprintf(), log
- * messages to \c stdout and error messages to \c stderr.
- *
- * If the log/error prefixes have been set they will be pre-pended to
- * the message.  If no custom log prefix is set none will be included.
- * If no custom error prefix is set \c "Error: " will be included.
- *
- * A trailing newline character is for error messages is removed if
- * the message is added to the log registry.
- *
- * All messages will be truncated at the ::MAX_LOG_MSG_LENGTH, this
- * includes any prefix.
- *
- * @param[in] logp Pointer to ::MSLogParam to use for this message
- * @param[in] function Name of function registering log message
- * @param[in] level Message level
- * @param[in] format Message format in printf() style
- * @param[in] ... Message format variables
- *
- * @returns The number of characters formatted on success, and a
- * negative value on error.
- ***************************************************************************/
+                                                                          * @brief Register log message using specified logging parameters.
+                                                                          *
+                                                                          * It is convenient to call this function via the ms_log_l() macro,
+                                                                          * which sets the calling function automatically.
+                                                                          *
+                                                                          * The function uses logging parameters specified in the supplied
+                                                                          * ::MSLogParam.  This reentrant capability allows using different
+                                                                          * parameters in different parts of a program or different threads.
+                                                                          *
+                                                                          * Three message levels are recognized, see @ref logging-levels for
+                                                                          * more information.
+                                                                          *
+                                                                          * This function builds the log/error message and passes to it to the
+                                                                          * appropriate print function.  If custom printing functions have not
+                                                                          * been defined, messages will be printed with \c fprintf(), log
+                                                                          * messages to \c stdout and error messages to \c stderr.
+                                                                          *
+                                                                          * If the log/error prefixes have been set they will be pre-pended to
+                                                                          * the message.  If no custom log prefix is set none will be included.
+                                                                          * If no custom error prefix is set \c "Error: " will be included.
+                                                                          *
+                                                                          * A trailing newline character is for error messages is removed if
+                                                                          * the message is added to the log registry.
+                                                                          *
+                                                                          * All messages will be truncated at the ::MAX_LOG_MSG_LENGTH, this
+                                                                          * includes any prefix.
+                                                                          *
+                                                                          * @param[in] logp Pointer to ::MSLogParam to use for this message
+                                                                          * @param[in] function Name of function registering log message
+                                                                          * @param[in] level Message level
+                                                                          * @param[in] format Message format in printf() style
+                                                                          * @param[in] ... Message format variables
+                                                                          *
+                                                                          * @returns The number of characters formatted on success, and a
+                                                                          * negative value on error.
+                                                                          ***************************************************************************/
 int
 ms_rlog_l (MSLogParam *logp, const char *function, int level, const char *format, ...)
 {
@@ -325,19 +325,19 @@ ms_rlog_l (MSLogParam *logp, const char *function, int level, const char *format
 } /* End of ms_rlog_l() */
 
 /**********************************************************************/ /**
- * @brief Log message using specified logging parameters and \c va_list
- *
- * Trailing newline character is removed when added messages to the
- * registry.
- *
- * @param[in] logp Pointer to ::MSLogParam to use for this message
- * @param[in] function Name of function registering log message
- * @param[in] level Message level
- * @param[in] varlist Message in a \c va_list in printf() style
- *
- * @returns The number of characters formatted on success, and a
- * negative value on error.
- ***************************************************************************/
+                                                                          * @brief Log message using specified logging parameters and \c va_list
+                                                                          *
+                                                                          * Trailing newline character is removed when added messages to the
+                                                                          * registry.
+                                                                          *
+                                                                          * @param[in] logp Pointer to ::MSLogParam to use for this message
+                                                                          * @param[in] function Name of function registering log message
+                                                                          * @param[in] level Message level
+                                                                          * @param[in] varlist Message in a \c va_list in printf() style
+                                                                          *
+                                                                          * @returns The number of characters formatted on success, and a
+                                                                          * negative value on error.
+                                                                          ***************************************************************************/
 int
 rlog_int (MSLogParam *logp, const char *function, int level,
           const char *format, va_list *varlist)
@@ -427,24 +427,24 @@ rlog_int (MSLogParam *logp, const char *function, int level,
 } /* End of rlog_int() */
 
 /**********************************************************************/ /**
- * @brief Add message to registry
- *
- * Add a message to the specified log registry.  Earliest entries are
- * removed to remain within the specified maximum number of messsages.
- *
- * @param[in] logreg Pointer to ::MSLogRegistry to use for this message
- * @param[in] function Name of function generating the message
- * @param[in] level Message level
- * @param[in] message Message text
- *
- * @returns Zero on sucess and non-zero on error
- ***************************************************************************/
+                                                                          * @brief Add message to registry
+                                                                          *
+                                                                          * Add a message to the specified log registry.  Earliest entries are
+                                                                          * removed to remain within the specified maximum number of messsages.
+                                                                          *
+                                                                          * @param[in] logreg Pointer to ::MSLogRegistry to use for this message
+                                                                          * @param[in] function Name of function generating the message
+                                                                          * @param[in] level Message level
+                                                                          * @param[in] message Message text
+                                                                          *
+                                                                          * @returns Zero on sucess and non-zero on error
+                                                                          ***************************************************************************/
 int
 add_message_int (MSLogRegistry *logreg, const char *function, int level,
                  const char *message)
 {
   MSLogEntry *logentry = NULL;
-  MSLogEntry *lognext = NULL;
+  MSLogEntry *lognext  = NULL;
   int count;
 
   if (!logreg || !message)
@@ -474,14 +474,14 @@ add_message_int (MSLogRegistry *logreg, const char *function, int level,
   logentry->message[sizeof (logentry->message) - 1] = '\0';
 
   /* Add entry to registry */
-  logentry->next = logreg->messages;
+  logentry->next   = logreg->messages;
   logreg->messages = logentry;
   logreg->messagecnt += 1;
 
   /* Remove earliest messages if more than maximum allowed */
   if (logreg->messagecnt > logreg->maxmessages)
   {
-    count = 0;
+    count    = 0;
     logentry = logreg->messages;
     while (logentry)
     {
@@ -501,16 +501,15 @@ add_message_int (MSLogRegistry *logreg, const char *function, int level,
   return 0;
 } /* End of add_message_int() */
 
-
 /**********************************************************************/ /**
- * @brief Send message to print functions
- *
- * @param[in] logp Pointer to ::MSLogParam appropriate for this message
- * @param[in] level Message level
- * @param[in] message Message to print
- *
- * @returns Zero on success, and a negative value on error.
- ***************************************************************************/
+                                                                          * @brief Send message to print functions
+                                                                          *
+                                                                          * @param[in] logp Pointer to ::MSLogParam appropriate for this message
+                                                                          * @param[in] level Message level
+                                                                          * @param[in] message Message to print
+                                                                          *
+                                                                          * @returns Zero on success, and a negative value on error.
+                                                                          ***************************************************************************/
 void
 print_message_int (MSLogParam *logp, int level, const char *message,
                    char *terminator)
@@ -542,33 +541,32 @@ print_message_int (MSLogParam *logp, int level, const char *message,
   }
 } /* End of print_message_int() */
 
-
 /**********************************************************************/ /**
- * @brief Emit, aka send to print functions, messages from log registry
- *
- * Emit messages from the log registry, using the printing functions
- * identified by the ::MSLogParam.
- *
- * Messages are printed in order from earliest to latest.
- *
- * The maximum number messages to emit, from most recent to earliest,
- * can be limited using \a count.  If the value is 0 all messages are
- * emitted.  If this limit is used and messages are left in the
- * registry, it is highly recommended to either emit them soon or
- * clear them with ms_rlog_free().  A common pattern would be to emit
- * the last message (e.g. \a count of 1) and immediately free
- * (discard) any remaining messages.
- *
- * @param[in] logp ::MSLogParam for this message or NULL for global parameters
- * @param[in] count Number of messages to emit, 0 to emit all messages
- * @param[in] context If non-zero include context by prefixing the function name (if available)
- *
- * @returns The number of message emitted on success, and a negative
- * value on error.
- *
- * \sa ms_rloginit()
- * \sa ms_rlog_free()
- ***************************************************************************/
+                                                                          * @brief Emit, aka send to print functions, messages from log registry
+                                                                          *
+                                                                          * Emit messages from the log registry, using the printing functions
+                                                                          * identified by the ::MSLogParam.
+                                                                          *
+                                                                          * Messages are printed in order from earliest to latest.
+                                                                          *
+                                                                          * The maximum number messages to emit, from most recent to earliest,
+                                                                          * can be limited using \a count.  If the value is 0 all messages are
+                                                                          * emitted.  If this limit is used and messages are left in the
+                                                                          * registry, it is highly recommended to either emit them soon or
+                                                                          * clear them with ms_rlog_free().  A common pattern would be to emit
+                                                                          * the last message (e.g. \a count of 1) and immediately free
+                                                                          * (discard) any remaining messages.
+                                                                          *
+                                                                          * @param[in] logp ::MSLogParam for this message or NULL for global parameters
+                                                                          * @param[in] count Number of messages to emit, 0 to emit all messages
+                                                                          * @param[in] context If non-zero include context by prefixing the function name (if available)
+                                                                          *
+                                                                          * @returns The number of message emitted on success, and a negative
+                                                                          * value on error.
+                                                                          *
+                                                                          * \sa ms_rloginit()
+                                                                          * \sa ms_rlog_free()
+                                                                          ***************************************************************************/
 int
 ms_rlog_emit (MSLogParam *logp, int count, int context)
 {
@@ -576,7 +574,7 @@ ms_rlog_emit (MSLogParam *logp, int count, int context)
   MSLogEntry *logprint = NULL;
   char local_message[MAX_LOG_MSG_LENGTH];
   char *message = NULL;
-  int emit = (count > 0) ? count : -1;
+  int emit      = (count > 0) ? count : -1;
 
   if (!logp)
     logp = &gMSLogParam;
@@ -588,7 +586,7 @@ ms_rlog_emit (MSLogParam *logp, int count, int context)
     logp->registry.messages = logentry->next;
 
     logentry->next = logprint;
-    logprint = logentry;
+    logprint       = logentry;
 
     if (emit > 0)
       emit--;
@@ -603,9 +601,9 @@ ms_rlog_emit (MSLogParam *logp, int count, int context)
     /* Add function name to message if requested and present */
     if (context && logprint->function[0] != '\0')
     {
-      snprintf (local_message, sizeof(local_message), "%s() %.*s",
+      snprintf (local_message, sizeof (local_message), "%s() %.*s",
                 logprint->function,
-                (int)(MAX_LOG_MSG_LENGTH - sizeof(logprint->function) - 3),
+                (int)(MAX_LOG_MSG_LENGTH - sizeof (logprint->function) - 3),
                 logprint->message);
       message = local_message;
     }
@@ -624,20 +622,19 @@ ms_rlog_emit (MSLogParam *logp, int count, int context)
   return 0;
 } /* End of ms_rlog_emit() */
 
-
 /**********************************************************************/ /**
- * @brief Free, without emitting, all messages from log registry
- *
- * @param[in] logp ::MSLogParam for this message or NULL for global parameters
- *
- * @returns The number of message freed on success, and a negative
- * value on error.
- ***************************************************************************/
+                                                                          * @brief Free, without emitting, all messages from log registry
+                                                                          *
+                                                                          * @param[in] logp ::MSLogParam for this message or NULL for global parameters
+                                                                          *
+                                                                          * @returns The number of message freed on success, and a negative
+                                                                          * value on error.
+                                                                          ***************************************************************************/
 int
 ms_rlog_free (MSLogParam *logp)
 {
   MSLogEntry *logentry = NULL;
-  int freed = 0;
+  int freed            = 0;
 
   if (!logp)
     logp = &gMSLogParam;

--- a/lookup.c
+++ b/lookup.c
@@ -23,18 +23,18 @@
 #include "libmseed.h"
 
 /**********************************************************************/ /**
- * @brief Determine data sample size for each type
- *
- * @param[in] sampletype Library sample type code:
- * @parblock
- *   - \c 'a' - Text/ASCII data type
- *   - \c 'i' - 32-bit integer data type
- *   - \c 'f' - 32-bit float data type
- *   - \c 'd' - 64-bit float (double) data type
- * @endparblock
- *
- * @returns The sample size based on type code or 0 for unknown.
- ***************************************************************************/
+                                                                          * @brief Determine data sample size for each type
+                                                                          *
+                                                                          * @param[in] sampletype Library sample type code:
+                                                                          * @parblock
+                                                                          *   - \c 'a' - Text/ASCII data type
+                                                                          *   - \c 'i' - 32-bit integer data type
+                                                                          *   - \c 'f' - 32-bit float data type
+                                                                          *   - \c 'd' - 64-bit float (double) data type
+                                                                          * @endparblock
+                                                                          *
+                                                                          * @returns The sample size based on type code or 0 for unknown.
+                                                                          ***************************************************************************/
 uint8_t
 ms_samplesize (const char sampletype)
 {
@@ -57,18 +57,18 @@ ms_samplesize (const char sampletype)
 } /* End of ms_samplesize() */
 
 /**********************************************************************/ /**
- * @brief Return sample size and/or type for given encoding value
- *
- * Determine the decoded sample size and/or type based on data
- * encoding.  The \a samplesize and \a sampletype values will only be
- * set if not NULL, allowing lookup of either value or both.
- *
- * @param[in] encoding Data sample encoding code
- * @param[out] samplesize Size of sample, pointer that will be set
- * @param[out] sampletype Sample type, pointer to \c char that will be set
- *
- * @returns 0 on success, -1 on error
- ***************************************************************************/
+                                                                          * @brief Return sample size and/or type for given encoding value
+                                                                          *
+                                                                          * Determine the decoded sample size and/or type based on data
+                                                                          * encoding.  The \a samplesize and \a sampletype values will only be
+                                                                          * set if not NULL, allowing lookup of either value or both.
+                                                                          *
+                                                                          * @param[in] encoding Data sample encoding code
+                                                                          * @param[out] samplesize Size of sample, pointer that will be set
+                                                                          * @param[out] sampletype Sample type, pointer to \c char that will be set
+                                                                          *
+                                                                          * @returns 0 on success, -1 on error
+                                                                          ***************************************************************************/
 int
 ms_encoding_sizetype (const uint8_t encoding, uint8_t *samplesize, char *sampletype)
 {
@@ -115,12 +115,12 @@ ms_encoding_sizetype (const uint8_t encoding, uint8_t *samplesize, char *samplet
 } /* End of ms_encodingstr_sizetype() */
 
 /**********************************************************************/ /**
- * @brief Descriptive string for data encodings
- *
- * @param[in] encoding Data sample encoding code
- *
- * @returns a string describing a data encoding format
- ***************************************************************************/
+                                                                          * @brief Descriptive string for data encodings
+                                                                          *
+                                                                          * @param[in] encoding Data sample encoding code
+                                                                          *
+                                                                          * @returns a string describing a data encoding format
+                                                                          ***************************************************************************/
 const char *
 ms_encodingstr (const uint8_t encoding)
 {
@@ -193,13 +193,13 @@ ms_encodingstr (const uint8_t encoding)
 } /* End of ms_encodingstr() */
 
 /**********************************************************************/ /**
- * @brief Descriptive string for library @ref return-values
- *
- * @param[in] errorcode Library error code
- *
- * @returns a string describing the library error code or NULL if the
- * code is unknown.
- ***************************************************************************/
+                                                                          * @brief Descriptive string for library @ref return-values
+                                                                          *
+                                                                          * @param[in] errorcode Library error code
+                                                                          *
+                                                                          * @returns a string describing the library error code or NULL if the
+                                                                          * code is unknown.
+                                                                          ***************************************************************************/
 const char *
 ms_errorstr (int errorcode)
 {

--- a/mseedformat.h
+++ b/mseedformat.h
@@ -22,11 +22,12 @@
 #define MSEEDFORMAT_H 1
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-#include <stdint.h>
 #include "libmseed.h"
+#include <stdint.h>
 
 /* Length of Fixed Section of Data Header for miniSEED 3 */
 #define MS3FSDH_LENGTH 40
@@ -59,24 +60,24 @@ extern "C" {
  *
  * Convenience macros for accessing the fields via typed pointers follow:
  ***************************************************************************/
-#define pMS3FSDH_INDICATOR(record)       ((char*)record)
-#define pMS3FSDH_FORMATVERSION(record)   ((uint8_t*)((uint8_t*)record+2))
-#define pMS3FSDH_FLAGS(record)           ((uint8_t*)((uint8_t*)record+3))
-#define pMS3FSDH_NSEC(record)            ((uint32_t*)((uint8_t*)record+4))
-#define pMS3FSDH_YEAR(record)            ((uint16_t*)((uint8_t*)record+8))
-#define pMS3FSDH_DAY(record)             ((uint16_t*)((uint8_t*)record+10))
-#define pMS3FSDH_HOUR(record)            ((uint8_t*)((uint8_t*)record+12))
-#define pMS3FSDH_MIN(record)             ((uint8_t*)((uint8_t*)record+13))
-#define pMS3FSDH_SEC(record)             ((uint8_t*)((uint8_t*)record+14))
-#define pMS3FSDH_ENCODING(record)        ((uint8_t*)((uint8_t*)record+15))
-#define pMS3FSDH_SAMPLERATE(record)      ((double*)((uint8_t*)record+16))
-#define pMS3FSDH_NUMSAMPLES(record)      ((uint32_t*)((uint8_t*)record+24))
-#define pMS3FSDH_CRC(record)             ((uint32_t*)((uint8_t*)record+28))
-#define pMS3FSDH_PUBVERSION(record)      ((uint8_t*)((uint8_t*)record+32))
-#define pMS3FSDH_SIDLENGTH(record)       ((uint8_t*)((uint8_t*)record+33))
-#define pMS3FSDH_EXTRALENGTH(record)     ((uint16_t*)((uint8_t*)record+34))
-#define pMS3FSDH_DATALENGTH(record)      ((uint32_t*)((uint8_t*)record+36))
-#define pMS3FSDH_SID(record)             ((char*)((uint8_t*)record+40))
+#define pMS3FSDH_INDICATOR(record) ((char *)record)
+#define pMS3FSDH_FORMATVERSION(record) ((uint8_t *)((uint8_t *)record + 2))
+#define pMS3FSDH_FLAGS(record) ((uint8_t *)((uint8_t *)record + 3))
+#define pMS3FSDH_NSEC(record) ((uint32_t *)((uint8_t *)record + 4))
+#define pMS3FSDH_YEAR(record) ((uint16_t *)((uint8_t *)record + 8))
+#define pMS3FSDH_DAY(record) ((uint16_t *)((uint8_t *)record + 10))
+#define pMS3FSDH_HOUR(record) ((uint8_t *)((uint8_t *)record + 12))
+#define pMS3FSDH_MIN(record) ((uint8_t *)((uint8_t *)record + 13))
+#define pMS3FSDH_SEC(record) ((uint8_t *)((uint8_t *)record + 14))
+#define pMS3FSDH_ENCODING(record) ((uint8_t *)((uint8_t *)record + 15))
+#define pMS3FSDH_SAMPLERATE(record) ((double *)((uint8_t *)record + 16))
+#define pMS3FSDH_NUMSAMPLES(record) ((uint32_t *)((uint8_t *)record + 24))
+#define pMS3FSDH_CRC(record) ((uint32_t *)((uint8_t *)record + 28))
+#define pMS3FSDH_PUBVERSION(record) ((uint8_t *)((uint8_t *)record + 32))
+#define pMS3FSDH_SIDLENGTH(record) ((uint8_t *)((uint8_t *)record + 33))
+#define pMS3FSDH_EXTRALENGTH(record) ((uint16_t *)((uint8_t *)record + 34))
+#define pMS3FSDH_DATALENGTH(record) ((uint32_t *)((uint8_t *)record + 36))
+#define pMS3FSDH_SID(record) ((char *)((uint8_t *)record + 40))
 
 /***************************************************************************
  * miniSEED 2.4 Fixed Section of Data Header
@@ -110,30 +111,30 @@ extern "C" {
  *
  * Convenience macros for accessing the fields via typed pointers follow:
  ***************************************************************************/
-#define pMS2FSDH_SEQNUM(record)          ((char*)record)
-#define pMS2FSDH_DATAQUALITY(record)     ((char*)((uint8_t*)record+6))
-#define pMS2FSDH_RESERVED(record)        ((char*)((uint8_t*)record+7))
-#define pMS2FSDH_STATION(record)         ((char*)((uint8_t*)record+8))
-#define pMS2FSDH_LOCATION(record)        ((char*)((uint8_t*)record+13))
-#define pMS2FSDH_CHANNEL(record)         ((char*)((uint8_t*)record+15))
-#define pMS2FSDH_NETWORK(record)         ((char*)((uint8_t*)record+18))
-#define pMS2FSDH_YEAR(record)            ((uint16_t*)((uint8_t*)record+20))
-#define pMS2FSDH_DAY(record)             ((uint16_t*)((uint8_t*)record+22))
-#define pMS2FSDH_HOUR(record)            ((uint8_t*)((uint8_t*)record+24))
-#define pMS2FSDH_MIN(record)             ((uint8_t*)((uint8_t*)record+25))
-#define pMS2FSDH_SEC(record)             ((uint8_t*)((uint8_t*)record+26))
-#define pMS2FSDH_UNUSED(record)          ((uint8_t*)((uint8_t*)record+27))
-#define pMS2FSDH_FSEC(record)            ((uint16_t*)((uint8_t*)record+28))
-#define pMS2FSDH_NUMSAMPLES(record)      ((uint16_t*)((uint8_t*)record+30))
-#define pMS2FSDH_SAMPLERATEFACT(record)  ((int16_t*)((uint8_t*)record+32))
-#define pMS2FSDH_SAMPLERATEMULT(record)  ((int16_t*)((uint8_t*)record+34))
-#define pMS2FSDH_ACTFLAGS(record)        ((uint8_t*)((uint8_t*)record+36))
-#define pMS2FSDH_IOFLAGS(record)         ((uint8_t*)((uint8_t*)record+37))
-#define pMS2FSDH_DQFLAGS(record)         ((uint8_t*)((uint8_t*)record+38))
-#define pMS2FSDH_NUMBLOCKETTES(record)   ((uint8_t*)((uint8_t*)record+39))
-#define pMS2FSDH_TIMECORRECT(record)     ((int32_t*)((uint8_t*)record+40))
-#define pMS2FSDH_DATAOFFSET(record)      ((uint16_t*)((uint8_t*)record+44))
-#define pMS2FSDH_BLOCKETTEOFFSET(record) ((uint16_t*)((uint8_t*)record+46))
+#define pMS2FSDH_SEQNUM(record) ((char *)record)
+#define pMS2FSDH_DATAQUALITY(record) ((char *)((uint8_t *)record + 6))
+#define pMS2FSDH_RESERVED(record) ((char *)((uint8_t *)record + 7))
+#define pMS2FSDH_STATION(record) ((char *)((uint8_t *)record + 8))
+#define pMS2FSDH_LOCATION(record) ((char *)((uint8_t *)record + 13))
+#define pMS2FSDH_CHANNEL(record) ((char *)((uint8_t *)record + 15))
+#define pMS2FSDH_NETWORK(record) ((char *)((uint8_t *)record + 18))
+#define pMS2FSDH_YEAR(record) ((uint16_t *)((uint8_t *)record + 20))
+#define pMS2FSDH_DAY(record) ((uint16_t *)((uint8_t *)record + 22))
+#define pMS2FSDH_HOUR(record) ((uint8_t *)((uint8_t *)record + 24))
+#define pMS2FSDH_MIN(record) ((uint8_t *)((uint8_t *)record + 25))
+#define pMS2FSDH_SEC(record) ((uint8_t *)((uint8_t *)record + 26))
+#define pMS2FSDH_UNUSED(record) ((uint8_t *)((uint8_t *)record + 27))
+#define pMS2FSDH_FSEC(record) ((uint16_t *)((uint8_t *)record + 28))
+#define pMS2FSDH_NUMSAMPLES(record) ((uint16_t *)((uint8_t *)record + 30))
+#define pMS2FSDH_SAMPLERATEFACT(record) ((int16_t *)((uint8_t *)record + 32))
+#define pMS2FSDH_SAMPLERATEMULT(record) ((int16_t *)((uint8_t *)record + 34))
+#define pMS2FSDH_ACTFLAGS(record) ((uint8_t *)((uint8_t *)record + 36))
+#define pMS2FSDH_IOFLAGS(record) ((uint8_t *)((uint8_t *)record + 37))
+#define pMS2FSDH_DQFLAGS(record) ((uint8_t *)((uint8_t *)record + 38))
+#define pMS2FSDH_NUMBLOCKETTES(record) ((uint8_t *)((uint8_t *)record + 39))
+#define pMS2FSDH_TIMECORRECT(record) ((int32_t *)((uint8_t *)record + 40))
+#define pMS2FSDH_DATAOFFSET(record) ((uint16_t *)((uint8_t *)record + 44))
+#define pMS2FSDH_BLOCKETTEOFFSET(record) ((uint16_t *)((uint8_t *)record + 46))
 
 /***************************************************************************
  * miniSEED 2.4 Blockette 100 - sample rate
@@ -147,11 +148,11 @@ extern "C" {
  *
  * Convenience macros for accessing the fields via typed pointers follow:
  ***************************************************************************/
-#define pMS2B100_TYPE(blockette)            ((uint16_t*)(blockette))
-#define pMS2B100_NEXT(blockette)            ((uint16_t*)((uint8_t*)blockette+2))
-#define pMS2B100_SAMPRATE(blockette)        ((float*)((uint8_t*)blockette+4))
-#define pMS2B100_FLAGS(blockette)           ((uint8_t*)((uint8_t*)blockette+8))
-#define pMS2B100_RESERVED(blockette)        ((uint8_t*)((uint8_t*)blockette+9))
+#define pMS2B100_TYPE(blockette) ((uint16_t *)(blockette))
+#define pMS2B100_NEXT(blockette) ((uint16_t *)((uint8_t *)blockette + 2))
+#define pMS2B100_SAMPRATE(blockette) ((float *)((uint8_t *)blockette + 4))
+#define pMS2B100_FLAGS(blockette) ((uint8_t *)((uint8_t *)blockette + 8))
+#define pMS2B100_RESERVED(blockette) ((uint8_t *)((uint8_t *)blockette + 9))
 
 /***************************************************************************
  * miniSEED 2.4 Blockette 200 - generic event detection
@@ -175,21 +176,21 @@ extern "C" {
  *
  * Convenience macros for accessing the fields via typed pointers follow:
  ***************************************************************************/
-#define pMS2B200_TYPE(blockette)            ((uint16_t*)(blockette))
-#define pMS2B200_NEXT(blockette)            ((uint16_t*)((uint8_t*)blockette+2))
-#define pMS2B200_AMPLITUDE(blockette)       ((float*)((uint8_t*)blockette+4))
-#define pMS2B200_PERIOD(blockette)          ((float*)((uint8_t*)blockette+8))
-#define pMS2B200_BACKGROUNDEST(blockette)   ((float*)((uint8_t*)blockette+12))
-#define pMS2B200_FLAGS(blockette)           ((uint8_t*)((uint8_t*)blockette+16))
-#define pMS2B200_RESERVED(blockette)        ((uint8_t*)((uint8_t*)blockette+17))
-#define pMS2B200_YEAR(blockette)            ((uint16_t*)((uint8_t*)blockette+18))
-#define pMS2B200_DAY(blockette)             ((uint16_t*)((uint8_t*)blockette+20))
-#define pMS2B200_HOUR(blockette)            ((uint8_t*)((uint8_t*)blockette+22))
-#define pMS2B200_MIN(blockette)             ((uint8_t*)((uint8_t*)blockette+23))
-#define pMS2B200_SEC(blockette)             ((uint8_t*)((uint8_t*)blockette+24))
-#define pMS2B200_UNUSED(blockette)          ((uint8_t*)((uint8_t*)blockette+25))
-#define pMS2B200_FSEC(blockette)            ((uint16_t*)((uint8_t*)blockette+26))
-#define pMS2B200_DETECTOR(blockette)        ((char*)((uint8_t*)blockette+28))
+#define pMS2B200_TYPE(blockette) ((uint16_t *)(blockette))
+#define pMS2B200_NEXT(blockette) ((uint16_t *)((uint8_t *)blockette + 2))
+#define pMS2B200_AMPLITUDE(blockette) ((float *)((uint8_t *)blockette + 4))
+#define pMS2B200_PERIOD(blockette) ((float *)((uint8_t *)blockette + 8))
+#define pMS2B200_BACKGROUNDEST(blockette) ((float *)((uint8_t *)blockette + 12))
+#define pMS2B200_FLAGS(blockette) ((uint8_t *)((uint8_t *)blockette + 16))
+#define pMS2B200_RESERVED(blockette) ((uint8_t *)((uint8_t *)blockette + 17))
+#define pMS2B200_YEAR(blockette) ((uint16_t *)((uint8_t *)blockette + 18))
+#define pMS2B200_DAY(blockette) ((uint16_t *)((uint8_t *)blockette + 20))
+#define pMS2B200_HOUR(blockette) ((uint8_t *)((uint8_t *)blockette + 22))
+#define pMS2B200_MIN(blockette) ((uint8_t *)((uint8_t *)blockette + 23))
+#define pMS2B200_SEC(blockette) ((uint8_t *)((uint8_t *)blockette + 24))
+#define pMS2B200_UNUSED(blockette) ((uint8_t *)((uint8_t *)blockette + 25))
+#define pMS2B200_FSEC(blockette) ((uint16_t *)((uint8_t *)blockette + 26))
+#define pMS2B200_DETECTOR(blockette) ((char *)((uint8_t *)blockette + 28))
 
 /***************************************************************************
  * miniSEED 2.4 Blockette 201 - Murdock event detection
@@ -216,24 +217,24 @@ extern "C" {
  *
  * Convenience macros for accessing the fields via typed pointers follow:
  ***************************************************************************/
-#define pMS2B201_TYPE(blockette)            ((uint16_t*)(blockette))
-#define pMS2B201_NEXT(blockette)            ((uint16_t*)((uint8_t*)blockette+2))
-#define pMS2B201_AMPLITUDE(blockette)       ((float*)((uint8_t*)blockette+4))
-#define pMS2B201_PERIOD(blockette)          ((float*)((uint8_t*)blockette+8))
-#define pMS2B201_BACKGROUNDEST(blockette)   ((float*)((uint8_t*)blockette+12))
-#define pMS2B201_FLAGS(blockette)           ((uint8_t*)((uint8_t*)blockette+16))
-#define pMS2B201_RESERVED(blockette)        ((uint8_t*)((uint8_t*)blockette+17))
-#define pMS2B201_YEAR(blockette)            ((uint16_t*)((uint8_t*)blockette+18))
-#define pMS2B201_DAY(blockette)             ((uint16_t*)((uint8_t*)blockette+20))
-#define pMS2B201_HOUR(blockette)            ((uint8_t*)((uint8_t*)blockette+22))
-#define pMS2B201_MIN(blockette)             ((uint8_t*)((uint8_t*)blockette+23))
-#define pMS2B201_SEC(blockette)             ((uint8_t*)((uint8_t*)blockette+24))
-#define pMS2B201_UNUSED(blockette)          ((uint8_t*)((uint8_t*)blockette+25))
-#define pMS2B201_FSEC(blockette)            ((uint16_t*)((uint8_t*)blockette+26))
-#define pMS2B201_MEDSNR(blockette)          ((uint8_t*)((uint8_t*)blockette+28))
-#define pMS2B201_LOOPBACK(blockette)        ((uint8_t*)((uint8_t*)blockette+34))
-#define pMS2B201_PICKALGORITHM(blockette)   ((uint8_t*)((uint8_t*)blockette+35))
-#define pMS2B201_DETECTOR(blockette)        ((char*)((uint8_t*)blockette+36))
+#define pMS2B201_TYPE(blockette) ((uint16_t *)(blockette))
+#define pMS2B201_NEXT(blockette) ((uint16_t *)((uint8_t *)blockette + 2))
+#define pMS2B201_AMPLITUDE(blockette) ((float *)((uint8_t *)blockette + 4))
+#define pMS2B201_PERIOD(blockette) ((float *)((uint8_t *)blockette + 8))
+#define pMS2B201_BACKGROUNDEST(blockette) ((float *)((uint8_t *)blockette + 12))
+#define pMS2B201_FLAGS(blockette) ((uint8_t *)((uint8_t *)blockette + 16))
+#define pMS2B201_RESERVED(blockette) ((uint8_t *)((uint8_t *)blockette + 17))
+#define pMS2B201_YEAR(blockette) ((uint16_t *)((uint8_t *)blockette + 18))
+#define pMS2B201_DAY(blockette) ((uint16_t *)((uint8_t *)blockette + 20))
+#define pMS2B201_HOUR(blockette) ((uint8_t *)((uint8_t *)blockette + 22))
+#define pMS2B201_MIN(blockette) ((uint8_t *)((uint8_t *)blockette + 23))
+#define pMS2B201_SEC(blockette) ((uint8_t *)((uint8_t *)blockette + 24))
+#define pMS2B201_UNUSED(blockette) ((uint8_t *)((uint8_t *)blockette + 25))
+#define pMS2B201_FSEC(blockette) ((uint16_t *)((uint8_t *)blockette + 26))
+#define pMS2B201_MEDSNR(blockette) ((uint8_t *)((uint8_t *)blockette + 28))
+#define pMS2B201_LOOPBACK(blockette) ((uint8_t *)((uint8_t *)blockette + 34))
+#define pMS2B201_PICKALGORITHM(blockette) ((uint8_t *)((uint8_t *)blockette + 35))
+#define pMS2B201_DETECTOR(blockette) ((char *)((uint8_t *)blockette + 36))
 
 /***************************************************************************
  * miniSEED 2.4 Blockette 300 - step calibration
@@ -261,25 +262,25 @@ extern "C" {
  *
  * Convenience macros for accessing the fields via typed pointers follow:
  ***************************************************************************/
-#define pMS2B300_TYPE(blockette)            ((uint16_t*)(blockette))
-#define pMS2B300_NEXT(blockette)            ((uint16_t*)((uint8_t*)blockette+2))
-#define pMS2B300_YEAR(blockette)            ((uint16_t*)((uint8_t*)blockette+4))
-#define pMS2B300_DAY(blockette)             ((uint16_t*)((uint8_t*)blockette+6))
-#define pMS2B300_HOUR(blockette)            ((uint8_t*)((uint8_t*)blockette+8))
-#define pMS2B300_MIN(blockette)             ((uint8_t*)((uint8_t*)blockette+9))
-#define pMS2B300_SEC(blockette)             ((uint8_t*)((uint8_t*)blockette+10))
-#define pMS2B300_UNUSED(blockette)          ((uint8_t*)((uint8_t*)blockette+11))
-#define pMS2B300_FSEC(blockette)            ((uint16_t*)((uint8_t*)blockette+12))
-#define pMS2B300_NUMCALIBRATIONS(blockette) ((uint8_t*)((uint8_t*)blockette+14))
-#define pMS2B300_FLAGS(blockette)           ((uint8_t*)((uint8_t*)blockette+15))
-#define pMS2B300_STEPDURATION(blockette)    ((uint32_t*)((uint8_t*)blockette+16))
-#define pMS2B300_INTERVALDURATION(blockette) ((uint32_t*)((uint8_t*)blockette+20))
-#define pMS2B300_AMPLITUDE(blockette)       ((float*)((uint8_t*)blockette+24))
-#define pMS2B300_INPUTCHANNEL(blockette)    ((char *)((uint8_t*)blockette+28))
-#define pMS2B300_RESERVED(blockette)        ((uint8_t*)((uint8_t*)blockette+31))
-#define pMS2B300_REFERENCEAMPLITUDE(blockette) ((uint32_t*)((uint8_t*)blockette+32))
-#define pMS2B300_COUPLING(blockette)        ((char*)((uint8_t*)blockette+36))
-#define pMS2B300_ROLLOFF(blockette)         ((char*)((uint8_t*)blockette+48))
+#define pMS2B300_TYPE(blockette) ((uint16_t *)(blockette))
+#define pMS2B300_NEXT(blockette) ((uint16_t *)((uint8_t *)blockette + 2))
+#define pMS2B300_YEAR(blockette) ((uint16_t *)((uint8_t *)blockette + 4))
+#define pMS2B300_DAY(blockette) ((uint16_t *)((uint8_t *)blockette + 6))
+#define pMS2B300_HOUR(blockette) ((uint8_t *)((uint8_t *)blockette + 8))
+#define pMS2B300_MIN(blockette) ((uint8_t *)((uint8_t *)blockette + 9))
+#define pMS2B300_SEC(blockette) ((uint8_t *)((uint8_t *)blockette + 10))
+#define pMS2B300_UNUSED(blockette) ((uint8_t *)((uint8_t *)blockette + 11))
+#define pMS2B300_FSEC(blockette) ((uint16_t *)((uint8_t *)blockette + 12))
+#define pMS2B300_NUMCALIBRATIONS(blockette) ((uint8_t *)((uint8_t *)blockette + 14))
+#define pMS2B300_FLAGS(blockette) ((uint8_t *)((uint8_t *)blockette + 15))
+#define pMS2B300_STEPDURATION(blockette) ((uint32_t *)((uint8_t *)blockette + 16))
+#define pMS2B300_INTERVALDURATION(blockette) ((uint32_t *)((uint8_t *)blockette + 20))
+#define pMS2B300_AMPLITUDE(blockette) ((float *)((uint8_t *)blockette + 24))
+#define pMS2B300_INPUTCHANNEL(blockette) ((char *)((uint8_t *)blockette + 28))
+#define pMS2B300_RESERVED(blockette) ((uint8_t *)((uint8_t *)blockette + 31))
+#define pMS2B300_REFERENCEAMPLITUDE(blockette) ((uint32_t *)((uint8_t *)blockette + 32))
+#define pMS2B300_COUPLING(blockette) ((char *)((uint8_t *)blockette + 36))
+#define pMS2B300_ROLLOFF(blockette) ((char *)((uint8_t *)blockette + 48))
 
 /***************************************************************************
  * miniSEED 2.4 Blockette 310 - sine calibration
@@ -307,25 +308,25 @@ extern "C" {
  *
  * Convenience macros for accessing the fields via typed pointers follow:
  ***************************************************************************/
-#define pMS2B310_TYPE(blockette)            ((uint16_t*)(blockette))
-#define pMS2B310_NEXT(blockette)            ((uint16_t*)((uint8_t*)blockette+2))
-#define pMS2B310_YEAR(blockette)            ((uint16_t*)((uint8_t*)blockette+4))
-#define pMS2B310_DAY(blockette)             ((uint16_t*)((uint8_t*)blockette+6))
-#define pMS2B310_HOUR(blockette)            ((uint8_t*)((uint8_t*)blockette+8))
-#define pMS2B310_MIN(blockette)             ((uint8_t*)((uint8_t*)blockette+9))
-#define pMS2B310_SEC(blockette)             ((uint8_t*)((uint8_t*)blockette+10))
-#define pMS2B310_UNUSED(blockette)          ((uint8_t*)((uint8_t*)blockette+11))
-#define pMS2B310_FSEC(blockette)            ((uint16_t*)((uint8_t*)blockette+12))
-#define pMS2B310_RESERVED1(blockette)       ((uint8_t*)((uint8_t*)blockette+14))
-#define pMS2B310_FLAGS(blockette)           ((uint8_t*)((uint8_t*)blockette+15))
-#define pMS2B310_DURATION(blockette)        ((uint32_t*)((uint8_t*)blockette+16))
-#define pMS2B310_PERIOD(blockette)          ((float*)((uint8_t*)blockette+20))
-#define pMS2B310_AMPLITUDE(blockette)       ((float*)((uint8_t*)blockette+24))
-#define pMS2B310_INPUTCHANNEL(blockette)    ((char *)((uint8_t*)blockette+28))
-#define pMS2B310_RESERVED2(blockette)       ((uint8_t*)((uint8_t*)blockette+31))
-#define pMS2B310_REFERENCEAMPLITUDE(blockette) ((uint32_t*)((uint8_t*)blockette+32))
-#define pMS2B310_COUPLING(blockette)        ((char*)((uint8_t*)blockette+36))
-#define pMS2B310_ROLLOFF(blockette)         ((char*)((uint8_t*)blockette+48))
+#define pMS2B310_TYPE(blockette) ((uint16_t *)(blockette))
+#define pMS2B310_NEXT(blockette) ((uint16_t *)((uint8_t *)blockette + 2))
+#define pMS2B310_YEAR(blockette) ((uint16_t *)((uint8_t *)blockette + 4))
+#define pMS2B310_DAY(blockette) ((uint16_t *)((uint8_t *)blockette + 6))
+#define pMS2B310_HOUR(blockette) ((uint8_t *)((uint8_t *)blockette + 8))
+#define pMS2B310_MIN(blockette) ((uint8_t *)((uint8_t *)blockette + 9))
+#define pMS2B310_SEC(blockette) ((uint8_t *)((uint8_t *)blockette + 10))
+#define pMS2B310_UNUSED(blockette) ((uint8_t *)((uint8_t *)blockette + 11))
+#define pMS2B310_FSEC(blockette) ((uint16_t *)((uint8_t *)blockette + 12))
+#define pMS2B310_RESERVED1(blockette) ((uint8_t *)((uint8_t *)blockette + 14))
+#define pMS2B310_FLAGS(blockette) ((uint8_t *)((uint8_t *)blockette + 15))
+#define pMS2B310_DURATION(blockette) ((uint32_t *)((uint8_t *)blockette + 16))
+#define pMS2B310_PERIOD(blockette) ((float *)((uint8_t *)blockette + 20))
+#define pMS2B310_AMPLITUDE(blockette) ((float *)((uint8_t *)blockette + 24))
+#define pMS2B310_INPUTCHANNEL(blockette) ((char *)((uint8_t *)blockette + 28))
+#define pMS2B310_RESERVED2(blockette) ((uint8_t *)((uint8_t *)blockette + 31))
+#define pMS2B310_REFERENCEAMPLITUDE(blockette) ((uint32_t *)((uint8_t *)blockette + 32))
+#define pMS2B310_COUPLING(blockette) ((char *)((uint8_t *)blockette + 36))
+#define pMS2B310_ROLLOFF(blockette) ((char *)((uint8_t *)blockette + 48))
 
 /***************************************************************************
  * miniSEED 2.4 Blockette 320 - pseudo-random calibration
@@ -353,25 +354,25 @@ extern "C" {
  *
  * Convenience macros for accessing the fields via typed pointers follow:
  ***************************************************************************/
-#define pMS2B320_TYPE(blockette)            ((uint16_t*)(blockette))
-#define pMS2B320_NEXT(blockette)            ((uint16_t*)((uint8_t*)blockette+2))
-#define pMS2B320_YEAR(blockette)            ((uint16_t*)((uint8_t*)blockette+4))
-#define pMS2B320_DAY(blockette)             ((uint16_t*)((uint8_t*)blockette+6))
-#define pMS2B320_HOUR(blockette)            ((uint8_t*)((uint8_t*)blockette+8))
-#define pMS2B320_MIN(blockette)             ((uint8_t*)((uint8_t*)blockette+9))
-#define pMS2B320_SEC(blockette)             ((uint8_t*)((uint8_t*)blockette+10))
-#define pMS2B320_UNUSED(blockette)          ((uint8_t*)((uint8_t*)blockette+11))
-#define pMS2B320_FSEC(blockette)            ((uint16_t*)((uint8_t*)blockette+12))
-#define pMS2B320_RESERVED1(blockette)       ((uint8_t*)((uint8_t*)blockette+14))
-#define pMS2B320_FLAGS(blockette)           ((uint8_t*)((uint8_t*)blockette+15))
-#define pMS2B320_DURATION(blockette)        ((uint32_t*)((uint8_t*)blockette+16))
-#define pMS2B320_PTPAMPLITUDE(blockette)    ((float*)((uint8_t*)blockette+20))
-#define pMS2B320_INPUTCHANNEL(blockette)    ((char *)((uint8_t*)blockette+24))
-#define pMS2B320_RESERVED2(blockette)       ((uint8_t*)((uint8_t*)blockette+27))
-#define pMS2B320_REFERENCEAMPLITUDE(blockette) ((uint32_t*)((uint8_t*)blockette+28))
-#define pMS2B320_COUPLING(blockette)        ((char*)((uint8_t*)blockette+32))
-#define pMS2B320_ROLLOFF(blockette)         ((char*)((uint8_t*)blockette+44))
-#define pMS2B320_NOISETYPE(blockette)       ((char*)((uint8_t*)blockette+56))
+#define pMS2B320_TYPE(blockette) ((uint16_t *)(blockette))
+#define pMS2B320_NEXT(blockette) ((uint16_t *)((uint8_t *)blockette + 2))
+#define pMS2B320_YEAR(blockette) ((uint16_t *)((uint8_t *)blockette + 4))
+#define pMS2B320_DAY(blockette) ((uint16_t *)((uint8_t *)blockette + 6))
+#define pMS2B320_HOUR(blockette) ((uint8_t *)((uint8_t *)blockette + 8))
+#define pMS2B320_MIN(blockette) ((uint8_t *)((uint8_t *)blockette + 9))
+#define pMS2B320_SEC(blockette) ((uint8_t *)((uint8_t *)blockette + 10))
+#define pMS2B320_UNUSED(blockette) ((uint8_t *)((uint8_t *)blockette + 11))
+#define pMS2B320_FSEC(blockette) ((uint16_t *)((uint8_t *)blockette + 12))
+#define pMS2B320_RESERVED1(blockette) ((uint8_t *)((uint8_t *)blockette + 14))
+#define pMS2B320_FLAGS(blockette) ((uint8_t *)((uint8_t *)blockette + 15))
+#define pMS2B320_DURATION(blockette) ((uint32_t *)((uint8_t *)blockette + 16))
+#define pMS2B320_PTPAMPLITUDE(blockette) ((float *)((uint8_t *)blockette + 20))
+#define pMS2B320_INPUTCHANNEL(blockette) ((char *)((uint8_t *)blockette + 24))
+#define pMS2B320_RESERVED2(blockette) ((uint8_t *)((uint8_t *)blockette + 27))
+#define pMS2B320_REFERENCEAMPLITUDE(blockette) ((uint32_t *)((uint8_t *)blockette + 28))
+#define pMS2B320_COUPLING(blockette) ((char *)((uint8_t *)blockette + 32))
+#define pMS2B320_ROLLOFF(blockette) ((char *)((uint8_t *)blockette + 44))
+#define pMS2B320_NOISETYPE(blockette) ((char *)((uint8_t *)blockette + 56))
 
 /***************************************************************************
  * miniSEED 2.4 Blockette 390 - generic calibration
@@ -395,21 +396,21 @@ extern "C" {
  *
  * Convenience macros for accessing the fields via typed pointers follow:
  ***************************************************************************/
-#define pMS2B390_TYPE(blockette)            ((uint16_t*)(blockette))
-#define pMS2B390_NEXT(blockette)            ((uint16_t*)((uint8_t*)blockette+2))
-#define pMS2B390_YEAR(blockette)            ((uint16_t*)((uint8_t*)blockette+4))
-#define pMS2B390_DAY(blockette)             ((uint16_t*)((uint8_t*)blockette+6))
-#define pMS2B390_HOUR(blockette)            ((uint8_t*)((uint8_t*)blockette+8))
-#define pMS2B390_MIN(blockette)             ((uint8_t*)((uint8_t*)blockette+9))
-#define pMS2B390_SEC(blockette)             ((uint8_t*)((uint8_t*)blockette+10))
-#define pMS2B390_UNUSED(blockette)          ((uint8_t*)((uint8_t*)blockette+11))
-#define pMS2B390_FSEC(blockette)            ((uint16_t*)((uint8_t*)blockette+12))
-#define pMS2B390_RESERVED1(blockette)       ((uint8_t*)((uint8_t*)blockette+14))
-#define pMS2B390_FLAGS(blockette)           ((uint8_t*)((uint8_t*)blockette+15))
-#define pMS2B390_DURATION(blockette)        ((uint32_t*)((uint8_t*)blockette+16))
-#define pMS2B390_AMPLITUDE(blockette)       ((float*)((uint8_t*)blockette+20))
-#define pMS2B390_INPUTCHANNEL(blockette)    ((char *)((uint8_t*)blockette+24))
-#define pMS2B390_RESERVED2(blockette)       ((uint8_t*)((uint8_t*)blockette+27))
+#define pMS2B390_TYPE(blockette) ((uint16_t *)(blockette))
+#define pMS2B390_NEXT(blockette) ((uint16_t *)((uint8_t *)blockette + 2))
+#define pMS2B390_YEAR(blockette) ((uint16_t *)((uint8_t *)blockette + 4))
+#define pMS2B390_DAY(blockette) ((uint16_t *)((uint8_t *)blockette + 6))
+#define pMS2B390_HOUR(blockette) ((uint8_t *)((uint8_t *)blockette + 8))
+#define pMS2B390_MIN(blockette) ((uint8_t *)((uint8_t *)blockette + 9))
+#define pMS2B390_SEC(blockette) ((uint8_t *)((uint8_t *)blockette + 10))
+#define pMS2B390_UNUSED(blockette) ((uint8_t *)((uint8_t *)blockette + 11))
+#define pMS2B390_FSEC(blockette) ((uint16_t *)((uint8_t *)blockette + 12))
+#define pMS2B390_RESERVED1(blockette) ((uint8_t *)((uint8_t *)blockette + 14))
+#define pMS2B390_FLAGS(blockette) ((uint8_t *)((uint8_t *)blockette + 15))
+#define pMS2B390_DURATION(blockette) ((uint32_t *)((uint8_t *)blockette + 16))
+#define pMS2B390_AMPLITUDE(blockette) ((float *)((uint8_t *)blockette + 20))
+#define pMS2B390_INPUTCHANNEL(blockette) ((char *)((uint8_t *)blockette + 24))
+#define pMS2B390_RESERVED2(blockette) ((uint8_t *)((uint8_t *)blockette + 27))
 
 /***************************************************************************
  * miniSEED 2.4 Blockette 395 - calibration abort
@@ -428,16 +429,16 @@ extern "C" {
  *
  * Convenience macros for accessing the fields via typed pointers follow:
  ***************************************************************************/
-#define pMS2B395_TYPE(blockette)            ((uint16_t*)(blockette))
-#define pMS2B395_NEXT(blockette)            ((uint16_t*)((uint8_t*)blockette+2))
-#define pMS2B395_YEAR(blockette)            ((uint16_t*)((uint8_t*)blockette+4))
-#define pMS2B395_DAY(blockette)             ((uint16_t*)((uint8_t*)blockette+6))
-#define pMS2B395_HOUR(blockette)            ((uint8_t*)((uint8_t*)blockette+8))
-#define pMS2B395_MIN(blockette)             ((uint8_t*)((uint8_t*)blockette+9))
-#define pMS2B395_SEC(blockette)             ((uint8_t*)((uint8_t*)blockette+10))
-#define pMS2B395_UNUSED(blockette)          ((uint8_t*)((uint8_t*)blockette+11))
-#define pMS2B395_FSEC(blockette)            ((uint16_t*)((uint8_t*)blockette+12))
-#define pMS2B395_RESERVED(blockette)        ((uint8_t*)((uint8_t*)blockette+14))
+#define pMS2B395_TYPE(blockette) ((uint16_t *)(blockette))
+#define pMS2B395_NEXT(blockette) ((uint16_t *)((uint8_t *)blockette + 2))
+#define pMS2B395_YEAR(blockette) ((uint16_t *)((uint8_t *)blockette + 4))
+#define pMS2B395_DAY(blockette) ((uint16_t *)((uint8_t *)blockette + 6))
+#define pMS2B395_HOUR(blockette) ((uint8_t *)((uint8_t *)blockette + 8))
+#define pMS2B395_MIN(blockette) ((uint8_t *)((uint8_t *)blockette + 9))
+#define pMS2B395_SEC(blockette) ((uint8_t *)((uint8_t *)blockette + 10))
+#define pMS2B395_UNUSED(blockette) ((uint8_t *)((uint8_t *)blockette + 11))
+#define pMS2B395_FSEC(blockette) ((uint16_t *)((uint8_t *)blockette + 12))
+#define pMS2B395_RESERVED(blockette) ((uint8_t *)((uint8_t *)blockette + 14))
 
 /***************************************************************************
  * miniSEED 2.4 Blockette 400 - beam
@@ -452,12 +453,12 @@ extern "C" {
  *
  * Convenience macros for accessing the fields via typed pointers follow:
  ***************************************************************************/
-#define pMS2B400_TYPE(blockette)            ((uint16_t*)(blockette))
-#define pMS2B400_NEXT(blockette)            ((uint16_t*)((uint8_t*)blockette+2))
-#define pMS2B400_AZIMUTH(blockette)         ((float*)((uint8_t*)blockette+4))
-#define pMS2B400_SLOWNESS(blockette)        ((float*)((uint8_t*)blockette+8))
-#define pMS2B400_CONFIGURATION(blockette)   ((uint16_t*)((uint8_t*)blockette+12))
-#define pMS2B400_RESERVED(blockette)        ((uint8_t*)((uint8_t*)blockette+14))
+#define pMS2B400_TYPE(blockette) ((uint16_t *)(blockette))
+#define pMS2B400_NEXT(blockette) ((uint16_t *)((uint8_t *)blockette + 2))
+#define pMS2B400_AZIMUTH(blockette) ((float *)((uint8_t *)blockette + 4))
+#define pMS2B400_SLOWNESS(blockette) ((float *)((uint8_t *)blockette + 8))
+#define pMS2B400_CONFIGURATION(blockette) ((uint16_t *)((uint8_t *)blockette + 12))
+#define pMS2B400_RESERVED(blockette) ((uint8_t *)((uint8_t *)blockette + 14))
 
 /***************************************************************************
  * miniSEED 2.4 Blockette 405 - beam delay
@@ -469,9 +470,9 @@ extern "C" {
  *
  * Convenience macros for accessing the fields via typed pointers follow:
  ***************************************************************************/
-#define pMS2B405_TYPE(blockette)            ((uint16_t*)(blockette))
-#define pMS2B405_NEXT(blockette)            ((uint16_t*)((uint8_t*)blockette+2))
-#define pMS2B405_DELAYVALUES(blockette)     ((uint16_t*)((uint8_t*)blockette+4))
+#define pMS2B405_TYPE(blockette) ((uint16_t *)(blockette))
+#define pMS2B405_NEXT(blockette) ((uint16_t *)((uint8_t *)blockette + 2))
+#define pMS2B405_DELAYVALUES(blockette) ((uint16_t *)((uint8_t *)blockette + 4))
 
 /***************************************************************************
  * miniSEED 2.4 Blockette 500 - timing
@@ -496,22 +497,22 @@ extern "C" {
  *
  * Convenience macros for accessing the fields via typed pointers follow:
  ***************************************************************************/
-#define pMS2B500_TYPE(blockette)            ((uint16_t*)(blockette))
-#define pMS2B500_NEXT(blockette)            ((uint16_t*)((uint8_t*)blockette+2))
-#define pMS2B500_VCOCORRECTION(blockette)   ((float*)((uint8_t*)blockette+4))
-#define pMS2B500_YEAR(blockette)            ((uint16_t*)((uint8_t*)blockette+8))
-#define pMS2B500_DAY(blockette)             ((uint16_t*)((uint8_t*)blockette+10))
-#define pMS2B500_HOUR(blockette)            ((uint8_t*)((uint8_t*)blockette+12))
-#define pMS2B500_MIN(blockette)             ((uint8_t*)((uint8_t*)blockette+13))
-#define pMS2B500_SEC(blockette)             ((uint8_t*)((uint8_t*)blockette+14))
-#define pMS2B500_UNUSED(blockette)          ((uint8_t*)((uint8_t*)blockette+15))
-#define pMS2B500_FSEC(blockette)            ((uint16_t*)((uint8_t*)blockette+16))
-#define pMS2B500_MICROSECOND(blockette)     ((int8_t*)((uint8_t*)blockette+18))
-#define pMS2B500_RECEPTIONQUALITY(blockette) ((uint8_t*)((uint8_t*)blockette+19))
-#define pMS2B500_EXCEPTIONCOUNT(blockette)  ((uint32_t*)((uint8_t*)blockette+20))
-#define pMS2B500_EXCEPTIONTYPE(blockette)   ((char*)((uint8_t*)blockette+24))
-#define pMS2B500_CLOCKMODEL(blockette)      ((char*)((uint8_t*)blockette+40))
-#define pMS2B500_CLOCKSTATUS(blockette)     ((char*)((uint8_t*)blockette+72))
+#define pMS2B500_TYPE(blockette) ((uint16_t *)(blockette))
+#define pMS2B500_NEXT(blockette) ((uint16_t *)((uint8_t *)blockette + 2))
+#define pMS2B500_VCOCORRECTION(blockette) ((float *)((uint8_t *)blockette + 4))
+#define pMS2B500_YEAR(blockette) ((uint16_t *)((uint8_t *)blockette + 8))
+#define pMS2B500_DAY(blockette) ((uint16_t *)((uint8_t *)blockette + 10))
+#define pMS2B500_HOUR(blockette) ((uint8_t *)((uint8_t *)blockette + 12))
+#define pMS2B500_MIN(blockette) ((uint8_t *)((uint8_t *)blockette + 13))
+#define pMS2B500_SEC(blockette) ((uint8_t *)((uint8_t *)blockette + 14))
+#define pMS2B500_UNUSED(blockette) ((uint8_t *)((uint8_t *)blockette + 15))
+#define pMS2B500_FSEC(blockette) ((uint16_t *)((uint8_t *)blockette + 16))
+#define pMS2B500_MICROSECOND(blockette) ((int8_t *)((uint8_t *)blockette + 18))
+#define pMS2B500_RECEPTIONQUALITY(blockette) ((uint8_t *)((uint8_t *)blockette + 19))
+#define pMS2B500_EXCEPTIONCOUNT(blockette) ((uint32_t *)((uint8_t *)blockette + 20))
+#define pMS2B500_EXCEPTIONTYPE(blockette) ((char *)((uint8_t *)blockette + 24))
+#define pMS2B500_CLOCKMODEL(blockette) ((char *)((uint8_t *)blockette + 40))
+#define pMS2B500_CLOCKSTATUS(blockette) ((char *)((uint8_t *)blockette + 72))
 
 /***************************************************************************
  * miniSEED 2.4 Blockette 1000 - data only SEED (miniSEED)
@@ -526,12 +527,12 @@ extern "C" {
  *
  * Convenience macros for accessing the fields via typed pointers follow:
  ***************************************************************************/
-#define pMS2B1000_TYPE(blockette)            ((uint16_t*)(blockette))
-#define pMS2B1000_NEXT(blockette)            ((uint16_t*)((uint8_t*)blockette+2))
-#define pMS2B1000_ENCODING(blockette)        ((uint8_t*)((uint8_t*)blockette+4))
-#define pMS2B1000_BYTEORDER(blockette)       ((uint8_t*)((uint8_t*)blockette+5))
-#define pMS2B1000_RECLEN(blockette)          ((uint8_t*)((uint8_t*)blockette+6))
-#define pMS2B1000_RESERVED(blockette)        ((uint8_t*)((uint8_t*)blockette+7))
+#define pMS2B1000_TYPE(blockette) ((uint16_t *)(blockette))
+#define pMS2B1000_NEXT(blockette) ((uint16_t *)((uint8_t *)blockette + 2))
+#define pMS2B1000_ENCODING(blockette) ((uint8_t *)((uint8_t *)blockette + 4))
+#define pMS2B1000_BYTEORDER(blockette) ((uint8_t *)((uint8_t *)blockette + 5))
+#define pMS2B1000_RECLEN(blockette) ((uint8_t *)((uint8_t *)blockette + 6))
+#define pMS2B1000_RESERVED(blockette) ((uint8_t *)((uint8_t *)blockette + 7))
 
 /***************************************************************************
  * miniSEED 2.4 Blockette 1001 - data extension
@@ -546,12 +547,12 @@ extern "C" {
  *
  * Convenience macros for accessing the fields via typed pointers follow:
  ***************************************************************************/
-#define pMS2B1001_TYPE(blockette)            ((uint16_t*)(blockette))
-#define pMS2B1001_NEXT(blockette)            ((uint16_t*)((uint8_t*)blockette+2))
-#define pMS2B1001_TIMINGQUALITY(blockette)   ((uint8_t*)((uint8_t*)blockette+4))
-#define pMS2B1001_MICROSECOND(blockette)     ((int8_t*)((uint8_t*)blockette+5))
-#define pMS2B1001_RESERVED(blockette)        ((uint8_t*)((uint8_t*)blockette+6))
-#define pMS2B1001_FRAMECOUNT(blockette)      ((uint8_t*)((uint8_t*)blockette+7))
+#define pMS2B1001_TYPE(blockette) ((uint16_t *)(blockette))
+#define pMS2B1001_NEXT(blockette) ((uint16_t *)((uint8_t *)blockette + 2))
+#define pMS2B1001_TIMINGQUALITY(blockette) ((uint8_t *)((uint8_t *)blockette + 4))
+#define pMS2B1001_MICROSECOND(blockette) ((int8_t *)((uint8_t *)blockette + 5))
+#define pMS2B1001_RESERVED(blockette) ((uint8_t *)((uint8_t *)blockette + 6))
+#define pMS2B1001_FRAMECOUNT(blockette) ((uint8_t *)((uint8_t *)blockette + 7))
 
 /***************************************************************************
  * miniSEED 2.4 Blockette 2000 - opaque data
@@ -569,74 +570,74 @@ extern "C" {
  *
  * Convenience macros for accessing the fields via typed pointers follow:
  ***************************************************************************/
-#define pMS2B2000_TYPE(blockette)            ((uint16_t*)(blockette))
-#define pMS2B2000_NEXT(blockette)            ((uint16_t*)((uint8_t*)blockette+2))
-#define pMS2B2000_LENGTH(blockette)          ((uint16_t*)((uint8_t*)blockette+4))
-#define pMS2B2000_DATAOFFSET(blockette)      ((uint16_t*)((uint8_t*)blockette+6))
-#define pMS2B2000_RECNUM(blockette)          ((uint32_t*)((uint8_t*)blockette+8))
-#define pMS2B2000_BYTEORDER(blockette)       ((uint8_t*)((uint8_t*)blockette+12))
-#define pMS2B2000_FLAGS(blockette)           ((uint8_t*)((uint8_t*)blockette+13))
-#define pMS2B2000_NUMHEADERS(blockette)      ((uint8_t*)((uint8_t*)blockette+14))
-#define pMS2B2000_PAYLOAD(blockette)         ((char*)((uint8_t*)blockette+15))
+#define pMS2B2000_TYPE(blockette) ((uint16_t *)(blockette))
+#define pMS2B2000_NEXT(blockette) ((uint16_t *)((uint8_t *)blockette + 2))
+#define pMS2B2000_LENGTH(blockette) ((uint16_t *)((uint8_t *)blockette + 4))
+#define pMS2B2000_DATAOFFSET(blockette) ((uint16_t *)((uint8_t *)blockette + 6))
+#define pMS2B2000_RECNUM(blockette) ((uint32_t *)((uint8_t *)blockette + 8))
+#define pMS2B2000_BYTEORDER(blockette) ((uint8_t *)((uint8_t *)blockette + 12))
+#define pMS2B2000_FLAGS(blockette) ((uint8_t *)((uint8_t *)blockette + 13))
+#define pMS2B2000_NUMHEADERS(blockette) ((uint8_t *)((uint8_t *)blockette + 14))
+#define pMS2B2000_PAYLOAD(blockette) ((char *)((uint8_t *)blockette + 15))
 
-/***************************************************************************
- * Simple static inline convenience functions to swap bytes to "host
- * order", as determined by the swap flag.
- ***************************************************************************/
-static inline int16_t
-HO2d (int16_t value, int swapflag)
-{
-  if (swapflag)
+  /***************************************************************************
+   * Simple static inline convenience functions to swap bytes to "host
+   * order", as determined by the swap flag.
+   ***************************************************************************/
+  static inline int16_t
+  HO2d (int16_t value, int swapflag)
   {
-    ms_gswap2 (&value);
+    if (swapflag)
+    {
+      ms_gswap2 (&value);
+    }
+    return value;
   }
-  return value;
-}
-static inline uint16_t
-HO2u (uint16_t value, int swapflag)
-{
-  if (swapflag)
+  static inline uint16_t
+  HO2u (uint16_t value, int swapflag)
   {
-    ms_gswap2 (&value);
+    if (swapflag)
+    {
+      ms_gswap2 (&value);
+    }
+    return value;
   }
-  return value;
-}
-static inline int32_t
-HO4d (int32_t value, int swapflag)
-{
-  if (swapflag)
+  static inline int32_t
+  HO4d (int32_t value, int swapflag)
   {
-    ms_gswap4 (&value);
+    if (swapflag)
+    {
+      ms_gswap4 (&value);
+    }
+    return value;
   }
-  return value;
-}
-static inline uint32_t
-HO4u (uint32_t value, int swapflag)
-{
-  if (swapflag)
+  static inline uint32_t
+  HO4u (uint32_t value, int swapflag)
   {
-    ms_gswap4 (&value);
+    if (swapflag)
+    {
+      ms_gswap4 (&value);
+    }
+    return value;
   }
-  return value;
-}
-static inline float
-HO4f (float value, int swapflag)
-{
-  if (swapflag)
+  static inline float
+  HO4f (float value, int swapflag)
   {
-    ms_gswap4 (&value);
+    if (swapflag)
+    {
+      ms_gswap4 (&value);
+    }
+    return value;
   }
-  return value;
-}
-static inline double
-HO8f (double value, int swapflag)
-{
-  if (swapflag)
+  static inline double
+  HO8f (double value, int swapflag)
   {
-    ms_gswap8 (&value);
+    if (swapflag)
+    {
+      ms_gswap8 (&value);
+    }
+    return value;
   }
-  return value;
-}
 
 /* Macro to test for sane year and day values, used primarily to
  * determine if byte order swapping is needed for miniSEED 2.x.
@@ -649,7 +650,7 @@ HO8f (double value, int swapflag)
  * If you are using this in 2056 to determine the byte order of miniSEED 2
  * you have my deepest sympathies.
  */
-#define MS_ISVALIDYEARDAY(Y,D) (Y >= 1900 && Y <= 2100 && D >= 1 && D <= 366)
+#define MS_ISVALIDYEARDAY(Y, D) (Y >= 1900 && Y <= 2100 && D >= 1 && D <= 366)
 
 #ifdef __cplusplus
 }

--- a/msio.c
+++ b/msio.c
@@ -148,17 +148,16 @@ header_callback (char *buffer, size_t size, size_t num, void *userdata)
 
     /* Convert start and end values to numbers if non-zero length */
     if (hcp->startoffset && startdigits)
-      *hcp->startoffset = (int64_t) strtoull (startstr, NULL, 10);
+      *hcp->startoffset = (int64_t)strtoull (startstr, NULL, 10);
 
     if (hcp->endoffset && enddigits)
-      *hcp->endoffset = (int64_t) strtoull (endstr, NULL, 10);
+      *hcp->endoffset = (int64_t)strtoull (endstr, NULL, 10);
   }
 
   return size;
 }
 
 #endif /* defined(LIBMSEED_URL) */
-
 
 /***************************************************************************
  * msio_fopen:
@@ -181,7 +180,7 @@ header_callback (char *buffer, size_t size, size_t num, void *userdata)
  ***************************************************************************/
 int
 msio_fopen (LMIO *io, const char *path, const char *mode,
-          int64_t *startoffset, int64_t *endoffset)
+            int64_t *startoffset, int64_t *endoffset)
 {
   int knownfile = 0;
 
@@ -339,7 +338,7 @@ msio_fopen (LMIO *io, const char *path, const char *mode,
     if (startoffset || endoffset)
     {
       hcp.startoffset = startoffset;
-      hcp.endoffset = endoffset;
+      hcp.endoffset   = endoffset;
 
       /* Configure header callback */
       if (curl_easy_setopt (io->handle, CURLOPT_HEADERFUNCTION, header_callback) != CURLE_OK)
@@ -388,7 +387,7 @@ msio_fopen (LMIO *io, const char *path, const char *mode,
 
     if ((io->handle = fopen (path, mode)) == NULL)
     {
-      ms_log (2, "Cannot open: %s (%s)\n", path, strerror(errno));
+      ms_log (2, "Cannot open: %s (%s)\n", path, strerror (errno));
       return -1;
     }
 
@@ -404,7 +403,7 @@ msio_fopen (LMIO *io, const char *path, const char *mode,
   }
 
   return 0;
-}  /* End of msio_fopen() */
+} /* End of msio_fopen() */
 
 /*********************************************************************
  * msio_fclose:
@@ -435,7 +434,7 @@ msio_fclose (LMIO *io)
 
     if (rv)
     {
-      ms_log (2, "Error closing file (%s)\n", strerror(errno));
+      ms_log (2, "Error closing file (%s)\n", strerror (errno));
       return -1;
     }
   }
@@ -451,13 +450,12 @@ msio_fclose (LMIO *io)
 #endif
   }
 
-  io->type = LMIO_NULL;
-  io->handle = NULL;
+  io->type    = LMIO_NULL;
+  io->handle  = NULL;
   io->handle2 = NULL;
 
   return 0;
 } /* End of msio_fclose() */
-
 
 /*********************************************************************
  * msio_fread:
@@ -776,7 +774,6 @@ lmp_ftell64 (FILE *stream)
 #endif
 } /* End of lmp_ftell64() */
 
-
 /***************************************************************************
  * lmp_fseek64:
  *
@@ -792,7 +789,6 @@ lmp_fseek64 (FILE *stream, int64_t offset, int whence)
   return (int)fseeko (stream, offset, whence);
 #endif
 } /* End of lmp_fseeko() */
-
 
 /***************************************************************************
  * @brief Sleep for a specified number of nanoseconds
@@ -812,14 +808,14 @@ lmp_nanosleep (uint64_t nanoseconds)
 #if defined(LMP_WIN)
 
   /* SleepEx is limited to milliseconds */
-  SleepEx ((DWORD) (nanoseconds / 1e6), 1);
+  SleepEx ((DWORD)(nanoseconds / 1e6), 1);
 
   return 0;
 #else
 
   struct timespec treq, trem;
 
-  treq.tv_sec  = (time_t) (nanoseconds / 1e9);
+  treq.tv_sec = (time_t)(nanoseconds / 1e9);
   treq.tv_nsec = (long)(nanoseconds - (uint64_t)treq.tv_sec * 1e9);
 
   nanosleep (&treq, &trem);

--- a/msio.h
+++ b/msio.h
@@ -22,20 +22,21 @@
 #define MSIO_H 1
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #include "libmseed.h"
 
-extern int msio_fopen (LMIO *io, const char *path, const char *mode,
-                       int64_t *startoffset, int64_t *endoffset);
-extern int msio_fclose (LMIO *io);
-extern size_t msio_fread (LMIO *io, void *buffer, size_t size);
-extern int msio_feof (LMIO *io);
-extern int msio_url_useragent (const char *program, const char *version);
-extern int msio_url_userpassword (const char *userpassword);
-extern int msio_url_addheader (const char *header);
-extern void msio_url_freeheaders (void);
+  extern int msio_fopen (LMIO *io, const char *path, const char *mode,
+                         int64_t *startoffset, int64_t *endoffset);
+  extern int msio_fclose (LMIO *io);
+  extern size_t msio_fread (LMIO *io, void *buffer, size_t size);
+  extern int msio_feof (LMIO *io);
+  extern int msio_url_useragent (const char *program, const char *version);
+  extern int msio_url_userpassword (const char *userpassword);
+  extern int msio_url_addheader (const char *header);
+  extern void msio_url_freeheaders (void);
 
 #ifdef __cplusplus
 }

--- a/msrutils.c
+++ b/msrutils.c
@@ -26,25 +26,25 @@
 #include "libmseed.h"
 
 /**********************************************************************/ /**
- * @brief Initialize and return an ::MS3Record
- *
- * Memory is allocated if for a new ::MS3Record if \a msr is NULL.
- *
- * If memory for the \c datasamples field has been allocated the pointer
- * will be retained for reuse.  If memory for extra headers has been
- * allocated it will be released.
- *
- * @param[in] msr A ::MS3Record to re-initialize
- *
- * @returns a pointer to a ::MS3Record struct on success or NULL on error.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Initialize and return an ::MS3Record
+                                                                          *
+                                                                          * Memory is allocated if for a new ::MS3Record if \a msr is NULL.
+                                                                          *
+                                                                          * If memory for the \c datasamples field has been allocated the pointer
+                                                                          * will be retained for reuse.  If memory for extra headers has been
+                                                                          * allocated it will be released.
+                                                                          *
+                                                                          * @param[in] msr A ::MS3Record to re-initialize
+                                                                          *
+                                                                          * @returns a pointer to a ::MS3Record struct on success or NULL on error.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 MS3Record *
 msr3_init (MS3Record *msr)
 {
   void *datasamples = NULL;
-  size_t datasize = 0;
+  size_t datasize   = 0;
 
   if (!msr)
   {
@@ -53,7 +53,7 @@ msr3_init (MS3Record *msr)
   else
   {
     datasamples = msr->datasamples;
-    datasize = msr->datasize;
+    datasize    = msr->datasize;
 
     if (msr->extra)
       libmseed_memory.free (msr->extra);
@@ -68,7 +68,7 @@ msr3_init (MS3Record *msr)
   memset (msr, 0, sizeof (MS3Record));
 
   msr->datasamples = datasamples;
-  msr->datasize = datasize;
+  msr->datasize    = datasize;
 
   msr->reclen    = -1;
   msr->samplecnt = -1;
@@ -78,13 +78,13 @@ msr3_init (MS3Record *msr)
 } /* End of msr3_init() */
 
 /**********************************************************************/ /**
- * @brief Free all memory associated with a ::MS3Record
- *
- * Free all memory associated with a ::MS3Record, including extra
- * header and data samples if present.
- *
- * @param[in] ppmsr Pointer to point of the ::MS3Record to free
- ***************************************************************************/
+                                                                          * @brief Free all memory associated with a ::MS3Record
+                                                                          *
+                                                                          * Free all memory associated with a ::MS3Record, including extra
+                                                                          * header and data samples if present.
+                                                                          *
+                                                                          * @param[in] ppmsr Pointer to point of the ::MS3Record to free
+                                                                          ***************************************************************************/
 void
 msr3_free (MS3Record **ppmsr)
 {
@@ -103,26 +103,26 @@ msr3_free (MS3Record **ppmsr)
 } /* End of msr3_free() */
 
 /**********************************************************************/ /**
- * @brief Duplicate a ::MS3Record
- *
- * Extra headers are duplicated as well.
- *
- * If the \a datadup flag is true (non-zero) and the source
- * ::MS3Record has associated data samples copy them as well.
- *
- * @param[in] msr ::MS3Record to duplicate
- * @param[in] datadup Flag to control duplication of data samples
- *
- * @returns Pointer to a new ::MS3Record on success and NULL on error
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Duplicate a ::MS3Record
+                                                                          *
+                                                                          * Extra headers are duplicated as well.
+                                                                          *
+                                                                          * If the \a datadup flag is true (non-zero) and the source
+                                                                          * ::MS3Record has associated data samples copy them as well.
+                                                                          *
+                                                                          * @param[in] msr ::MS3Record to duplicate
+                                                                          * @param[in] datadup Flag to control duplication of data samples
+                                                                          *
+                                                                          * @returns Pointer to a new ::MS3Record on success and NULL on error
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 MS3Record *
 msr3_duplicate (MS3Record *msr, int8_t datadup)
 {
   MS3Record *dupmsr = 0;
-  size_t datasize = 0;
-  int samplesize = 0;
+  size_t datasize   = 0;
+  int samplesize    = 0;
 
   if (!msr)
   {
@@ -138,7 +138,7 @@ msr3_duplicate (MS3Record *msr, int8_t datadup)
   memcpy (dupmsr, msr, sizeof (MS3Record));
 
   /* Reset pointers to not alias memory held by other structures */
-  dupmsr->extra = NULL;
+  dupmsr->extra       = NULL;
   dupmsr->datasamples = NULL;
 
   /* Copy extra headers */
@@ -171,7 +171,7 @@ msr3_duplicate (MS3Record *msr, int8_t datadup)
     datasize = msr->numsamples * samplesize;
 
     /* Allocate memory for new data array */
-    if ((dupmsr->datasamples = libmseed_memory.malloc ((size_t) (datasize))) == NULL)
+    if ((dupmsr->datasamples = libmseed_memory.malloc ((size_t)(datasize))) == NULL)
     {
       ms_log (2, "Error allocating memory\n");
       msr3_free (&dupmsr);
@@ -185,29 +185,29 @@ msr3_duplicate (MS3Record *msr, int8_t datadup)
   else
   {
     dupmsr->datasamples = NULL;
-    dupmsr->datasize = 0;
-    dupmsr->numsamples = 0;
+    dupmsr->datasize    = 0;
+    dupmsr->numsamples  = 0;
   }
 
   return dupmsr;
 } /* End of msr3_duplicate() */
 
 /**********************************************************************/ /**
- * @brief Calculate time of the last sample in a record
- *
- * If leap seconds have been loaded into the internal library list:
- * when a record completely contains a leap second, starts before and
- * ends after, the calculated end time will be adjusted (reduced) by
- * one second.
- * @note On the epoch time scale the value of a leap second is the
- * same as the second following the leap second, without external
- * information the values are ambiguous.
- * \sa ms_readleapsecondfile()
- *
- * @param[in] msr ::MS3Record to calculate end time of
- *
- * @returns Time of the last sample on success and NSTERROR on error.
- ***************************************************************************/
+                                                                          * @brief Calculate time of the last sample in a record
+                                                                          *
+                                                                          * If leap seconds have been loaded into the internal library list:
+                                                                          * when a record completely contains a leap second, starts before and
+                                                                          * ends after, the calculated end time will be adjusted (reduced) by
+                                                                          * one second.
+                                                                          * @note On the epoch time scale the value of a leap second is the
+                                                                          * same as the second following the leap second, without external
+                                                                          * information the values are ambiguous.
+                                                                          * \sa ms_readleapsecondfile()
+                                                                          *
+                                                                          * @param[in] msr ::MS3Record to calculate end time of
+                                                                          *
+                                                                          * @returns Time of the last sample on success and NSTERROR on error.
+                                                                          ***************************************************************************/
 nstime_t
 msr3_endtime (MS3Record *msr)
 {
@@ -222,18 +222,17 @@ msr3_endtime (MS3Record *msr)
   return ms_sampletime (msr->starttime, sampleoffset, msr->samprate);
 } /* End of msr3_endtime() */
 
-
 /**********************************************************************/ /**
- * @brief Print header values of an MS3Record
- *
- * @param[in] msr ::MS3Record to print
- * @param[in] details Flags to control the level of details:
- * @parblock
- *  - \c 0 - print a single summary line
- *  - \c 1 - print most details of header
- *  - \c >1 - print all details of header and extra headers if present
- * @endparblock
- ***************************************************************************/
+                                                                          * @brief Print header values of an MS3Record
+                                                                          *
+                                                                          * @param[in] msr ::MS3Record to print
+                                                                          * @param[in] details Flags to control the level of details:
+                                                                          * @parblock
+                                                                          *  - \c 0 - print a single summary line
+                                                                          *  - \c 1 - print most details of header
+                                                                          *  - \c >1 - print all details of header and extra headers if present
+                                                                          * @endparblock
+                                                                          ***************************************************************************/
 void
 msr3_print (MS3Record *msr, int8_t details)
 {
@@ -253,7 +252,7 @@ msr3_print (MS3Record *msr, int8_t details)
             msr->sid, msr->pubversion, msr->reclen, msr->formatversion);
     ms_log (0, "             start time: %s\n", time);
     ms_log (0, "      number of samples: %" PRId64 "\n", msr->samplecnt);
-    ms_log (0, "       sample rate (Hz): %.10g\n", msr3_sampratehz(msr));
+    ms_log (0, "       sample rate (Hz): %.10g\n", msr3_sampratehz (msr));
 
     if (details > 1)
     {
@@ -300,17 +299,17 @@ msr3_print (MS3Record *msr, int8_t details)
 } /* End of msr3_print() */
 
 /**********************************************************************/ /**
- * @brief Resize data sample buffer of ::MS3Record to what is needed
- *
- * This routine should only be used if pre-allocation of memory, via
- * ::libmseed_prealloc_block_size, was enabled to allocate the buffer.
- *
- * @param[in] msr ::MS3Record to resize buffer
- *
- * @returns Return 0 on success, otherwise returns a libmseed error code.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Resize data sample buffer of ::MS3Record to what is needed
+                                                                          *
+                                                                          * This routine should only be used if pre-allocation of memory, via
+                                                                          * ::libmseed_prealloc_block_size, was enabled to allocate the buffer.
+                                                                          *
+                                                                          * @param[in] msr ::MS3Record to resize buffer
+                                                                          *
+                                                                          * @returns Return 0 on success, otherwise returns a libmseed error code.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 msr3_resize_buffer (MS3Record *msr)
 {
@@ -323,11 +322,11 @@ msr3_resize_buffer (MS3Record *msr)
     return MS_GENERROR;
   }
 
-  samplesize = ms_samplesize(msr->sampletype);
+  samplesize = ms_samplesize (msr->sampletype);
 
   if (samplesize && msr->datasamples && msr->numsamples > 0)
   {
-    datasize = (size_t) msr->numsamples * samplesize;
+    datasize = (size_t)msr->numsamples * samplesize;
 
     if (msr->datasize > datasize)
     {
@@ -347,12 +346,12 @@ msr3_resize_buffer (MS3Record *msr)
 } /* End of msr3_resize_buffer() */
 
 /**********************************************************************/ /**
- * @brief Calculate sample rate in samples/second (Hertz) for a given ::MS3Record
- *
- * @param[in] msr ::MS3Record to calculate sample rate for
- *
- * @returns Return sample rate in Hertz (samples per second)
- ***************************************************************************/
+                                                                          * @brief Calculate sample rate in samples/second (Hertz) for a given ::MS3Record
+                                                                          *
+                                                                          * @param[in] msr ::MS3Record to calculate sample rate for
+                                                                          *
+                                                                          * @returns Return sample rate in Hertz (samples per second)
+                                                                          ***************************************************************************/
 inline double
 msr3_sampratehz (MS3Record *msr)
 {
@@ -366,20 +365,20 @@ msr3_sampratehz (MS3Record *msr)
 } /* End of msr3_sampratehz() */
 
 /**********************************************************************/ /**
- * @brief Calculate data latency based on the host time
- *
- * Calculation is based on the time of the last sample in the record; in
- * other words, the difference between the host time and the time of
- * the last sample in the record.
- *
- * Double precision is returned, but the true precision is dependent
- * on the accuracy of the host system clock among other things.
- *
- * @param[in] msr ::MS3Record to calculate lactency for
- *
- * @returns seconds of latency or 0.0 on error (indistinguishable from
- * 0.0 latency).
- ***************************************************************************/
+                                                                          * @brief Calculate data latency based on the host time
+                                                                          *
+                                                                          * Calculation is based on the time of the last sample in the record; in
+                                                                          * other words, the difference between the host time and the time of
+                                                                          * the last sample in the record.
+                                                                          *
+                                                                          * Double precision is returned, but the true precision is dependent
+                                                                          * on the accuracy of the host system clock among other things.
+                                                                          *
+                                                                          * @param[in] msr ::MS3Record to calculate lactency for
+                                                                          *
+                                                                          * @returns seconds of latency or 0.0 on error (indistinguishable from
+                                                                          * 0.0 latency).
+                                                                          ***************************************************************************/
 double
 msr3_host_latency (MS3Record *msr)
 {

--- a/pack.c
+++ b/pack.c
@@ -24,10 +24,10 @@
 #include <string.h>
 #include <time.h>
 
+#include "extraheaders.h"
 #include "libmseed.h"
 #include "mseedformat.h"
 #include "packdata.h"
-#include "extraheaders.h"
 
 /* Internal from another source file */
 extern double ms_nomsamprate (int factor, int multiplier);
@@ -49,59 +49,58 @@ static int ms_genfactmult (double samprate, int16_t *factor, int16_t *multiplier
 
 static uint32_t ms_timestr2btime (const char *timestr, uint8_t *btime, char *sid, int8_t swapflag);
 
-
 /**********************************************************************/ /**
- * @brief Pack data into miniSEED records.
- *
- * Packing is performed according to the version at
- * @ref MS3Record.formatversion.
- *
- * The @ref MS3Record.datasamples array and @ref MS3Record.numsamples
- * value will __not__ be changed by this routine.  It is the
- * responsibility of the calling routine to adjust the data buffer if
- * desired.
- *
- * As each record is filled and finished they are passed to \a
- * record_handler() which should expect 1) a \c char* to the record,
- * 2) the length of the record and 3) a pointer supplied by the
- * original caller containing optional private data (\a handlerdata).
- * It is the responsibility of \a record_handler() to process the
- * record, the memory will be re-used or freed when \a
- * record_handler() returns.
- *
- * The following data encodings and expected @ref MS3Record.sampletype
- * are supported:
- *   - ::DE_ASCII (0), text (ASCII), expects type \c 'a'
- *   - ::DE_INT16 (1), 16-bit integer, expects type \c 'i'
- *   - ::DE_INT32 (3), 32-bit integer, expects type \c 'i'
- *   - ::DE_FLOAT32 (4), 32-bit float (IEEE), expects type \c 'f'
- *   - ::DE_FLOAT64 (5), 64-bit float (IEEE), expects type \c 'd'
- *   - ::DE_STEIM1 (10), Stiem-1 compressed integers, expects type \c 'i'
- *   - ::DE_STEIM2 (11), Stiem-2 compressed integers, expects type \c 'i'
- *
- * If \a flags has ::MSF_FLUSHDATA set, all of the data will be packed
- * into data records even though the last one will probably be smaller
- * than requested or, in the case of miniSEED 2, unfilled.
- *
- * Default values are: record length = 4096, encoding = 11 (Steim2).
- * The defaults are triggered when \a msr.reclen and \a msr.encoding
- * are set to -1.
- *
- * @param[in] msr ::MS3Record containing data to pack
- * @param[in] record_handler() Callback function called for each record
- * @param[in] handlerdata A pointer that will be provided to the \a record_handler()
- * @param[out] packedsamples The number of samples packed, returned to caller
- * @param[in] flags Bit flags used to control the packing process:
- * @parblock
- *  - \c ::MSF_FLUSHDATA : Pack all data in the buffer
- *  - \c ::MSF_PACKVER2 : Pack miniSEED version 2 regardless of ::MS3Record.formatversion
- * @endparblock
- * @param[in] verbose Controls logging verbosity, 0 is no diagnostic output
- *
- * @returns the number of records created on success and -1 on error.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Pack data into miniSEED records.
+                                                                          *
+                                                                          * Packing is performed according to the version at
+                                                                          * @ref MS3Record.formatversion.
+                                                                          *
+                                                                          * The @ref MS3Record.datasamples array and @ref MS3Record.numsamples
+                                                                          * value will __not__ be changed by this routine.  It is the
+                                                                          * responsibility of the calling routine to adjust the data buffer if
+                                                                          * desired.
+                                                                          *
+                                                                          * As each record is filled and finished they are passed to \a
+                                                                          * record_handler() which should expect 1) a \c char* to the record,
+                                                                          * 2) the length of the record and 3) a pointer supplied by the
+                                                                          * original caller containing optional private data (\a handlerdata).
+                                                                          * It is the responsibility of \a record_handler() to process the
+                                                                          * record, the memory will be re-used or freed when \a
+                                                                          * record_handler() returns.
+                                                                          *
+                                                                          * The following data encodings and expected @ref MS3Record.sampletype
+                                                                          * are supported:
+                                                                          *   - ::DE_ASCII (0), text (ASCII), expects type \c 'a'
+                                                                          *   - ::DE_INT16 (1), 16-bit integer, expects type \c 'i'
+                                                                          *   - ::DE_INT32 (3), 32-bit integer, expects type \c 'i'
+                                                                          *   - ::DE_FLOAT32 (4), 32-bit float (IEEE), expects type \c 'f'
+                                                                          *   - ::DE_FLOAT64 (5), 64-bit float (IEEE), expects type \c 'd'
+                                                                          *   - ::DE_STEIM1 (10), Stiem-1 compressed integers, expects type \c 'i'
+                                                                          *   - ::DE_STEIM2 (11), Stiem-2 compressed integers, expects type \c 'i'
+                                                                          *
+                                                                          * If \a flags has ::MSF_FLUSHDATA set, all of the data will be packed
+                                                                          * into data records even though the last one will probably be smaller
+                                                                          * than requested or, in the case of miniSEED 2, unfilled.
+                                                                          *
+                                                                          * Default values are: record length = 4096, encoding = 11 (Steim2).
+                                                                          * The defaults are triggered when \a msr.reclen and \a msr.encoding
+                                                                          * are set to -1.
+                                                                          *
+                                                                          * @param[in] msr ::MS3Record containing data to pack
+                                                                          * @param[in] record_handler() Callback function called for each record
+                                                                          * @param[in] handlerdata A pointer that will be provided to the \a record_handler()
+                                                                          * @param[out] packedsamples The number of samples packed, returned to caller
+                                                                          * @param[in] flags Bit flags used to control the packing process:
+                                                                          * @parblock
+                                                                          *  - \c ::MSF_FLUSHDATA : Pack all data in the buffer
+                                                                          *  - \c ::MSF_PACKVER2 : Pack miniSEED version 2 regardless of ::MS3Record.formatversion
+                                                                          * @endparblock
+                                                                          * @param[in] verbose Controls logging verbosity, 0 is no diagnostic output
+                                                                          *
+                                                                          * @returns the number of records created on success and -1 on error.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 msr3_pack (MS3Record *msr, void (*record_handler) (char *, int, void *),
            void *handlerdata, int64_t *packedsamples, uint32_t flags, int8_t verbose)
@@ -162,8 +161,8 @@ msr3_pack_mseed3 (MS3Record *msr, void (*record_handler) (char *, int, void *),
                   void *handlerdata, int64_t *packedsamples,
                   uint32_t flags, int8_t verbose)
 {
-  char *rawrec = NULL;
-  char *encoded = NULL;  /* Separate encoded data buffer for alignment */
+  char *rawrec  = NULL;
+  char *encoded = NULL; /* Separate encoded data buffer for alignment */
   int8_t swapflag;
   int dataoffset = 0;
 
@@ -198,10 +197,10 @@ msr3_pack_mseed3 (MS3Record *msr, void (*record_handler) (char *, int, void *),
     return -1;
   }
 
-  if (msr->reclen < (MS3FSDH_LENGTH + strlen(msr->sid) + msr->extralength))
+  if (msr->reclen < (MS3FSDH_LENGTH + strlen (msr->sid) + msr->extralength))
   {
-    ms_log (2, "%s: Record length (%d) is not large enough for header (%d), SID (%"PRIsize_t"), and extra (%d)\n",
-            msr->sid, msr->reclen, MS3FSDH_LENGTH, strlen(msr->sid), msr->extralength);
+    ms_log (2, "%s: Record length (%d) is not large enough for header (%d), SID (%" PRIsize_t "), and extra (%d)\n",
+            msr->sid, msr->reclen, MS3FSDH_LENGTH, strlen (msr->sid), msr->extralength);
     return -1;
   }
 
@@ -230,12 +229,12 @@ msr3_pack_mseed3 (MS3Record *msr, void (*record_handler) (char *, int, void *),
   if (msr->numsamples <= 0)
   {
     /* Set encoding to ASCII for consistency and to reduce expectations */
-    *pMS3FSDH_ENCODING(rawrec) = DE_ASCII;
+    *pMS3FSDH_ENCODING (rawrec) = DE_ASCII;
 
     /* Calculate CRC (with CRC field set to 0) and set */
-    memset (pMS3FSDH_CRC(rawrec), 0, sizeof(uint32_t));
-    crc = ms_crc32c ((const uint8_t*)rawrec, dataoffset, 0);
-    *pMS3FSDH_CRC(rawrec) = HO4u (crc, swapflag);
+    memset (pMS3FSDH_CRC (rawrec), 0, sizeof (uint32_t));
+    crc                    = ms_crc32c ((const uint8_t *)rawrec, dataoffset, 0);
+    *pMS3FSDH_CRC (rawrec) = HO4u (crc, swapflag);
 
     if (verbose >= 1)
       ms_log (0, "%s: Packed %d byte record with no payload\n", msr->sid, dataoffset);
@@ -290,7 +289,7 @@ msr3_pack_mseed3 (MS3Record *msr, void (*record_handler) (char *, int, void *),
 
   /* Pack samples into records */
   totalpackedsamples = 0;
-  packoffset = 0;
+  packoffset         = 0;
   if (packedsamples)
     *packedsamples = 0;
 
@@ -317,13 +316,13 @@ msr3_pack_mseed3 (MS3Record *msr, void (*record_handler) (char *, int, void *),
     memcpy (rawrec + dataoffset, encoded, datalength);
 
     /* Update number of samples and data length */
-    *pMS3FSDH_NUMSAMPLES(rawrec) = HO4u (packsamples, swapflag);
-    *pMS3FSDH_DATALENGTH(rawrec) = HO2u (datalength, swapflag);
+    *pMS3FSDH_NUMSAMPLES (rawrec) = HO4u (packsamples, swapflag);
+    *pMS3FSDH_DATALENGTH (rawrec) = HO2u (datalength, swapflag);
 
     /* Calculate CRC (with CRC field set to 0) and set */
-    memset (pMS3FSDH_CRC(rawrec), 0, sizeof(uint32_t));
-    crc = ms_crc32c ((const uint8_t*)rawrec, reclen, 0);
-    *pMS3FSDH_CRC(rawrec) = HO4u (crc, swapflag);
+    memset (pMS3FSDH_CRC (rawrec), 0, sizeof (uint32_t));
+    crc                    = ms_crc32c ((const uint8_t *)rawrec, reclen, 0);
+    *pMS3FSDH_CRC (rawrec) = HO4u (crc, swapflag);
 
     if (verbose >= 1)
       ms_log (0, "%s: Packed %d samples into %d byte record\n", msr->sid, packsamples, reclen);
@@ -352,10 +351,10 @@ msr3_pack_mseed3 (MS3Record *msr, void (*record_handler) (char *, int, void *),
 
     *pMS3FSDH_NSEC (rawrec) = HO4u (nsec, swapflag);
     *pMS3FSDH_YEAR (rawrec) = HO2u (year, swapflag);
-    *pMS3FSDH_DAY (rawrec) = HO2u (day, swapflag);
+    *pMS3FSDH_DAY (rawrec)  = HO2u (day, swapflag);
     *pMS3FSDH_HOUR (rawrec) = hour;
-    *pMS3FSDH_MIN (rawrec) = min;
-    *pMS3FSDH_SEC (rawrec) = sec;
+    *pMS3FSDH_MIN (rawrec)  = min;
+    *pMS3FSDH_SEC (rawrec)  = sec;
   }
 
   if (verbose >= 2)
@@ -370,24 +369,24 @@ msr3_pack_mseed3 (MS3Record *msr, void (*record_handler) (char *, int, void *),
 } /* End of msr3_pack_mseed3() */
 
 /**********************************************************************/ /**
- * @brief Repack a parsed miniSEED record into a version 3 record.
- *
- * Pack the parsed header into a version 3 header and copy the raw
- * encoded data from the original record.  The original record must be
- * available at the ::MS3Record.record pointer.
- *
- * This can be used to efficiently convert format versions or modify
- * header values without unpacking the data samples.
- *
- * @param[in] msr ::MS3Record containing record to repack
- * @param[out] record Destination buffer for repacked record
- * @param[in] recbuflen Length of destination buffer
- * @param[in] verbose Controls logging verbosity, 0 is no diagnostic output
- *
- * @returns record length on success and -1 on error.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Repack a parsed miniSEED record into a version 3 record.
+                                                                          *
+                                                                          * Pack the parsed header into a version 3 header and copy the raw
+                                                                          * encoded data from the original record.  The original record must be
+                                                                          * available at the ::MS3Record.record pointer.
+                                                                          *
+                                                                          * This can be used to efficiently convert format versions or modify
+                                                                          * header values without unpacking the data samples.
+                                                                          *
+                                                                          * @param[in] msr ::MS3Record containing record to repack
+                                                                          * @param[out] record Destination buffer for repacked record
+                                                                          * @param[in] recbuflen Length of destination buffer
+                                                                          * @param[in] verbose Controls logging verbosity, 0 is no diagnostic output
+                                                                          *
+                                                                          * @returns record length on success and -1 on error.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 msr3_repack_mseed3 (MS3Record *msr, char *record, uint32_t recbuflen,
                     int8_t verbose)
@@ -399,7 +398,7 @@ msr3_repack_mseed3 (MS3Record *msr, char *record, uint32_t recbuflen,
   uint32_t reclen;
   int8_t swapflag;
 
-  if (!msr || ! record)
+  if (!msr || !record)
   {
     ms_log (2, "Required argument not defined: 'msr' or 'record'\n");
     return -1;
@@ -451,13 +450,13 @@ msr3_repack_mseed3 (MS3Record *msr, char *record, uint32_t recbuflen,
   swapflag = (ms_bigendianhost ()) ? 1 : 0;
 
   /* Update number of samples and data length */
-  *pMS3FSDH_NUMSAMPLES(record) = HO4u ((uint32_t)msr->samplecnt, swapflag);
-  *pMS3FSDH_DATALENGTH(record) = HO2u (origdatasize, swapflag);
+  *pMS3FSDH_NUMSAMPLES (record) = HO4u ((uint32_t)msr->samplecnt, swapflag);
+  *pMS3FSDH_DATALENGTH (record) = HO2u (origdatasize, swapflag);
 
   /* Calculate CRC (with CRC field set to 0) and set */
-  memset (pMS3FSDH_CRC(record), 0, sizeof(uint32_t));
-  crc = ms_crc32c ((const uint8_t*)record, reclen, 0);
-  *pMS3FSDH_CRC(record) = HO4u (crc, swapflag);
+  memset (pMS3FSDH_CRC (record), 0, sizeof (uint32_t));
+  crc                    = ms_crc32c ((const uint8_t *)record, reclen, 0);
+  *pMS3FSDH_CRC (record) = HO4u (crc, swapflag);
 
   if (verbose >= 1)
     ms_log (0, "%s: Repacked %" PRId64 " samples into a %u byte record\n",
@@ -467,21 +466,21 @@ msr3_repack_mseed3 (MS3Record *msr, char *record, uint32_t recbuflen,
 } /* End of msr3_repack_mseed3() */
 
 /**********************************************************************/ /**
- * @brief Pack a miniSEED version 3 header into the specified buffer.
- *
- * Default values are: record length = 4096, encoding = 11 (Steim2).
- * The defaults are triggered when \a msr.reclen and \a msr.encoding
- * are set to -1.
- *
- * @param[in] msr ::MS3Record to pack
- * @param[out] record Destination for packed header
- * @param[in] recbuflen Length of destination buffer
- * @param[in] verbose Controls logging verbosity, 0 is no diagnostic output
- *
- * @returns the size of the header (fixed and extra) on success, otherwise -1.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Pack a miniSEED version 3 header into the specified buffer.
+                                                                          *
+                                                                          * Default values are: record length = 4096, encoding = 11 (Steim2).
+                                                                          * The defaults are triggered when \a msr.reclen and \a msr.encoding
+                                                                          * are set to -1.
+                                                                          *
+                                                                          * @param[in] msr ::MS3Record to pack
+                                                                          * @param[out] record Destination for packed header
+                                                                          * @param[in] recbuflen Length of destination buffer
+                                                                          * @param[in] verbose Controls logging verbosity, 0 is no diagnostic output
+                                                                          *
+                                                                          * @returns the size of the header (fixed and extra) on success, otherwise -1.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 msr3_pack_header3 (MS3Record *msr, char *record, uint32_t recbuflen, int8_t verbose)
 {
@@ -518,7 +517,7 @@ msr3_pack_header3 (MS3Record *msr, char *record, uint32_t recbuflen, int8_t verb
 
   if (recbuflen < (uint32_t)(MS3FSDH_LENGTH + sidlength + msr->extralength))
   {
-    ms_log (2, "%s: Buffer length (%d) is not large enough for fixed header (%d), SID (%"PRIsize_t"), and extra (%d)\n",
+    ms_log (2, "%s: Buffer length (%d) is not large enough for fixed header (%d), SID (%" PRIsize_t "), and extra (%d)\n",
             msr->sid, msr->reclen, MS3FSDH_LENGTH, sidlength, msr->extralength);
     return -1;
   }
@@ -539,35 +538,35 @@ msr3_pack_header3 (MS3Record *msr, char *record, uint32_t recbuflen, int8_t verb
   /* Ensure that SID length fits in format, which uses data type uint8_t */
   if (sidlength > 255)
   {
-    ms_log (2, "%s: Source ID too long: %"PRIsize_t" bytes\n", msr->sid, sidlength);
+    ms_log (2, "%s: Source ID too long: %" PRIsize_t " bytes\n", msr->sid, sidlength);
     return -1;
   }
 
   extraoffset = MS3FSDH_LENGTH + sidlength;
 
   /* Build fixed header */
-  record[0] = 'M';
-  record[1] = 'S';
+  record[0]                        = 'M';
+  record[1]                        = 'S';
   *pMS3FSDH_FORMATVERSION (record) = 3;
-  *pMS3FSDH_FLAGS (record) = msr->flags;
-  *pMS3FSDH_NSEC (record) = HO4u (nsec, swapflag);
-  *pMS3FSDH_YEAR (record) = HO2u (year, swapflag);
-  *pMS3FSDH_DAY (record) = HO2u (day, swapflag);
-  *pMS3FSDH_HOUR (record) = hour;
-  *pMS3FSDH_MIN (record) = min;
-  *pMS3FSDH_SEC (record) = sec;
-  *pMS3FSDH_ENCODING (record) = msr->encoding;
+  *pMS3FSDH_FLAGS (record)         = msr->flags;
+  *pMS3FSDH_NSEC (record)          = HO4u (nsec, swapflag);
+  *pMS3FSDH_YEAR (record)          = HO2u (year, swapflag);
+  *pMS3FSDH_DAY (record)           = HO2u (day, swapflag);
+  *pMS3FSDH_HOUR (record)          = hour;
+  *pMS3FSDH_MIN (record)           = min;
+  *pMS3FSDH_SEC (record)           = sec;
+  *pMS3FSDH_ENCODING (record)      = msr->encoding;
 
   /* If rate positive and less than one, convert to period notation */
   if (msr->samprate != 0.0 && msr->samprate > 0 && msr->samprate < 1.0)
-    *pMS3FSDH_SAMPLERATE(record) = HO8f((-1.0 / msr->samprate), swapflag);
+    *pMS3FSDH_SAMPLERATE (record) = HO8f ((-1.0 / msr->samprate), swapflag);
   else
-    *pMS3FSDH_SAMPLERATE(record) = HO8f(msr->samprate, swapflag);
+    *pMS3FSDH_SAMPLERATE (record) = HO8f (msr->samprate, swapflag);
 
-  *pMS3FSDH_PUBVERSION(record) = msr->pubversion;
-  *pMS3FSDH_SIDLENGTH(record) = (uint8_t)sidlength;
-  *pMS3FSDH_EXTRALENGTH(record) = HO2u(msr->extralength, swapflag);
-  memcpy (pMS3FSDH_SID(record), msr->sid, sidlength);
+  *pMS3FSDH_PUBVERSION (record)  = msr->pubversion;
+  *pMS3FSDH_SIDLENGTH (record)   = (uint8_t)sidlength;
+  *pMS3FSDH_EXTRALENGTH (record) = HO2u (msr->extralength, swapflag);
+  memcpy (pMS3FSDH_SID (record), msr->sid, sidlength);
 
   if (msr->extralength > 0)
     memcpy (record + extraoffset, msr->extra, msr->extralength);
@@ -589,8 +588,8 @@ msr3_pack_mseed2 (MS3Record *msr, void (*record_handler) (char *, int, void *),
                   void *handlerdata, int64_t *packedsamples,
                   uint32_t flags, int8_t verbose)
 {
-  char *rawrec = NULL;
-  char *encoded = NULL;  /* Separate encoded data buffer for alignment */
+  char *rawrec  = NULL;
+  char *encoded = NULL; /* Separate encoded data buffer for alignment */
   int8_t swapflag;
   int dataoffset = 0;
   int headerlen;
@@ -705,7 +704,7 @@ msr3_pack_mseed2 (MS3Record *msr, void (*record_handler) (char *, int, void *),
   }
 
   /* Set data offset in header */
-  *pMS2FSDH_DATAOFFSET(rawrec) = HO2u (dataoffset, swapflag);
+  *pMS2FSDH_DATAOFFSET (rawrec) = HO2u (dataoffset, swapflag);
 
   /* Determine the max data bytes and sample count */
   maxdatabytes = msr->reclen - dataoffset;
@@ -738,7 +737,7 @@ msr3_pack_mseed2 (MS3Record *msr, void (*record_handler) (char *, int, void *),
 
   /* Pack samples into records */
   totalpackedsamples = 0;
-  packoffset = 0;
+  packoffset         = 0;
   if (packedsamples)
     *packedsamples = 0;
 
@@ -764,7 +763,7 @@ msr3_pack_mseed2 (MS3Record *msr, void (*record_handler) (char *, int, void *),
     memcpy (rawrec + dataoffset, encoded, datalength);
 
     /* Update number of samples */
-    *pMS2FSDH_NUMSAMPLES(rawrec) = HO2u (packsamples, swapflag);
+    *pMS2FSDH_NUMSAMPLES (rawrec) = HO2u (packsamples, swapflag);
 
     if (verbose >= 1)
       ms_log (0, "%s: Packed %d samples into %d byte record\n", msr->sid, packsamples, msr->reclen);
@@ -812,21 +811,21 @@ msr3_pack_mseed2 (MS3Record *msr, void (*record_handler) (char *, int, void *),
 } /* End of msr3_pack_mseed2() */
 
 /**********************************************************************/ /**
- * @brief Pack a miniSEED version 2 header into the specified buffer.
- *
- * Default values are: record length = 4096, encoding = 11 (Steim2).
- * The defaults are triggered when \a msr.reclen and \a msr.encoding
- * are set to -1.
- *
- * @param[in] msr ::MS3Record to pack
- * @param[out] record Destination for packed header
- * @param[in] recbuflen Length of destination buffer
- * @param[in] verbose Controls logging verbosity, 0 is no diagnostic output
- *
- * @returns the size of the header (fixed and blockettes) on success, otherwise -1.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Pack a miniSEED version 2 header into the specified buffer.
+                                                                          *
+                                                                          * Default values are: record length = 4096, encoding = 11 (Steim2).
+                                                                          * The defaults are triggered when \a msr.reclen and \a msr.encoding
+                                                                          * are set to -1.
+                                                                          *
+                                                                          * @param[in] msr ::MS3Record to pack
+                                                                          * @param[out] record Destination for packed header
+                                                                          * @param[in] recbuflen Length of destination buffer
+                                                                          * @param[in] verbose Controls logging verbosity, 0 is no diagnostic output
+                                                                          *
+                                                                          * @returns the size of the header (fixed and blockettes) on success, otherwise -1.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 msr3_pack_header2 (MS3Record *msr, char *record, uint32_t recbuflen, int8_t verbose)
 {
@@ -933,11 +932,11 @@ msr3_pack_header2 (MS3Record *msr, char *record, uint32_t recbuflen, int8_t verb
   }
 
   /* Calculate time at fractional 100usec resolution and microsecond offset */
-  fsec = nsec / 100000;
+  fsec        = nsec / 100000;
   msec_offset = ((nsec / 1000) - (fsec * 100));
 
   /* Generate factor & multipler representation of sample rate */
-  if (ms_genfactmult (msr3_sampratehz(msr), &factor, &multiplier))
+  if (ms_genfactmult (msr3_sampratehz (msr), &factor, &multiplier))
   {
     ms_log (2, "%s: Cannot convert sample rate (%g) to factor and multiplier\n", msr->sid, msr->samprate);
     return -1;
@@ -1076,14 +1075,14 @@ msr3_pack_header2 (MS3Record *msr, char *record, uint32_t recbuflen, int8_t verb
   if (yyjson_get_num_pointer (ehroot, "/FDSN/Time/Quality", &header_number) || msec_offset)
   {
     *next_blockette = HO2u ((uint16_t)written, swapflag);
-    next_blockette = pMS2B1001_NEXT (record + written);
+    next_blockette  = pMS2B1001_NEXT (record + written);
     *pMS2FSDH_NUMBLOCKETTES (record) += 1;
 
     *pMS2B1001_TYPE (record + written) = HO2u (1001, swapflag);
     *pMS2B1001_NEXT (record + written) = 0;
 
     if (yyjson_get_num_pointer (ehroot, "/FDSN/Time/Quality", &header_number))
-      *pMS2B1001_TIMINGQUALITY (record + written) = (uint8_t) (header_number + 0.5);
+      *pMS2B1001_TIMINGQUALITY (record + written) = (uint8_t)(header_number + 0.5);
     else
       *pMS2B1001_TIMINGQUALITY (record + written) = 0;
 
@@ -1095,10 +1094,10 @@ msr3_pack_header2 (MS3Record *msr, char *record, uint32_t recbuflen, int8_t verb
   }
 
   /* Add Blockette 100 if sample rate is not well represented by factor/multiplier */
-  if (ms_dabs(msr3_sampratehz(msr) - ms_nomsamprate(factor, multiplier)) > 0.0001)
+  if (ms_dabs (msr3_sampratehz (msr) - ms_nomsamprate (factor, multiplier)) > 0.0001)
   {
     *next_blockette = HO2u ((uint16_t)written, swapflag);
-    next_blockette = pMS2B100_NEXT (record + written);
+    next_blockette  = pMS2B100_NEXT (record + written);
     *pMS2FSDH_NUMBLOCKETTES (record) += 1;
 
     *pMS2B100_TYPE (record + written)     = HO2u (100, swapflag);
@@ -1186,16 +1185,16 @@ msr3_pack_header2 (MS3Record *msr, char *record, uint32_t recbuflen, int8_t verb
       if ((ehval = yyjson_get_pointer (ehiterval, "/Type")) && yyjson_is_str (ehval) &&
           strncasecmp (yyjson_get_str (ehval), "MURDOCK", 6) == 0)
       {
-        blockette_type = 201;
+        blockette_type   = 201;
         blockette_length = 60;
       }
       else
       {
-        blockette_type = 200;
+        blockette_type   = 200;
         blockette_length = 52;
       }
 
-      if ((recbuflen - written) < blockette_length )
+      if ((recbuflen - written) < blockette_length)
       {
         ms_log (2, "%s: Record length not large enough for B%d\n", msr->sid, blockette_type);
         yyjson_doc_free (ehdoc);
@@ -1204,7 +1203,7 @@ msr3_pack_header2 (MS3Record *msr, char *record, uint32_t recbuflen, int8_t verb
 
       /* The initial fields of B200 and B201 are the same */
       *next_blockette = HO2u ((uint16_t)written, swapflag);
-      next_blockette = pMS2B200_NEXT (record + written);
+      next_blockette  = pMS2B200_NEXT (record + written);
       *pMS2FSDH_NUMBLOCKETTES (record) += 1;
 
       memset (record + written, 0, blockette_length);
@@ -1325,7 +1324,7 @@ msr3_pack_header2 (MS3Record *msr, char *record, uint32_t recbuflen, int8_t verb
       }
       else if ((ehval = yyjson_get_pointer (ehiterval, "/EndTime")))
       {
-        blockette_type = 395;
+        blockette_type   = 395;
         blockette_length = 16;
       }
 
@@ -1336,7 +1335,7 @@ msr3_pack_header2 (MS3Record *msr, char *record, uint32_t recbuflen, int8_t verb
         return -1;
       }
 
-      if ((recbuflen - written) < blockette_length )
+      if ((recbuflen - written) < blockette_length)
       {
         ms_log (2, "%s: Record length not large enough for B%d\n", msr->sid, blockette_type);
         yyjson_doc_free (ehdoc);
@@ -1504,7 +1503,7 @@ msr3_pack_header2 (MS3Record *msr, char *record, uint32_t recbuflen, int8_t verb
       /* Add Blockette 395 if EndTime is included */
       if ((ehval = yyjson_get_pointer (ehiterval, "/EndTime")) && yyjson_is_str (ehval))
       {
-        blockette_type  = 395;
+        blockette_type   = 395;
         blockette_length = 16;
 
         if ((recbuflen - written) < blockette_length)
@@ -1599,10 +1598,10 @@ msr_pack_data (void *dest, void *src, int maxsamples, int maxdatabytes,
       return -1;
     }
 
-    if (maxdatabytes < sizeof(int16_t))
+    if (maxdatabytes < sizeof (int16_t))
     {
-      ms_log (2, "%s: Not enough space in record (%d) for INT16 encoding, need at least %"PRIsize_t" bytes\n",
-              sid, maxdatabytes, sizeof(int16_t));
+      ms_log (2, "%s: Not enough space in record (%d) for INT16 encoding, need at least %" PRIsize_t " bytes\n",
+              sid, maxdatabytes, sizeof (int16_t));
       return -1;
     }
 
@@ -1624,10 +1623,10 @@ msr_pack_data (void *dest, void *src, int maxsamples, int maxdatabytes,
       return -1;
     }
 
-    if (maxdatabytes < sizeof(int32_t))
+    if (maxdatabytes < sizeof (int32_t))
     {
-      ms_log (2, "%s: Not enough space in record (%d) for INT32 encoding, need at least %"PRIsize_t" bytes\n",
-              sid, maxdatabytes, sizeof(int32_t));
+      ms_log (2, "%s: Not enough space in record (%d) for INT32 encoding, need at least %" PRIsize_t " bytes\n",
+              sid, maxdatabytes, sizeof (int32_t));
       return -1;
     }
 
@@ -1649,10 +1648,10 @@ msr_pack_data (void *dest, void *src, int maxsamples, int maxdatabytes,
       return -1;
     }
 
-    if (maxdatabytes < sizeof(float))
+    if (maxdatabytes < sizeof (float))
     {
-      ms_log (2, "%s: Not enough space in record (%d) for FLOAT32 encoding, need at least %"PRIsize_t" bytes\n",
-              sid, maxdatabytes, sizeof(float));
+      ms_log (2, "%s: Not enough space in record (%d) for FLOAT32 encoding, need at least %" PRIsize_t " bytes\n",
+              sid, maxdatabytes, sizeof (float));
       return -1;
     }
 
@@ -1674,10 +1673,10 @@ msr_pack_data (void *dest, void *src, int maxsamples, int maxdatabytes,
       return -1;
     }
 
-    if (maxdatabytes < sizeof(double))
+    if (maxdatabytes < sizeof (double))
     {
-      ms_log (2, "%s: Not enough space in record (%d) for FLOAT64 encoding, need at least %"PRIsize_t" bytes\n",
-              sid, maxdatabytes, sizeof(double));
+      ms_log (2, "%s: Not enough space in record (%d) for FLOAT64 encoding, need at least %" PRIsize_t " bytes\n",
+              sid, maxdatabytes, sizeof (double));
       return -1;
     }
 
@@ -1710,7 +1709,7 @@ msr_pack_data (void *dest, void *src, int maxsamples, int maxdatabytes,
       ms_log (0, "%s: Packing Steim1 data frames\n", sid);
 
     /* Always big endian Steim1 */
-    swapflag = (ms_bigendianhost()) ? 0 : 1;
+    swapflag = (ms_bigendianhost ()) ? 0 : 1;
 
     nsamples = msr_encode_steim1 ((int32_t *)src, maxsamples, (int32_t *)dest, maxdatabytes, 0, byteswritten, swapflag);
 
@@ -1735,7 +1734,7 @@ msr_pack_data (void *dest, void *src, int maxsamples, int maxdatabytes,
       ms_log (0, "%s: Packing Steim2 data frames\n", sid);
 
     /* Always big endian Steim2 */
-    swapflag = (ms_bigendianhost()) ? 0 : 1;
+    swapflag = (ms_bigendianhost ()) ? 0 : 1;
 
     nsamples = msr_encode_steim2 ((int32_t *)src, maxsamples, (int32_t *)dest, maxdatabytes, 0, byteswritten, sid, swapflag);
 
@@ -1888,7 +1887,7 @@ ms_reduce_rate (double samprate, int16_t *factor1, int16_t *factor2)
 {
   int num;
   int den;
-  int32_t intsamprate = (int32_t) (samprate + 0.5);
+  int32_t intsamprate = (int32_t)(samprate + 0.5);
 
   int32_t searchfactor1;
   int32_t searchfactor2;

--- a/packdata.c
+++ b/packdata.c
@@ -266,7 +266,8 @@ msr_encode_steim1 (int32_t *input, int samplecount, int32_t *output,
   int widx;
   int idx;
 
-  union dword {
+  union dword
+  {
     int8_t d8[4];
     int16_t d16[2];
     int32_t d32;
@@ -461,7 +462,8 @@ msr_encode_steim2 (int32_t *input, int samplecount, int32_t *output,
   int widx;
   int idx;
 
-  union dword {
+  union dword
+  {
     int8_t d8[4];
     int16_t d16[2];
     int32_t d32;

--- a/packdata.h
+++ b/packdata.h
@@ -23,7 +23,8 @@
 #define PACKDATA_H 1
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #include "libmseed.h"
@@ -31,25 +32,25 @@ extern "C" {
 #define STEIM1_FRAME_MAX_SAMPLES 60
 #define STEIM2_FRAME_MAX_SAMPLES 105
 
-/* Control for printing debugging information, declared in packdata.c */
-extern int libmseed_encodedebug;
+  /* Control for printing debugging information, declared in packdata.c */
+  extern int libmseed_encodedebug;
 
-extern int msr_encode_text (char *input, int samplecount, char *output,
-                            int outputlength);
-extern int msr_encode_int16 (int32_t *input, int samplecount, int16_t *output,
-                             int outputlength, int swapflag);
-extern int msr_encode_int32 (int32_t *input, int samplecount, int32_t *output,
-                             int outputlength, int swapflag);
-extern int msr_encode_float32 (float *input, int samplecount, float *output,
+  extern int msr_encode_text (char *input, int samplecount, char *output,
+                              int outputlength);
+  extern int msr_encode_int16 (int32_t *input, int samplecount, int16_t *output,
                                int outputlength, int swapflag);
-extern int msr_encode_float64 (double *input, int samplecount, double *output,
+  extern int msr_encode_int32 (int32_t *input, int samplecount, int32_t *output,
                                int outputlength, int swapflag);
-extern int msr_encode_steim1 (int32_t *input, int samplecount, int32_t *output,
-                              int outputlength, int32_t diff0, uint16_t *byteswritten,
-                              int swapflag);
-extern int msr_encode_steim2 (int32_t *input, int samplecount, int32_t *output,
-                              int outputlength, int32_t diff0, uint16_t *byteswritten,
-                              char *sid, int swapflag);
+  extern int msr_encode_float32 (float *input, int samplecount, float *output,
+                                 int outputlength, int swapflag);
+  extern int msr_encode_float64 (double *input, int samplecount, double *output,
+                                 int outputlength, int swapflag);
+  extern int msr_encode_steim1 (int32_t *input, int samplecount, int32_t *output,
+                                int outputlength, int32_t diff0, uint16_t *byteswritten,
+                                int swapflag);
+  extern int msr_encode_steim2 (int32_t *input, int samplecount, int32_t *output,
+                                int outputlength, int32_t diff0, uint16_t *byteswritten,
+                                char *sid, int swapflag);
 
 #ifdef __cplusplus
 }

--- a/parseutils.c
+++ b/parseutils.c
@@ -25,44 +25,44 @@
 #include <time.h>
 
 #include "libmseed.h"
-#include "unpack.h"
 #include "mseedformat.h"
+#include "unpack.h"
 
 /***********************************************************************/ /**
- * @brief Parse miniSEED from a buffer
- *
- * This routine will attempt to parse (detect and unpack) a miniSEED
- * record from a specified memory buffer and populate a supplied
- * ::MS3Record structure.  Both miniSEED 2.x and 3.x records are
- * supported.
- *
- * The record length is automatically detected.  For miniSEED 2.x this
- * means the record must contain a 1000 blockette.
- *
- * @param record Buffer containing record to parse
- * @param recbuflen Buffer length in bytes
- * @param ppmsr Pointer-to-point to a ::MS3Record that will be populated
- * @param flags Flags controlling features:
- * @parblock
- *  - \c ::MSF_UNPACKDATA - Unpack data samples
- *  - \c ::MSF_VALIDATECRC Validate CRC (if present in format)
- * @endparblock
- * @param verbose control verbosity of diagnostic output
- *
- * @return Parsing status
- * @retval 0 Success, populates the supplied ::MS3Record.
- * @retval >0 Data record detected but not enough data is present, the
- *       return value is a hint of how many more bytes are needed.
- * @retval <0 library error code is returned.
- *
- * \ref MessageOnError - this function logs a message on error except MS_NOTSEED
- ***************************************************************************/
+                                                                           * @brief Parse miniSEED from a buffer
+                                                                           *
+                                                                           * This routine will attempt to parse (detect and unpack) a miniSEED
+                                                                           * record from a specified memory buffer and populate a supplied
+                                                                           * ::MS3Record structure.  Both miniSEED 2.x and 3.x records are
+                                                                           * supported.
+                                                                           *
+                                                                           * The record length is automatically detected.  For miniSEED 2.x this
+                                                                           * means the record must contain a 1000 blockette.
+                                                                           *
+                                                                           * @param record Buffer containing record to parse
+                                                                           * @param recbuflen Buffer length in bytes
+                                                                           * @param ppmsr Pointer-to-point to a ::MS3Record that will be populated
+                                                                           * @param flags Flags controlling features:
+                                                                           * @parblock
+                                                                           *  - \c ::MSF_UNPACKDATA - Unpack data samples
+                                                                           *  - \c ::MSF_VALIDATECRC Validate CRC (if present in format)
+                                                                           * @endparblock
+                                                                           * @param verbose control verbosity of diagnostic output
+                                                                           *
+                                                                           * @return Parsing status
+                                                                           * @retval 0 Success, populates the supplied ::MS3Record.
+                                                                           * @retval >0 Data record detected but not enough data is present, the
+                                                                           *       return value is a hint of how many more bytes are needed.
+                                                                           * @retval <0 library error code is returned.
+                                                                           *
+                                                                           * \ref MessageOnError - this function logs a message on error except MS_NOTSEED
+                                                                           ***************************************************************************/
 int
 msr3_parse (char *record, uint64_t recbuflen, MS3Record **ppmsr,
             uint32_t flags, int8_t verbose)
 {
-  int reclen  = 0;
-  int retcode = MS_NOERROR;
+  int reclen            = 0;
+  int retcode           = MS_NOERROR;
   uint8_t formatversion = 0;
 
   if (!ppmsr || !record)
@@ -154,32 +154,32 @@ msr3_parse (char *record, uint64_t recbuflen, MS3Record **ppmsr,
 } /* End of msr3_parse() */
 
 /***************************************************************/ /**
- * @brief Detect miniSEED record in buffer
- *
- * Determine if the buffer contains a miniSEED data record by
- * verifying known signatures (fields with known limited values).
- *
- * If miniSEED 2.x is detected, search the record up to recbuflen
- * bytes for a 1000 blockette. If no blockette 1000 is found, search
- * at 64-byte offsets for the fixed section of the next header,
- * thereby implying the record length.
- *
- * @param[in] record Buffer to test for record
- * @param[in] recbuflen Length of buffer
- * @param[out] formatversion Major version of format detected, 0 if unknown
- *
- * @retval -1 Data record not detected or error
- * @retval 0 Data record detected but could not determine length
- * @retval >0 Size of the record in bytes
- *
- * \ref MessageOnError - this function logs a message on error
- *********************************************************************/
+                                                                   * @brief Detect miniSEED record in buffer
+                                                                   *
+                                                                   * Determine if the buffer contains a miniSEED data record by
+                                                                   * verifying known signatures (fields with known limited values).
+                                                                   *
+                                                                   * If miniSEED 2.x is detected, search the record up to recbuflen
+                                                                   * bytes for a 1000 blockette. If no blockette 1000 is found, search
+                                                                   * at 64-byte offsets for the fixed section of the next header,
+                                                                   * thereby implying the record length.
+                                                                   *
+                                                                   * @param[in] record Buffer to test for record
+                                                                   * @param[in] recbuflen Length of buffer
+                                                                   * @param[out] formatversion Major version of format detected, 0 if unknown
+                                                                   *
+                                                                   * @retval -1 Data record not detected or error
+                                                                   * @retval 0 Data record detected but could not determine length
+                                                                   * @retval >0 Size of the record in bytes
+                                                                   *
+                                                                   * \ref MessageOnError - this function logs a message on error
+                                                                   *********************************************************************/
 int
 ms3_detect (const char *record, uint64_t recbuflen, uint8_t *formatversion)
 {
-  uint8_t swapflag = 0; /* Byte swapping flag */
-  uint8_t foundlen = 0; /* Found record length */
-  int32_t reclen = -1; /* Size of record in bytes */
+  uint8_t swapflag = 0;  /* Byte swapping flag */
+  uint8_t foundlen = 0;  /* Found record length */
+  int32_t reclen   = -1; /* Size of record in bytes */
 
   uint16_t blkt_offset; /* Byte offset for next blockette */
   uint16_t blkt_type;
@@ -214,10 +214,10 @@ ms3_detect (const char *record, uint64_t recbuflen, uint8_t *formatversion)
     *formatversion = 2;
 
     /* Check to see if byte swapping is needed by checking for sane year and day */
-    if (!MS_ISVALIDYEARDAY (*pMS2FSDH_YEAR(record), *pMS2FSDH_DAY(record)))
+    if (!MS_ISVALIDYEARDAY (*pMS2FSDH_YEAR (record), *pMS2FSDH_DAY (record)))
       swapflag = 1;
 
-    blkt_offset = HO2u(*pMS2FSDH_BLOCKETTEOFFSET (record), swapflag);
+    blkt_offset = HO2u (*pMS2FSDH_BLOCKETTEOFFSET (record), swapflag);
 
     /* Loop through blockettes as long as number is non-zero and viable */
     while (blkt_offset != 0 &&
@@ -269,7 +269,7 @@ ms3_detect (const char *record, uint64_t recbuflen, uint8_t *formatversion)
         if (MS2_ISVALIDHEADER (nextfsdh))
         {
           foundlen = 1;
-          reclen = nextfsdh - record;
+          reclen   = nextfsdh - record;
           break;
         }
 
@@ -285,31 +285,31 @@ ms3_detect (const char *record, uint64_t recbuflen, uint8_t *formatversion)
 } /* End of ms3_detect() */
 
 /**********************************************************************/ /**
- * @brief Parse and verify a miniSEED 3.x record header
- *
- * Parsing is done at the lowest level, printing error messages for
- * invalid header values and optionally print raw header values.
- *
- * The buffer at \a record is assumed to be a miniSEED record.  Not
- * every possible test is performed, common errors and those causing
- * library parsing to fail should be detected.
- *
- * This routine is primarily intended to diagnose invalid miniSEED headers.
- *
- * @param[in] record Buffer to parse as miniSEED
- * @param[in] maxreclen Maximum length to search in buffer
- * @param[in] details Controls diagnostic output as follows:
- * @parblock
- *  - \c 0 - only print error messages for invalid header fields
- *  - \c 1 - print basic fields in addition to invalid field errors
- *  - \c 2 - print all fields in addition to invalid field errors
- * @endparblock
- *
- * @returns 0 when no errors were detected or a positive count of
- * errors detected.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Parse and verify a miniSEED 3.x record header
+                                                                          *
+                                                                          * Parsing is done at the lowest level, printing error messages for
+                                                                          * invalid header values and optionally print raw header values.
+                                                                          *
+                                                                          * The buffer at \a record is assumed to be a miniSEED record.  Not
+                                                                          * every possible test is performed, common errors and those causing
+                                                                          * library parsing to fail should be detected.
+                                                                          *
+                                                                          * This routine is primarily intended to diagnose invalid miniSEED headers.
+                                                                          *
+                                                                          * @param[in] record Buffer to parse as miniSEED
+                                                                          * @param[in] maxreclen Maximum length to search in buffer
+                                                                          * @param[in] details Controls diagnostic output as follows:
+                                                                          * @parblock
+                                                                          *  - \c 0 - only print error messages for invalid header fields
+                                                                          *  - \c 1 - print basic fields in addition to invalid field errors
+                                                                          *  - \c 2 - print all fields in addition to invalid field errors
+                                                                          * @endparblock
+                                                                          *
+                                                                          * @returns 0 when no errors were detected or a positive count of
+                                                                          * errors detected.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 ms_parse_raw3 (char *record, int maxreclen, int8_t details)
 {
@@ -334,7 +334,7 @@ ms_parse_raw3 (char *record, int maxreclen, int8_t details)
     return 1;
   }
 
-  swapflag = (ms_bigendianhost()) ? 1 : 0;
+  swapflag = (ms_bigendianhost ()) ? 1 : 0;
 
   if (details > 1)
   {
@@ -344,7 +344,7 @@ ms_parse_raw3 (char *record, int maxreclen, int8_t details)
       ms_log (0, "Not swapping multi-byte quantities in header\n");
   }
 
-  sidlength = *pMS3FSDH_SIDLENGTH(record);
+  sidlength = *pMS3FSDH_SIDLENGTH (record);
 
   /* Check if source identifier length is unreasonably small */
   if (sidlength < 4)
@@ -360,7 +360,7 @@ ms_parse_raw3 (char *record, int maxreclen, int8_t details)
     return 1;
   }
 
-  sid = pMS3FSDH_SID(record);
+  sid = pMS3FSDH_SID (record);
 
   /* Validate fixed section header fields */
   X = record; /* Pointer of convenience */
@@ -374,24 +374,24 @@ ms_parse_raw3 (char *record, int maxreclen, int8_t details)
   }
 
   /* Check data format == 3 */
-  if (((uint8_t)*(X + 2)) != 3)
+  if (((uint8_t) * (X + 2)) != 3)
   {
     ms_log (2, "%.*s: Invalid miniSEED format version: '%d'\n",
-            sidlength, sid, (uint8_t)*(X + 2));
+            sidlength, sid, (uint8_t) * (X + 2));
     retval++;
   }
 
   /* Check start time fields */
-  if (HO2u(*pMS3FSDH_YEAR (record), swapflag) < 1900 || HO2u(*pMS3FSDH_YEAR (record), swapflag) > 2100)
+  if (HO2u (*pMS3FSDH_YEAR (record), swapflag) < 1900 || HO2u (*pMS3FSDH_YEAR (record), swapflag) > 2100)
   {
     ms_log (2, "%.*s: Unlikely start year (1900-2100): '%d'\n",
-            sidlength, sid, HO2u(*pMS3FSDH_YEAR (record), swapflag));
+            sidlength, sid, HO2u (*pMS3FSDH_YEAR (record), swapflag));
     retval++;
   }
-  if (HO2u(*pMS3FSDH_DAY (record), swapflag) < 1 || HO2u(*pMS3FSDH_DAY (record), swapflag) > 366)
+  if (HO2u (*pMS3FSDH_DAY (record), swapflag) < 1 || HO2u (*pMS3FSDH_DAY (record), swapflag) > 366)
   {
     ms_log (2, "%.*s: Invalid start day (1-366): '%d'\n",
-            sidlength, sid, HO2u(*pMS3FSDH_DAY (record), swapflag));
+            sidlength, sid, HO2u (*pMS3FSDH_DAY (record), swapflag));
     retval++;
   }
   if (*pMS3FSDH_HOUR (record) > 23)
@@ -412,10 +412,10 @@ ms_parse_raw3 (char *record, int maxreclen, int8_t details)
             sidlength, sid, *pMS3FSDH_SEC (record));
     retval++;
   }
-  if (HO4u(*pMS3FSDH_NSEC (record), swapflag) > 999999999)
+  if (HO4u (*pMS3FSDH_NSEC (record), swapflag) > 999999999)
   {
     ms_log (2, "%.*s: Invalid start nanoseconds (0-999999999): '%u'\n",
-            sidlength, sid, HO4u(*pMS3FSDH_NSEC (record), swapflag));
+            sidlength, sid, HO4u (*pMS3FSDH_NSEC (record), swapflag));
     retval++;
   }
 
@@ -452,24 +452,24 @@ ms_parse_raw3 (char *record, int maxreclen, int8_t details)
         ms_log (0, "                         [Bit 7] Undefined bit set\n");
     }
     ms_log (0, "             start time: %u,%u,%u:%u:%u.%09u\n",
-            HO2u(*pMS3FSDH_YEAR (record), swapflag),
-            HO2u(*pMS3FSDH_DAY (record), swapflag),
+            HO2u (*pMS3FSDH_YEAR (record), swapflag),
+            HO2u (*pMS3FSDH_DAY (record), swapflag),
             *pMS3FSDH_HOUR (record),
             *pMS3FSDH_MIN (record),
             *pMS3FSDH_SEC (record),
-            HO4u(*pMS3FSDH_NSEC (record), swapflag));
-    ms_log (0, "   sample rate+/period-: %g\n", HO8f(*pMS3FSDH_SAMPLERATE (record), swapflag));
+            HO4u (*pMS3FSDH_NSEC (record), swapflag));
+    ms_log (0, "   sample rate+/period-: %g\n", HO8f (*pMS3FSDH_SAMPLERATE (record), swapflag));
     ms_log (0, "          data encoding: %u\n", *pMS3FSDH_ENCODING (record));
     ms_log (0, "    publication version: %u\n", *pMS3FSDH_PUBVERSION (record));
-    ms_log (0, "      number of samples: %u\n", HO4u(*pMS3FSDH_NUMSAMPLES (record), swapflag));
-    ms_log (0, "                    CRC: 0x%X\n", HO4u(*pMS3FSDH_CRC (record), swapflag));
+    ms_log (0, "      number of samples: %u\n", HO4u (*pMS3FSDH_NUMSAMPLES (record), swapflag));
+    ms_log (0, "                    CRC: 0x%X\n", HO4u (*pMS3FSDH_CRC (record), swapflag));
     ms_log (0, "   length of identifier: %u\n", *pMS3FSDH_SIDLENGTH (record));
-    ms_log (0, "length of extra headers: %u\n", HO2u(*pMS3FSDH_EXTRALENGTH (record), swapflag));
-    ms_log (0, " length of data payload: %u\n", HO2u(*pMS3FSDH_DATALENGTH (record), swapflag));
+    ms_log (0, "length of extra headers: %u\n", HO2u (*pMS3FSDH_EXTRALENGTH (record), swapflag));
+    ms_log (0, " length of data payload: %u\n", HO2u (*pMS3FSDH_DATALENGTH (record), swapflag));
   } /* Done printing raw header details */
 
   /* Print extra headers */
-  msr.extralength = HO2u(*pMS3FSDH_EXTRALENGTH (record), swapflag);
+  msr.extralength = HO2u (*pMS3FSDH_EXTRALENGTH (record), swapflag);
 
   if (details > 1 && msr.extralength > 0)
   {
@@ -489,37 +489,37 @@ ms_parse_raw3 (char *record, int maxreclen, int8_t details)
 } /* End of ms_parse_raw3() */
 
 /**********************************************************************/ /**
- * @brief Parse and verify a miniSEED 2.x record header
- *
- * Parsing is done at the lowest level, printing error messages for
- * invalid header values and optionally print raw header values.
- *
- * The buffer \a record is assumed to be a miniSEED record.  Not every
- * possible test is performed, common errors and those causing
- * libmseed parsing to fail should be detected.
- *
- * This routine is primarily intended to diagnose invalid miniSEED headers.
- *
- * @param[in] record Buffer to parse as miniSEED
- * @param[in] maxreclen Maximum length to search in buffer
- * @param[in] details Controls diagnostic output as follows:
- * @parblock
- *  - \c 0 - only print error messages for invalid header fields
- *  - \c 1 - print basic fields in addition to invalid field errors
- *  - \c 2 - print all fields in addition to invalid field errors
- * @endparblock
- * @param[in] swapflag Flag controlling byte-swapping as follows:
- * @parblock
- *  - \c 1 - swap multibyte quantities
- *  - \c 0 - do not swap
- *  - \c -1 - autodetect byte order using year test, swap if needed
- * @endparblock
- *
- * @returns 0 when no errors were detected or a positive count of
- * errors detected.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Parse and verify a miniSEED 2.x record header
+                                                                          *
+                                                                          * Parsing is done at the lowest level, printing error messages for
+                                                                          * invalid header values and optionally print raw header values.
+                                                                          *
+                                                                          * The buffer \a record is assumed to be a miniSEED record.  Not every
+                                                                          * possible test is performed, common errors and those causing
+                                                                          * libmseed parsing to fail should be detected.
+                                                                          *
+                                                                          * This routine is primarily intended to diagnose invalid miniSEED headers.
+                                                                          *
+                                                                          * @param[in] record Buffer to parse as miniSEED
+                                                                          * @param[in] maxreclen Maximum length to search in buffer
+                                                                          * @param[in] details Controls diagnostic output as follows:
+                                                                          * @parblock
+                                                                          *  - \c 0 - only print error messages for invalid header fields
+                                                                          *  - \c 1 - print basic fields in addition to invalid field errors
+                                                                          *  - \c 2 - print all fields in addition to invalid field errors
+                                                                          * @endparblock
+                                                                          * @param[in] swapflag Flag controlling byte-swapping as follows:
+                                                                          * @parblock
+                                                                          *  - \c 1 - swap multibyte quantities
+                                                                          *  - \c 0 - do not swap
+                                                                          *  - \c -1 - autodetect byte order using year test, swap if needed
+                                                                          * @endparblock
+                                                                          *
+                                                                          * @returns 0 when no errors were detected or a positive count of
+                                                                          * errors detected.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
 {
@@ -527,9 +527,9 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
   char sid[21] = {0};
   char *X;
   uint8_t b;
-  int retval = 0;
-  int b1000encoding = -1;
-  int b1000reclen = -1;
+  int retval          = 0;
+  int b1000encoding   = -1;
+  int b1000reclen     = -1;
   int endofblockettes = -1;
   int idx;
 
@@ -627,14 +627,14 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
   }
 
   /* Check start time fields */
-  if (HO2u(*pMS2FSDH_YEAR (record), swapflag) < 1900 || HO2u(*pMS2FSDH_YEAR (record), swapflag) > 2100)
+  if (HO2u (*pMS2FSDH_YEAR (record), swapflag) < 1900 || HO2u (*pMS2FSDH_YEAR (record), swapflag) > 2100)
   {
-    ms_log (2, "%s: Unlikely start year (1900-2100): '%d'\n", sid, HO2u(*pMS2FSDH_YEAR (record), swapflag));
+    ms_log (2, "%s: Unlikely start year (1900-2100): '%d'\n", sid, HO2u (*pMS2FSDH_YEAR (record), swapflag));
     retval++;
   }
-  if (HO2u(*pMS2FSDH_DAY (record), swapflag) < 1 || HO2u(*pMS2FSDH_DAY (record), swapflag) > 366)
+  if (HO2u (*pMS2FSDH_DAY (record), swapflag) < 1 || HO2u (*pMS2FSDH_DAY (record), swapflag) > 366)
   {
-    ms_log (2, "%s: Invalid start day (1-366): '%d'\n", sid, HO2u(*pMS2FSDH_DAY (record), swapflag));
+    ms_log (2, "%s: Invalid start day (1-366): '%d'\n", sid, HO2u (*pMS2FSDH_DAY (record), swapflag));
     retval++;
   }
   if (*pMS2FSDH_HOUR (record) > 23)
@@ -652,29 +652,29 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
     ms_log (2, "%s: Invalid start second (0-60): '%d'\n", sid, *pMS2FSDH_SEC (record));
     retval++;
   }
-  if (HO2u(*pMS2FSDH_FSEC (record), swapflag) > 9999)
+  if (HO2u (*pMS2FSDH_FSEC (record), swapflag) > 9999)
   {
-    ms_log (2, "%s: Invalid start fractional seconds (0-9999): '%d'\n", sid, HO2u(*pMS2FSDH_FSEC (record), swapflag));
+    ms_log (2, "%s: Invalid start fractional seconds (0-9999): '%d'\n", sid, HO2u (*pMS2FSDH_FSEC (record), swapflag));
     retval++;
   }
 
   /* Check number of samples, max samples in 4096-byte Steim-2 encoded record: 6601 */
-  if (HO2u(*pMS2FSDH_NUMSAMPLES(record), swapflag) > 20000)
+  if (HO2u (*pMS2FSDH_NUMSAMPLES (record), swapflag) > 20000)
   {
     ms_log (2, "%s: Unlikely number of samples (>20000): '%d'\n",
-            sid, HO2u(*pMS2FSDH_NUMSAMPLES(record), swapflag));
+            sid, HO2u (*pMS2FSDH_NUMSAMPLES (record), swapflag));
     retval++;
   }
 
   /* Sanity check that there is space for blockettes when both data and blockettes are present */
-  if (HO2u(*pMS2FSDH_NUMSAMPLES(record), swapflag) > 0 &&
-      *pMS2FSDH_NUMBLOCKETTES(record) > 0 &&
-      HO2u(*pMS2FSDH_DATAOFFSET(record), swapflag) <= HO2u(*pMS2FSDH_BLOCKETTEOFFSET(record), swapflag))
+  if (HO2u (*pMS2FSDH_NUMSAMPLES (record), swapflag) > 0 &&
+      *pMS2FSDH_NUMBLOCKETTES (record) > 0 &&
+      HO2u (*pMS2FSDH_DATAOFFSET (record), swapflag) <= HO2u (*pMS2FSDH_BLOCKETTEOFFSET (record), swapflag))
   {
     ms_log (2, "%s: No space for %d blockettes, data offset: %d, blockette offset: %d\n", sid,
-            *pMS2FSDH_NUMBLOCKETTES(record),
-            HO2u(*pMS2FSDH_DATAOFFSET(record), swapflag),
-            HO2u(*pMS2FSDH_BLOCKETTEOFFSET(record), swapflag));
+            *pMS2FSDH_NUMBLOCKETTES (record),
+            HO2u (*pMS2FSDH_DATAOFFSET (record), swapflag),
+            HO2u (*pMS2FSDH_BLOCKETTEOFFSET (record), swapflag));
     retval++;
   }
 
@@ -682,8 +682,8 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
   if (details >= 1)
   {
     /* Determine nominal sample rate */
-    nomsamprate = ms_nomsamprate (HO2d(*pMS2FSDH_SAMPLERATEFACT (record), swapflag),
-                                  HO2d(*pMS2FSDH_SAMPLERATEMULT (record), swapflag));
+    nomsamprate = ms_nomsamprate (HO2d (*pMS2FSDH_SAMPLERATEFACT (record), swapflag),
+                                  HO2d (*pMS2FSDH_SAMPLERATEMULT (record), swapflag));
 
     /* Print header values */
     ms_log (0, "RECORD -- %s\n", sid);
@@ -704,17 +704,17 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
     ms_log (0, "           network code: '%c%c'\n",
             pMS2FSDH_NETWORK (record)[0], pMS2FSDH_NETWORK (record)[1]);
     ms_log (0, "             start time: %d,%d,%d:%d:%d.%04d (unused: %d)\n",
-            HO2u(*pMS2FSDH_YEAR (record), swapflag),
-            HO2u(*pMS2FSDH_DAY (record), swapflag),
+            HO2u (*pMS2FSDH_YEAR (record), swapflag),
+            HO2u (*pMS2FSDH_DAY (record), swapflag),
             *pMS2FSDH_HOUR (record),
             *pMS2FSDH_MIN (record),
             *pMS2FSDH_SEC (record),
-            HO2u(*pMS2FSDH_FSEC (record), swapflag),
+            HO2u (*pMS2FSDH_FSEC (record), swapflag),
             *pMS2FSDH_UNUSED (record));
-    ms_log (0, "      number of samples: %d\n", HO2u(*pMS2FSDH_NUMSAMPLES (record), swapflag));
+    ms_log (0, "      number of samples: %d\n", HO2u (*pMS2FSDH_NUMSAMPLES (record), swapflag));
     ms_log (0, "     sample rate factor: %d  (%.10g samples per second)\n",
-            HO2d(*pMS2FSDH_SAMPLERATEFACT (record), swapflag), nomsamprate);
-    ms_log (0, " sample rate multiplier: %d\n", HO2d(*pMS2FSDH_SAMPLERATEMULT (record), swapflag));
+            HO2d (*pMS2FSDH_SAMPLERATEFACT (record), swapflag), nomsamprate);
+    ms_log (0, " sample rate multiplier: %d\n", HO2d (*pMS2FSDH_SAMPLERATEMULT (record), swapflag));
 
     /* Print flag details if requested */
     if (details > 1)
@@ -787,16 +787,16 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
     }
 
     ms_log (0, "   number of blockettes: %d\n", *pMS2FSDH_NUMBLOCKETTES (record));
-    ms_log (0, "        time correction: %ld\n", (long int)HO4d(*pMS2FSDH_TIMECORRECT (record), swapflag));
-    ms_log (0, "            data offset: %d\n", HO2u(*pMS2FSDH_DATAOFFSET (record), swapflag));
-    ms_log (0, " first blockette offset: %d\n", HO2u(*pMS2FSDH_BLOCKETTEOFFSET (record), swapflag));
+    ms_log (0, "        time correction: %ld\n", (long int)HO4d (*pMS2FSDH_TIMECORRECT (record), swapflag));
+    ms_log (0, "            data offset: %d\n", HO2u (*pMS2FSDH_DATAOFFSET (record), swapflag));
+    ms_log (0, " first blockette offset: %d\n", HO2u (*pMS2FSDH_BLOCKETTEOFFSET (record), swapflag));
   } /* Done printing raw header details */
 
   /* Validate and report information in the blockette chain */
-  if (HO2u(*pMS2FSDH_BLOCKETTEOFFSET (record), swapflag) > 46 &&
-      HO2u(*pMS2FSDH_BLOCKETTEOFFSET (record), swapflag) < maxreclen)
+  if (HO2u (*pMS2FSDH_BLOCKETTEOFFSET (record), swapflag) > 46 &&
+      HO2u (*pMS2FSDH_BLOCKETTEOFFSET (record), swapflag) < maxreclen)
   {
-    int blkt_offset = HO2u(*pMS2FSDH_BLOCKETTEOFFSET (record), swapflag);
+    int blkt_offset = HO2u (*pMS2FSDH_BLOCKETTEOFFSET (record), swapflag);
     int blkt_count  = 0;
     int blkt_length;
     uint16_t blkt_type;
@@ -848,19 +848,19 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
         if (details >= 1)
         {
           ms_log (0, "          actual sample rate: %.10g\n",
-                  HO4f(*pMS2B100_SAMPRATE(record + blkt_offset), swapflag));
+                  HO4f (*pMS2B100_SAMPRATE (record + blkt_offset), swapflag));
 
           if (details > 1)
           {
-            b = *pMS2B100_FLAGS(record + blkt_offset);
+            b = *pMS2B100_FLAGS (record + blkt_offset);
             ms_log (0, "             undefined flags: [%d%d%d%d%d%d%d%d] 8 bits\n",
                     bit (b, 0x80), bit (b, 0x40), bit (b, 0x20), bit (b, 0x10),
                     bit (b, 0x08), bit (b, 0x04), bit (b, 0x02), bit (b, 0x01));
 
             ms_log (0, "          reserved bytes (3): %u,%u,%u\n",
-                    pMS2B100_RESERVED(record + blkt_offset)[0],
-                    pMS2B100_RESERVED(record + blkt_offset)[1],
-                    pMS2B100_RESERVED(record + blkt_offset)[2]);
+                    pMS2B100_RESERVED (record + blkt_offset)[0],
+                    pMS2B100_RESERVED (record + blkt_offset)[1],
+                    pMS2B100_RESERVED (record + blkt_offset)[2]);
           }
         }
       }
@@ -869,13 +869,13 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
       {
         if (details >= 1)
         {
-          ms_log (0, "            signal amplitude: %g\n", HO4f(*pMS2B200_AMPLITUDE(record + blkt_offset), swapflag));
-          ms_log (0, "               signal period: %g\n", HO4f(*pMS2B200_PERIOD(record + blkt_offset), swapflag));
-          ms_log (0, "         background estimate: %g\n", HO4f(*pMS2B200_BACKGROUNDEST(record + blkt_offset), swapflag));
+          ms_log (0, "            signal amplitude: %g\n", HO4f (*pMS2B200_AMPLITUDE (record + blkt_offset), swapflag));
+          ms_log (0, "               signal period: %g\n", HO4f (*pMS2B200_PERIOD (record + blkt_offset), swapflag));
+          ms_log (0, "         background estimate: %g\n", HO4f (*pMS2B200_BACKGROUNDEST (record + blkt_offset), swapflag));
 
           if (details > 1)
           {
-            b = *pMS2B200_FLAGS(record + blkt_offset);
+            b = *pMS2B200_FLAGS (record + blkt_offset);
             ms_log (0, "       event detection flags: [%d%d%d%d%d%d%d%d] 8 bits\n",
                     bit (b, 0x80), bit (b, 0x40), bit (b, 0x20), bit (b, 0x10),
                     bit (b, 0x08), bit (b, 0x04), bit (b, 0x02), bit (b, 0x01));
@@ -893,12 +893,12 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
           }
 
           ms_log (0, "           signal onset time: %d,%d,%d:%d:%d.%04d (unused: %d)\n",
-                  HO2u(*pMS2B200_YEAR (record + blkt_offset), swapflag),
-                  HO2u(*pMS2B200_DAY (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B200_YEAR (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B200_DAY (record + blkt_offset), swapflag),
                   *pMS2B200_HOUR (record + blkt_offset),
                   *pMS2B200_MIN (record + blkt_offset),
                   *pMS2B200_SEC (record + blkt_offset),
-                  HO2u(*pMS2B200_FSEC (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B200_FSEC (record + blkt_offset), swapflag),
                   *pMS2B200_UNUSED (record + blkt_offset));
           ms_log (0, "               detector name: %.24s\n", pMS2B200_DETECTOR (record + blkt_offset));
         }
@@ -908,11 +908,11 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
       {
         if (details >= 1)
         {
-          ms_log (0, "            signal amplitude: %g\n", HO4f(*pMS2B201_AMPLITUDE(record + blkt_offset), swapflag));
-          ms_log (0, "               signal period: %g\n", HO4f(*pMS2B201_PERIOD(record + blkt_offset), swapflag));
-          ms_log (0, "         background estimate: %g\n", HO4f(*pMS2B201_BACKGROUNDEST(record + blkt_offset), swapflag));
+          ms_log (0, "            signal amplitude: %g\n", HO4f (*pMS2B201_AMPLITUDE (record + blkt_offset), swapflag));
+          ms_log (0, "               signal period: %g\n", HO4f (*pMS2B201_PERIOD (record + blkt_offset), swapflag));
+          ms_log (0, "         background estimate: %g\n", HO4f (*pMS2B201_BACKGROUNDEST (record + blkt_offset), swapflag));
 
-          b = *pMS2B201_FLAGS(record + blkt_offset);
+          b = *pMS2B201_FLAGS (record + blkt_offset);
           ms_log (0, "       event detection flags: [%d%d%d%d%d%d%d%d] 8 bits\n",
                   bit (b, 0x80), bit (b, 0x40), bit (b, 0x20), bit (b, 0x10),
                   bit (b, 0x08), bit (b, 0x04), bit (b, 0x02), bit (b, 0x01));
@@ -922,14 +922,14 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
             ms_log (0, "                         [Bit 0] 0: Compression wave\n");
 
           if (details > 1)
-            ms_log (0, "               reserved byte: %u\n", *pMS2B201_RESERVED(record + blkt_offset));
+            ms_log (0, "               reserved byte: %u\n", *pMS2B201_RESERVED (record + blkt_offset));
           ms_log (0, "           signal onset time: %d,%d,%d:%d:%d.%04d (unused: %d)\n",
-                  HO2u(*pMS2B201_YEAR (record + blkt_offset), swapflag),
-                  HO2u(*pMS2B201_DAY (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B201_YEAR (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B201_DAY (record + blkt_offset), swapflag),
                   *pMS2B201_HOUR (record + blkt_offset),
                   *pMS2B201_MIN (record + blkt_offset),
                   *pMS2B201_SEC (record + blkt_offset),
-                  HO2u(*pMS2B201_FSEC (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B201_FSEC (record + blkt_offset), swapflag),
                   *pMS2B201_UNUSED (record + blkt_offset));
           ms_log (0, "                  SNR values: ");
 
@@ -947,12 +947,12 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
         if (details >= 1)
         {
           ms_log (0, "      calibration start time: %d,%d,%d:%d:%d.%04d (unused: %d)\n",
-                  HO2u(*pMS2B300_YEAR (record + blkt_offset), swapflag),
-                  HO2u(*pMS2B300_DAY (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B300_YEAR (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B300_DAY (record + blkt_offset), swapflag),
                   *pMS2B300_HOUR (record + blkt_offset),
                   *pMS2B300_MIN (record + blkt_offset),
                   *pMS2B300_SEC (record + blkt_offset),
-                  HO2u(*pMS2B300_FSEC (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B300_FSEC (record + blkt_offset), swapflag),
                   *pMS2B300_UNUSED (record + blkt_offset));
           ms_log (0, "      number of calibrations: %u\n", *pMS2B300_NUMCALIBRATIONS (record + blkt_offset));
 
@@ -969,13 +969,13 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
           if (b & 0x08)
             ms_log (0, "                         [Bit 3] Calibration continued from previous record(s)\n");
 
-          ms_log (0, "               step duration: %u\n", HO4u(*pMS2B300_STEPDURATION (record + blkt_offset), swapflag));
-          ms_log (0, "           interval duration: %u\n", HO4u(*pMS2B300_INTERVALDURATION (record + blkt_offset), swapflag));
-          ms_log (0, "            signal amplitude: %g\n", HO4f(*pMS2B300_AMPLITUDE (record + blkt_offset), swapflag));
+          ms_log (0, "               step duration: %u\n", HO4u (*pMS2B300_STEPDURATION (record + blkt_offset), swapflag));
+          ms_log (0, "           interval duration: %u\n", HO4u (*pMS2B300_INTERVALDURATION (record + blkt_offset), swapflag));
+          ms_log (0, "            signal amplitude: %g\n", HO4f (*pMS2B300_AMPLITUDE (record + blkt_offset), swapflag));
           ms_log (0, "        input signal channel: %.3s", pMS2B300_INPUTCHANNEL (record + blkt_offset));
           if (details > 1)
             ms_log (0, "               reserved byte: %u\n", *pMS2B300_RESERVED (record + blkt_offset));
-          ms_log (0, "         reference amplitude: %u\n", HO4u(*pMS2B300_REFERENCEAMPLITUDE (record + blkt_offset), swapflag));
+          ms_log (0, "         reference amplitude: %u\n", HO4u (*pMS2B300_REFERENCEAMPLITUDE (record + blkt_offset), swapflag));
           ms_log (0, "                    coupling: %.12s\n", pMS2B300_COUPLING (record + blkt_offset));
           ms_log (0, "                     rolloff: %.12s\n", pMS2B300_ROLLOFF (record + blkt_offset));
         }
@@ -986,12 +986,12 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
         if (details >= 1)
         {
           ms_log (0, "      calibration start time: %d,%d,%d:%d:%d.%04d (unused: %d)\n",
-                  HO2u(*pMS2B310_YEAR (record + blkt_offset), swapflag),
-                  HO2u(*pMS2B310_DAY (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B310_YEAR (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B310_DAY (record + blkt_offset), swapflag),
                   *pMS2B310_HOUR (record + blkt_offset),
                   *pMS2B310_MIN (record + blkt_offset),
                   *pMS2B310_SEC (record + blkt_offset),
-                  HO2u(*pMS2B310_FSEC (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B310_FSEC (record + blkt_offset), swapflag),
                   *pMS2B310_UNUSED (record + blkt_offset));
           if (details > 1)
             ms_log (0, "               reserved byte: %u\n", *pMS2B310_RESERVED1 (record + blkt_offset));
@@ -1011,13 +1011,13 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
           if (b & 0x40)
             ms_log (0, "                         [Bit 6] RMS amplitude\n");
 
-          ms_log (0, "        calibration duration: %u\n", HO4u(*pMS2B310_DURATION (record + blkt_offset), swapflag));
-          ms_log (0, "               signal period: %g\n", HO4f(*pMS2B310_PERIOD (record + blkt_offset), swapflag));
-          ms_log (0, "            signal amplitude: %g\n", HO4f(*pMS2B310_AMPLITUDE (record + blkt_offset), swapflag));
+          ms_log (0, "        calibration duration: %u\n", HO4u (*pMS2B310_DURATION (record + blkt_offset), swapflag));
+          ms_log (0, "               signal period: %g\n", HO4f (*pMS2B310_PERIOD (record + blkt_offset), swapflag));
+          ms_log (0, "            signal amplitude: %g\n", HO4f (*pMS2B310_AMPLITUDE (record + blkt_offset), swapflag));
           ms_log (0, "        input signal channel: %.3s", pMS2B310_INPUTCHANNEL (record + blkt_offset));
           if (details > 1)
             ms_log (0, "               reserved byte: %u\n", *pMS2B310_RESERVED2 (record + blkt_offset));
-          ms_log (0, "         reference amplitude: %u\n", HO4u(*pMS2B310_REFERENCEAMPLITUDE (record + blkt_offset), swapflag));
+          ms_log (0, "         reference amplitude: %u\n", HO4u (*pMS2B310_REFERENCEAMPLITUDE (record + blkt_offset), swapflag));
           ms_log (0, "                    coupling: %.12s\n", pMS2B310_COUPLING (record + blkt_offset));
           ms_log (0, "                     rolloff: %.12s\n", pMS2B310_ROLLOFF (record + blkt_offset));
         }
@@ -1028,12 +1028,12 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
         if (details >= 1)
         {
           ms_log (0, "      calibration start time: %d,%d,%d:%d:%d.%04d (unused: %d)\n",
-                  HO2u(*pMS2B320_YEAR (record + blkt_offset), swapflag),
-                  HO2u(*pMS2B320_DAY (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B320_YEAR (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B320_DAY (record + blkt_offset), swapflag),
                   *pMS2B320_HOUR (record + blkt_offset),
                   *pMS2B320_MIN (record + blkt_offset),
                   *pMS2B320_SEC (record + blkt_offset),
-                  HO2u(*pMS2B320_FSEC (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B320_FSEC (record + blkt_offset), swapflag),
                   *pMS2B320_UNUSED (record + blkt_offset));
           if (details > 1)
             ms_log (0, "               reserved byte: %u\n", *pMS2B320_RESERVED1 (record + blkt_offset));
@@ -1049,12 +1049,12 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
           if (b & 0x10)
             ms_log (0, "                         [Bit 4] Random amplitudes\n");
 
-          ms_log (0, "        calibration duration: %u\n", HO4u(*pMS2B320_DURATION (record + blkt_offset), swapflag));
-          ms_log (0, "      peak-to-peak amplitude: %g\n", HO4f(*pMS2B320_PTPAMPLITUDE (record + blkt_offset), swapflag));
+          ms_log (0, "        calibration duration: %u\n", HO4u (*pMS2B320_DURATION (record + blkt_offset), swapflag));
+          ms_log (0, "      peak-to-peak amplitude: %g\n", HO4f (*pMS2B320_PTPAMPLITUDE (record + blkt_offset), swapflag));
           ms_log (0, "        input signal channel: %.3s", pMS2B320_INPUTCHANNEL (record + blkt_offset));
           if (details > 1)
             ms_log (0, "               reserved byte: %u\n", *pMS2B320_RESERVED2 (record + blkt_offset));
-          ms_log (0, "         reference amplitude: %u\n", HO4u(*pMS2B320_REFERENCEAMPLITUDE (record + blkt_offset), swapflag));
+          ms_log (0, "         reference amplitude: %u\n", HO4u (*pMS2B320_REFERENCEAMPLITUDE (record + blkt_offset), swapflag));
           ms_log (0, "                    coupling: %.12s\n", pMS2B320_COUPLING (record + blkt_offset));
           ms_log (0, "                     rolloff: %.12s\n", pMS2B320_ROLLOFF (record + blkt_offset));
           ms_log (0, "                  noise type: %.8s\n", pMS2B320_NOISETYPE (record + blkt_offset));
@@ -1066,12 +1066,12 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
         if (details >= 1)
         {
           ms_log (0, "      calibration start time: %d,%d,%d:%d:%d.%04d (unused: %d)\n",
-                  HO2u(*pMS2B390_YEAR (record + blkt_offset), swapflag),
-                  HO2u(*pMS2B390_DAY (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B390_YEAR (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B390_DAY (record + blkt_offset), swapflag),
                   *pMS2B390_HOUR (record + blkt_offset),
                   *pMS2B390_MIN (record + blkt_offset),
                   *pMS2B390_SEC (record + blkt_offset),
-                  HO2u(*pMS2B390_FSEC (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B390_FSEC (record + blkt_offset), swapflag),
                   *pMS2B390_UNUSED (record + blkt_offset));
           if (details > 1)
             ms_log (0, "               reserved byte: %u\n", *pMS2B390_RESERVED1 (record + blkt_offset));
@@ -1085,8 +1085,8 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
           if (b & 0x08)
             ms_log (0, "                         [Bit 3] Calibration continued from previous record(s)\n");
 
-          ms_log (0, "        calibration duration: %u\n", HO4u(*pMS2B390_DURATION (record + blkt_offset), swapflag));
-          ms_log (0, "            signal amplitude: %g\n", HO4f(*pMS2B390_AMPLITUDE (record + blkt_offset), swapflag));
+          ms_log (0, "        calibration duration: %u\n", HO4u (*pMS2B390_DURATION (record + blkt_offset), swapflag));
+          ms_log (0, "            signal amplitude: %g\n", HO4f (*pMS2B390_AMPLITUDE (record + blkt_offset), swapflag));
           ms_log (0, "        input signal channel: %.3s", pMS2B390_INPUTCHANNEL (record + blkt_offset));
           if (details > 1)
             ms_log (0, "               reserved byte: %u\n", *pMS2B390_RESERVED2 (record + blkt_offset));
@@ -1098,12 +1098,12 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
         if (details >= 1)
         {
           ms_log (0, "        calibration end time: %d,%d,%d:%d:%d.%04d (unused: %d)\n",
-                  HO2u(*pMS2B395_YEAR (record + blkt_offset), swapflag),
-                  HO2u(*pMS2B395_DAY (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B395_YEAR (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B395_DAY (record + blkt_offset), swapflag),
                   *pMS2B395_HOUR (record + blkt_offset),
                   *pMS2B395_MIN (record + blkt_offset),
                   *pMS2B395_SEC (record + blkt_offset),
-                  HO2u(*pMS2B395_FSEC (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B395_FSEC (record + blkt_offset), swapflag),
                   *pMS2B395_UNUSED (record + blkt_offset));
           if (details > 1)
             ms_log (0, "          reserved bytes (2): %u,%u\n",
@@ -1115,9 +1115,9 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
       {
         if (details >= 1)
         {
-          ms_log (0, "      beam azimuth (degrees): %g\n", HO4f(*pMS2B400_AZIMUTH (record + blkt_offset), swapflag));
-          ms_log (0, "  beam slowness (sec/degree): %g\n", HO4f(*pMS2B400_SLOWNESS (record + blkt_offset), swapflag));
-          ms_log (0, "               configuration: %u\n", HO2u(*pMS2B400_CONFIGURATION (record + blkt_offset), swapflag));
+          ms_log (0, "      beam azimuth (degrees): %g\n", HO4f (*pMS2B400_AZIMUTH (record + blkt_offset), swapflag));
+          ms_log (0, "  beam slowness (sec/degree): %g\n", HO4f (*pMS2B400_SLOWNESS (record + blkt_offset), swapflag));
+          ms_log (0, "               configuration: %u\n", HO2u (*pMS2B400_CONFIGURATION (record + blkt_offset), swapflag));
           if (details > 1)
             ms_log (0, "          reserved bytes (2): %u,%u\n",
                     pMS2B400_RESERVED (record + blkt_offset)[0], pMS2B400_RESERVED (record + blkt_offset)[1]);
@@ -1127,25 +1127,25 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
       else if (blkt_type == 405)
       {
         if (details >= 1)
-          ms_log (0, "           first delay value: %u\n", HO2u(*pMS2B405_DELAYVALUES (record + blkt_offset), swapflag));
+          ms_log (0, "           first delay value: %u\n", HO2u (*pMS2B405_DELAYVALUES (record + blkt_offset), swapflag));
       }
 
       else if (blkt_type == 500)
       {
         if (details >= 1)
         {
-          ms_log (0, "              VCO correction: %g%%\n", HO4f(*pMS2B500_VCOCORRECTION (record + blkt_offset), swapflag));
+          ms_log (0, "              VCO correction: %g%%\n", HO4f (*pMS2B500_VCOCORRECTION (record + blkt_offset), swapflag));
           ms_log (0, "           time of exception: %d,%d,%d:%d:%d.%04d (unused: %d)\n",
-                  HO2u(*pMS2B500_YEAR (record + blkt_offset), swapflag),
-                  HO2u(*pMS2B500_DAY (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B500_YEAR (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B500_DAY (record + blkt_offset), swapflag),
                   *pMS2B500_HOUR (record + blkt_offset),
                   *pMS2B500_MIN (record + blkt_offset),
                   *pMS2B500_SEC (record + blkt_offset),
-                  HO2u(*pMS2B500_FSEC (record + blkt_offset), swapflag),
+                  HO2u (*pMS2B500_FSEC (record + blkt_offset), swapflag),
                   *pMS2B500_UNUSED (record + blkt_offset));
           ms_log (0, "                        usec: %d\n", *pMS2B500_MICROSECOND (record + blkt_offset));
           ms_log (0, "           reception quality: %u%%\n", *pMS2B500_RECEPTIONQUALITY (record + blkt_offset));
-          ms_log (0, "             exception count: %u\n", HO4u(*pMS2B500_EXCEPTIONCOUNT (record + blkt_offset), swapflag));
+          ms_log (0, "             exception count: %u\n", HO4u (*pMS2B500_EXCEPTIONCOUNT (record + blkt_offset), swapflag));
           ms_log (0, "              exception type: %.16s\n", pMS2B500_EXCEPTIONTYPE (record + blkt_offset));
           ms_log (0, "                 clock model: %.32s\n", pMS2B500_CLOCKMODEL (record + blkt_offset));
           ms_log (0, "                clock status: %.128s\n", pMS2B500_CLOCKSTATUS (record + blkt_offset));
@@ -1231,9 +1231,9 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
 
         if (details >= 1)
         {
-          ms_log (0, "            blockette length: %u\n", HO2u(*pMS2B2000_LENGTH (record + blkt_offset), swapflag));
-          ms_log (0, "                 data offset: %u\n", HO2u(*pMS2B2000_DATAOFFSET (record + blkt_offset), swapflag));
-          ms_log (0, "               record number: %u\n", HO4u(*pMS2B2000_RECNUM (record + blkt_offset), swapflag));
+          ms_log (0, "            blockette length: %u\n", HO2u (*pMS2B2000_LENGTH (record + blkt_offset), swapflag));
+          ms_log (0, "                 data offset: %u\n", HO2u (*pMS2B2000_DATAOFFSET (record + blkt_offset), swapflag));
+          ms_log (0, "               record number: %u\n", HO4u (*pMS2B2000_RECNUM (record + blkt_offset), swapflag));
           ms_log (0, "                  byte order: %s (val:%u)\n",
                   order, *pMS2B2000_BYTEORDER (record + blkt_offset));
           b = *pMS2B2000_FLAGS (record + blkt_offset);
@@ -1274,7 +1274,7 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
           /* Crude display of the opaque data headers, hopefully printable */
           if (details > 1)
             ms_log (0, "                     headers: %.*s\n",
-                    (HO2u(*pMS2B2000_DATAOFFSET (record + blkt_offset), swapflag) - 15),
+                    (HO2u (*pMS2B2000_DATAOFFSET (record + blkt_offset), swapflag) - 15),
                     pMS2B2000_PAYLOAD (record + blkt_offset));
         }
       }
@@ -1309,25 +1309,25 @@ ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
     }
 
     /* Check that the data and blockette offsets are within the record */
-    if (b1000reclen && HO2u(*pMS2FSDH_DATAOFFSET (record), swapflag) > b1000reclen)
+    if (b1000reclen && HO2u (*pMS2FSDH_DATAOFFSET (record), swapflag) > b1000reclen)
     {
       ms_log (2, "%s: Data offset (%d) beyond record length (%d)\n",
-              sid, HO2u(*pMS2FSDH_DATAOFFSET (record), swapflag), b1000reclen);
+              sid, HO2u (*pMS2FSDH_DATAOFFSET (record), swapflag), b1000reclen);
       retval++;
     }
-    if (b1000reclen && HO2u(*pMS2FSDH_BLOCKETTEOFFSET (record), swapflag) > b1000reclen)
+    if (b1000reclen && HO2u (*pMS2FSDH_BLOCKETTEOFFSET (record), swapflag) > b1000reclen)
     {
       ms_log (2, "%s: Blockette offset (%d) beyond record length (%d)\n",
-              sid, HO2u(*pMS2FSDH_BLOCKETTEOFFSET (record), swapflag), b1000reclen);
+              sid, HO2u (*pMS2FSDH_BLOCKETTEOFFSET (record), swapflag), b1000reclen);
       retval++;
     }
 
     /* Check that the data offset is beyond the end of the blockettes */
-    if (HO2u(*pMS2FSDH_NUMSAMPLES (record), swapflag) &&
-        HO2u(*pMS2FSDH_DATAOFFSET (record), swapflag) <= endofblockettes)
+    if (HO2u (*pMS2FSDH_NUMSAMPLES (record), swapflag) &&
+        HO2u (*pMS2FSDH_DATAOFFSET (record), swapflag) <= endofblockettes)
     {
       ms_log (2, "%s: Data offset (%d) is within blockette chain (end of blockettes: %d)\n",
-              sid, HO2u(*pMS2FSDH_DATAOFFSET (record), swapflag), endofblockettes);
+              sid, HO2u (*pMS2FSDH_DATAOFFSET (record), swapflag), endofblockettes);
       retval++;
     }
 

--- a/selection.c
+++ b/selection.c
@@ -30,36 +30,36 @@ static int ms_isinteger (const char *string);
 static int ms_globmatch (const char *string, const char *pattern);
 
 /**********************************************************************/ /**
- * @brief Test the specified parameters for a matching selection entry
- *
- * Search the ::MS3Selections for an entry matching the provided
- * parameters.  The ::MS3Selections.sidpattern may contain globbing
- * characters.  The ::MS3Selections.timewindows many contain start and
- * end times set to ::NSTUNSET to denote "open" times.
- *
- * Positive matching requires:
- * @parblock
- *  -# glob match of sid against sidpattern in selection
- *  -# time window intersection with range in selection
- *  -# equal pubversion if selection pubversion > 0
- * @endparblock
- *
- * @param[in] selections ::MS3Selections to search
- * @param[in] sid Source ID to match
- * @param[in] starttime Start time to match
- * @param[in] endtime End time to match
- * @param[in] pubversion Publication version to match
- * @param[out] ppselecttime Pointer-to-pointer to return the matching ::MS3SelectTime entry
- *
- * @returns A pointer to matching ::MS3Selections entry successful
- * match and NULL for no match or error.
- ***************************************************************************/
+                                                                          * @brief Test the specified parameters for a matching selection entry
+                                                                          *
+                                                                          * Search the ::MS3Selections for an entry matching the provided
+                                                                          * parameters.  The ::MS3Selections.sidpattern may contain globbing
+                                                                          * characters.  The ::MS3Selections.timewindows many contain start and
+                                                                          * end times set to ::NSTUNSET to denote "open" times.
+                                                                          *
+                                                                          * Positive matching requires:
+                                                                          * @parblock
+                                                                          *  -# glob match of sid against sidpattern in selection
+                                                                          *  -# time window intersection with range in selection
+                                                                          *  -# equal pubversion if selection pubversion > 0
+                                                                          * @endparblock
+                                                                          *
+                                                                          * @param[in] selections ::MS3Selections to search
+                                                                          * @param[in] sid Source ID to match
+                                                                          * @param[in] starttime Start time to match
+                                                                          * @param[in] endtime End time to match
+                                                                          * @param[in] pubversion Publication version to match
+                                                                          * @param[out] ppselecttime Pointer-to-pointer to return the matching ::MS3SelectTime entry
+                                                                          *
+                                                                          * @returns A pointer to matching ::MS3Selections entry successful
+                                                                          * match and NULL for no match or error.
+                                                                          ***************************************************************************/
 MS3Selections *
 ms3_matchselect (MS3Selections *selections, char *sid, nstime_t starttime,
                  nstime_t endtime, int pubversion, MS3SelectTime **ppselecttime)
 {
-  MS3Selections *findsl = NULL;
-  MS3SelectTime *findst = NULL;
+  MS3Selections *findsl  = NULL;
+  MS3SelectTime *findst  = NULL;
   MS3SelectTime *matchst = NULL;
 
   if (selections)
@@ -122,25 +122,25 @@ ms3_matchselect (MS3Selections *selections, char *sid, nstime_t starttime,
 } /* End of ms3_matchselect() */
 
 /**********************************************************************/ /**
- * @brief Test the ::MS3Record for a matching selection entry
- *
- * Search the ::MS3Selections for an entry matching the provided
- * parameters.
- *
- * Positive matching requires:
- * @parblock
- *  -# glob match of sid against sidpattern in selection
- *  -# time window intersection with range in selection
- *  -# equal pubversion if selection pubversion > 0
- * @endparblock
- *
- * @param[in] selections ::MS3Selections to search
- * @param[in] msr ::MS3Record to match against selections
- * @param[out] ppselecttime Pointer-to-pointer to return the matching ::MS3SelectTime entry
- *
- * @returns A pointer to matching ::MS3Selections entry successful
- * match and NULL for no match or error.
- ***************************************************************************/
+                                                                          * @brief Test the ::MS3Record for a matching selection entry
+                                                                          *
+                                                                          * Search the ::MS3Selections for an entry matching the provided
+                                                                          * parameters.
+                                                                          *
+                                                                          * Positive matching requires:
+                                                                          * @parblock
+                                                                          *  -# glob match of sid against sidpattern in selection
+                                                                          *  -# time window intersection with range in selection
+                                                                          *  -# equal pubversion if selection pubversion > 0
+                                                                          * @endparblock
+                                                                          *
+                                                                          * @param[in] selections ::MS3Selections to search
+                                                                          * @param[in] msr ::MS3Record to match against selections
+                                                                          * @param[out] ppselecttime Pointer-to-pointer to return the matching ::MS3SelectTime entry
+                                                                          *
+                                                                          * @returns A pointer to matching ::MS3Selections entry successful
+                                                                          * match and NULL for no match or error.
+                                                                          ***************************************************************************/
 MS3Selections *
 msr3_matchselect (MS3Selections *selections, MS3Record *msr, MS3SelectTime **ppselecttime)
 {
@@ -156,26 +156,26 @@ msr3_matchselect (MS3Selections *selections, MS3Record *msr, MS3SelectTime **pps
 } /* End of msr3_matchselect() */
 
 /**********************************************************************/ /**
- * @brief Add selection parameters to selection list.
- *
- * The \a sidpattern may contain globbing characters.
- *
- * The \a starttime and \a endtime may be set to ::NSTUNSET to denote
- * "open" times.
- *
- * The \a pubversion may be set to 0 to match any publication
- * version.
- *
- * @param[in] ppselections ::MS3Selections to add new selection to
- * @param[in] sidpattern Source ID pattern, may contain globbing characters
- * @param[in] starttime Start time for selection, ::NSTUNSET for open
- * @param[in] endtime End time for selection, ::NSTUNSET for open
- * @param[in] pubversion Publication version for selection, 0 for any
- *
- * @returns 0 on success and -1 on error.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Add selection parameters to selection list.
+                                                                          *
+                                                                          * The \a sidpattern may contain globbing characters.
+                                                                          *
+                                                                          * The \a starttime and \a endtime may be set to ::NSTUNSET to denote
+                                                                          * "open" times.
+                                                                          *
+                                                                          * The \a pubversion may be set to 0 to match any publication
+                                                                          * version.
+                                                                          *
+                                                                          * @param[in] ppselections ::MS3Selections to add new selection to
+                                                                          * @param[in] sidpattern Source ID pattern, may contain globbing characters
+                                                                          * @param[in] starttime Start time for selection, ::NSTUNSET for open
+                                                                          * @param[in] endtime End time for selection, ::NSTUNSET for open
+                                                                          * @param[in] pubversion Publication version for selection, 0 for any
+                                                                          *
+                                                                          * @returns 0 on success and -1 on error.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 ms3_addselect (MS3Selections **ppselections, char *sidpattern,
                nstime_t starttime, nstime_t endtime, uint8_t pubversion)
@@ -198,7 +198,7 @@ ms3_addselect (MS3Selections **ppselections, char *sidpattern,
   memset (newst, 0, sizeof (MS3SelectTime));
 
   newst->starttime = starttime;
-  newst->endtime = endtime;
+  newst->endtime   = endtime;
 
   /* Add new Selections struct to begining of list */
   if (!*ppselections)
@@ -213,15 +213,15 @@ ms3_addselect (MS3Selections **ppselections, char *sidpattern,
 
     strncpy (newsl->sidpattern, sidpattern, sizeof (newsl->sidpattern));
     newsl->sidpattern[sizeof (newsl->sidpattern) - 1] = '\0';
-    newsl->pubversion = pubversion;
+    newsl->pubversion                                 = pubversion;
 
     /* Add new MS3SelectTime struct as first in list */
-    *ppselections = newsl;
+    *ppselections      = newsl;
     newsl->timewindows = newst;
   }
   else
   {
-    MS3Selections *findsl = *ppselections;
+    MS3Selections *findsl  = *ppselections;
     MS3Selections *matchsl = 0;
 
     /* Search for matching MS3Selections entry */
@@ -239,7 +239,7 @@ ms3_addselect (MS3Selections **ppselections, char *sidpattern,
     if (matchsl)
     {
       /* Add time window selection to beginning of window list */
-      newst->next = matchsl->timewindows;
+      newst->next          = matchsl->timewindows;
       matchsl->timewindows = newst;
     }
     else
@@ -254,11 +254,11 @@ ms3_addselect (MS3Selections **ppselections, char *sidpattern,
 
       strncpy (newsl->sidpattern, sidpattern, sizeof (newsl->sidpattern));
       newsl->sidpattern[sizeof (newsl->sidpattern) - 1] = '\0';
-      newsl->pubversion = pubversion;
+      newsl->pubversion                                 = pubversion;
 
       /* Add new MS3Selections to beginning of list */
-      newsl->next = *ppselections;
-      *ppselections = newsl;
+      newsl->next        = *ppselections;
+      *ppselections      = newsl;
       newsl->timewindows = newst;
     }
   }
@@ -387,41 +387,41 @@ ms3_addselect_comp (MS3Selections **ppselections, char *network, char *station,
 #define MAX_SELECTION_FIELDS 8
 
 /**********************************************************************/ /**
- * @brief Read data selections from a file
- *
- * Selections from a file are added to the specified selections list.
- * On errors this routine will leave allocated memory unreachable
- * (leaked), it is expected that this is a program failing condition.
- *
- * As a special case if the filename is "-", selection lines will be
- * read from stdin.
- *
- * Each line of the file contains a single selection and may be one of
- * these two line formats:
- * @code
- *   SourceID  [Starttime  [Endtime  [Pubversion]]]
- * @endcode
- *  or
- * @code
- *   Network  Station  Location  Channel  [Pubversion  [Starttime  [Endtime]]]
- * @endcode
- *
- * The \c Starttime and \c Endtime values must be in a form recognized
- * by ms_timestr2nstime() and include a full date (i.e. just a year is
- * not allowed).
- *
- * In the latter version, if the "Channel" field is a SEED 2.x channel
- * (3-characters) it will automatically be converted into extended
- * channel form (band_source_position).
- *
- * In the latter version, the "Pubversion" field, which was "Quality"
- * in the previous version of the library, is assumed to be a
- * publication version if it is an integer, otherwise it is ignored.
- *
- * @returns Count of selections added on success and -1 on error.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Read data selections from a file
+                                                                          *
+                                                                          * Selections from a file are added to the specified selections list.
+                                                                          * On errors this routine will leave allocated memory unreachable
+                                                                          * (leaked), it is expected that this is a program failing condition.
+                                                                          *
+                                                                          * As a special case if the filename is "-", selection lines will be
+                                                                          * read from stdin.
+                                                                          *
+                                                                          * Each line of the file contains a single selection and may be one of
+                                                                          * these two line formats:
+                                                                          * @code
+                                                                          *   SourceID  [Starttime  [Endtime  [Pubversion]]]
+                                                                          * @endcode
+                                                                          *  or
+                                                                          * @code
+                                                                          *   Network  Station  Location  Channel  [Pubversion  [Starttime  [Endtime]]]
+                                                                          * @endcode
+                                                                          *
+                                                                          * The \c Starttime and \c Endtime values must be in a form recognized
+                                                                          * by ms_timestr2nstime() and include a full date (i.e. just a year is
+                                                                          * not allowed).
+                                                                          *
+                                                                          * In the latter version, if the "Channel" field is a SEED 2.x channel
+                                                                          * (3-characters) it will automatically be converted into extended
+                                                                          * channel form (band_source_position).
+                                                                          *
+                                                                          * In the latter version, the "Pubversion" field, which was "Quality"
+                                                                          * in the previous version of the library, is assumed to be a
+                                                                          * publication version if it is an integer, otherwise it is ignored.
+                                                                          *
+                                                                          * @returns Count of selections added on success and -1 on error.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 ms3_readselectionsfile (MS3Selections **ppselections, char *filename)
 {
@@ -435,7 +435,7 @@ ms3_readselectionsfile (MS3Selections **ppselections, char *filename)
   char *cp;
   char next;
   int selectcount = 0;
-  int linecount = 0;
+  int linecount   = 0;
   int fieldidx;
   uint8_t isstart2;
   uint8_t isend3;
@@ -482,7 +482,7 @@ ms3_readselectionsfile (MS3Selections **ppselections, char *filename)
       cp++;
     }
     cp--;
-    while (cp >= line && isspace((int)(*cp)))
+    while (cp >= line && isspace ((int)(*cp)))
     {
       *cp = '\0';
       cp--;
@@ -490,9 +490,9 @@ ms3_readselectionsfile (MS3Selections **ppselections, char *filename)
 
     /* Trim leading whitespace if any */
     cp = line;
-    while (isspace((int)(*cp)))
+    while (isspace ((int)(*cp)))
     {
-      line = cp = cp+1;
+      line = cp = cp + 1;
     }
 
     /* Skip empty lines */
@@ -504,8 +504,8 @@ ms3_readselectionsfile (MS3Selections **ppselections, char *filename)
       continue;
 
     /* Set fields array to whitespace delimited fields */
-    cp = line;
-    next = 0;  /* For this loop: 0 = whitespace, 1 = non-whitespace */
+    cp       = line;
+    next     = 0; /* For this loop: 0 = whitespace, 1 = non-whitespace */
     fieldidx = 0;
     while (*cp && fieldidx < MAX_SELECTION_FIELDS)
     {
@@ -536,13 +536,13 @@ ms3_readselectionsfile (MS3Selections **ppselections, char *filename)
 #define INITDATEGLOB "[0-9][0-9][0-9][0-9][-/,][0-9]*"
 
     isstart2 = (fields[1]) ? ms_globmatch (fields[1], INITDATEGLOB) : 0;
-    isend3 = (fields[2]) ? ms_globmatch (fields[2], INITDATEGLOB) : 0;
+    isend3   = (fields[2]) ? ms_globmatch (fields[2], INITDATEGLOB) : 0;
     isstart6 = (fields[5]) ? ms_globmatch (fields[5], INITDATEGLOB) : 0;
-    isend7 = (fields[6]) ? ms_globmatch (fields[6], INITDATEGLOB) : 0;
+    isend7   = (fields[6]) ? ms_globmatch (fields[6], INITDATEGLOB) : 0;
 
     /* Convert starttime to nstime_t */
     starttime = NSTUNSET;
-    cp = NULL;
+    cp        = NULL;
     if (isstart2)
       cp = fields[1];
     else if (isstart6)
@@ -559,7 +559,7 @@ ms3_readselectionsfile (MS3Selections **ppselections, char *filename)
 
     /* Convert endtime to nstime_t */
     endtime = NSTUNSET;
-    cp = NULL;
+    cp      = NULL;
     if (isend3)
       cp = fields[2];
     else if (isend7)
@@ -578,7 +578,7 @@ ms3_readselectionsfile (MS3Selections **ppselections, char *filename)
     if (fieldidx == 1 ||
         (fieldidx == 2 && isstart2) ||
         (fieldidx == 3 && isstart2 && isend3) ||
-        (fieldidx == 4 && isstart2 && isend3 && ms_isinteger(fields[3])))
+        (fieldidx == 4 && isstart2 && isend3 && ms_isinteger (fields[3])))
     {
       /* Convert publication version to integer */
       pubversion = 0;
@@ -588,14 +588,14 @@ ms3_readselectionsfile (MS3Selections **ppselections, char *filename)
 
         longpver = strtol (fields[3], NULL, 10);
 
-        if (longpver < 0 || longpver > 255 )
+        if (longpver < 0 || longpver > 255)
         {
           ms_log (2, "Cannot convert publication version (line %d): %s\n", linecount, fields[3]);
           return -1;
         }
         else
         {
-          pubversion = (uint8_t) longpver;
+          pubversion = (uint8_t)longpver;
         }
       }
 
@@ -613,20 +613,20 @@ ms3_readselectionsfile (MS3Selections **ppselections, char *filename)
     {
       /* Convert quality field to publication version if integer */
       pubversion = 0;
-      if (fields[4] && ms_isinteger(fields[4]))
+      if (fields[4] && ms_isinteger (fields[4]))
       {
         long int longpver;
 
         longpver = strtol (fields[4], NULL, 10);
 
-        if (longpver < 0 || longpver > 255 )
+        if (longpver < 0 || longpver > 255)
         {
           ms_log (2, "Cannot convert publication version (line %d): %s\n", linecount, fields[4]);
           return -1;
         }
         else
         {
-          pubversion = (uint8_t) longpver;
+          pubversion = (uint8_t)longpver;
         }
       }
 
@@ -652,12 +652,12 @@ ms3_readselectionsfile (MS3Selections **ppselections, char *filename)
 } /* End of ms_readselectionsfile() */
 
 /**********************************************************************/ /**
- * @brief Free all memory associated with a ::MS3Selections
- *
- * All memory from one or more ::MS3Selections (in a linked list) are freed.
- *
- * @param[in] selections Start of ::MS3Selections to free
- ***************************************************************************/
+                                                                          * @brief Free all memory associated with a ::MS3Selections
+                                                                          *
+                                                                          * All memory from one or more ::MS3Selections (in a linked list) are freed.
+                                                                          *
+                                                                          * @param[in] selections Start of ::MS3Selections to free
+                                                                          ***************************************************************************/
 void
 ms3_freeselections (MS3Selections *selections)
 {
@@ -694,12 +694,12 @@ ms3_freeselections (MS3Selections *selections)
 } /* End of ms3_freeselections() */
 
 /**********************************************************************/ /**
- * @brief Print the selections list using the ms_log() facility.
- *
- * All selections are printed with simple formatting.
- *
- * @param[in] selections Start of ::MS3Selections to print
- ***************************************************************************/
+                                                                          * @brief Print the selections list using the ms_log() facility.
+                                                                          *
+                                                                          * All selections are printed with simple formatting.
+                                                                          *
+                                                                          * @param[in] selections Start of ::MS3Selections to print
+                                                                          ***************************************************************************/
 void
 ms3_printselections (MS3Selections *selections)
 {
@@ -751,7 +751,7 @@ ms_isinteger (const char *string)
 {
   while (*string)
   {
-    if (!isdigit((int)(*string)))
+    if (!isdigit ((int)(*string)))
       return 0;
     string++;
   }

--- a/tracelist.c
+++ b/tracelist.c
@@ -35,18 +35,18 @@ static uint32_t lm_lcg_r (uint64_t *state);
 static uint8_t lm_random_height (uint8_t maximum, uint64_t *state);
 
 /**********************************************************************/ /**
- * @brief Initialize a ::MS3TraceList container
- *
- * A new ::MS3TraceList is allocated if needed. If the supplied
- * ::MS3TraceList is not NULL it will be re-initialized and any
- * associated memory will be freed including data at \a prvtptr pointers.
- *
- * @param[in] mstl ::MS3TraceList to reinitialize or NULL
- *
- * @returns a pointer to a MS3TraceList struct on success or NULL on error.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Initialize a ::MS3TraceList container
+                                                                          *
+                                                                          * A new ::MS3TraceList is allocated if needed. If the supplied
+                                                                          * ::MS3TraceList is not NULL it will be re-initialized and any
+                                                                          * associated memory will be freed including data at \a prvtptr pointers.
+                                                                          *
+                                                                          * @param[in] mstl ::MS3TraceList to reinitialize or NULL
+                                                                          *
+                                                                          * @returns a pointer to a MS3TraceList struct on success or NULL on error.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 MS3TraceList *
 mstl3_init (MS3TraceList *mstl)
 {
@@ -66,28 +66,28 @@ mstl3_init (MS3TraceList *mstl)
   memset (mstl, 0, sizeof (MS3TraceList));
 
   /* Seed PRNG with 1, we only need random distribution */
-  mstl->prngstate = 1;
+  mstl->prngstate     = 1;
   mstl->traces.height = MSTRACEID_SKIPLIST_HEIGHT;
 
   return mstl;
 } /* End of mstl3_init() */
 
 /**********************************************************************/ /**
- * @brief Free all memory associated with a ::MS3TraceList
- *
- * The pointer to the target ::MS3TraceList will be set to NULL.
- *
- * @param[in] ppmstl Pointer-to-pointer to the target ::MS3TraceList to free
- * @param[in] freeprvtptr If true, also free any data at the \a
- * prvtptr members of ::MS3TraceID.prvtptr, ::MS3TraceSeg.prvtptr, and
- * ::MS3RecordPtr.prvtptr (in ::MS3TraceSeg.recordlist)
- ***************************************************************************/
+                                                                          * @brief Free all memory associated with a ::MS3TraceList
+                                                                          *
+                                                                          * The pointer to the target ::MS3TraceList will be set to NULL.
+                                                                          *
+                                                                          * @param[in] ppmstl Pointer-to-pointer to the target ::MS3TraceList to free
+                                                                          * @param[in] freeprvtptr If true, also free any data at the \a
+                                                                          * prvtptr members of ::MS3TraceID.prvtptr, ::MS3TraceSeg.prvtptr, and
+                                                                          * ::MS3RecordPtr.prvtptr (in ::MS3TraceSeg.recordlist)
+                                                                          ***************************************************************************/
 void
 mstl3_free (MS3TraceList **ppmstl, int8_t freeprvtptr)
 {
-  MS3TraceID *id = 0;
-  MS3TraceID *nextid = 0;
-  MS3TraceSeg *seg = 0;
+  MS3TraceID *id       = 0;
+  MS3TraceID *nextid   = 0;
+  MS3TraceSeg *seg     = 0;
   MS3TraceSeg *nextseg = 0;
   MS3RecordPtr *recordptr;
   MS3RecordPtr *nextrecordptr;
@@ -158,21 +158,21 @@ mstl3_free (MS3TraceList **ppmstl, int8_t freeprvtptr)
 } /* End of mstl3_free() */
 
 /**********************************************************************/ /**
- * @brief Find matching ::MS3TraceID in a ::MS3TraceList
- *
- * Return the ::MS3TraceID matching the \a sid in the specified ::MS3TraceList.
- *
- * If \a prev is not NULL, set pointers to previous entries for the
- * expected location of the trace ID.  Useful for adding a new ID
- * with mstl3_addID(), and should be set to \a NULL otherwise.
- *
- * @param[in] mstl Pointer to the ::MS3TraceList to search
- * @param[in] sid Source ID to search for in the list
- * @param[in] pubversion If non-zero, find the entry with this version
- * @param[out] prev Pointers to previous entries in expected location or NULL
- *
- * @returns a pointer to the matching ::MS3TraceID or NULL if not found or error.
- ***************************************************************************/
+                                                                          * @brief Find matching ::MS3TraceID in a ::MS3TraceList
+                                                                          *
+                                                                          * Return the ::MS3TraceID matching the \a sid in the specified ::MS3TraceList.
+                                                                          *
+                                                                          * If \a prev is not NULL, set pointers to previous entries for the
+                                                                          * expected location of the trace ID.  Useful for adding a new ID
+                                                                          * with mstl3_addID(), and should be set to \a NULL otherwise.
+                                                                          *
+                                                                          * @param[in] mstl Pointer to the ::MS3TraceList to search
+                                                                          * @param[in] sid Source ID to search for in the list
+                                                                          * @param[in] pubversion If non-zero, find the entry with this version
+                                                                          * @param[out] prev Pointers to previous entries in expected location or NULL
+                                                                          *
+                                                                          * @returns a pointer to the matching ::MS3TraceID or NULL if not found or error.
+                                                                          ***************************************************************************/
 MS3TraceID *
 mstl3_findID (MS3TraceList *mstl, const char *sid, uint8_t pubversion, MS3TraceID **prev)
 {
@@ -203,7 +203,7 @@ mstl3_findID (MS3TraceList *mstl, const char *sid, uint8_t pubversion, MS3TraceI
     }
     else
     {
-      cmp = strcmp(id->next[level]->sid, sid);
+      cmp = strcmp (id->next[level]->sid, sid);
 
       /* If source IDs match, check publication if matching requested */
       if (!cmp && pubversion && id->next[level]->pubversion != pubversion)
@@ -230,21 +230,21 @@ mstl3_findID (MS3TraceList *mstl, const char *sid, uint8_t pubversion, MS3TraceI
 } /* End of mstl3_findID() */
 
 /**********************************************************************/ /**
- * @brief Add ::MS3TraceID to a ::MS3TraceList
- *
- * The \a prev array is the list of pointers to previous entries at different
- * levels of the skip list.  It is common to first search the list using
- * mstl3_findID() which returns this list of pointers for use here.
- * If this value is NULL mstl3_findID() will be run to find the pointers.
- *
- * @param[in] mstl Add ID to this ::MS3TraceList
- * @param[in] id The ::MS3TraceID to add
- * @param[in] prev Pointers to previous entries in expected location, can be NULL
- *
- * @returns a pointer to the added ::MS3TraceID or NULL on error.
- *
- * \sa mstl3_findID()
- ***************************************************************************/
+                                                                          * @brief Add ::MS3TraceID to a ::MS3TraceList
+                                                                          *
+                                                                          * The \a prev array is the list of pointers to previous entries at different
+                                                                          * levels of the skip list.  It is common to first search the list using
+                                                                          * mstl3_findID() which returns this list of pointers for use here.
+                                                                          * If this value is NULL mstl3_findID() will be run to find the pointers.
+                                                                          *
+                                                                          * @param[in] mstl Add ID to this ::MS3TraceList
+                                                                          * @param[in] id The ::MS3TraceID to add
+                                                                          * @param[in] prev Pointers to previous entries in expected location, can be NULL
+                                                                          *
+                                                                          * @returns a pointer to the added ::MS3TraceID or NULL on error.
+                                                                          *
+                                                                          * \sa mstl3_findID()
+                                                                          ***************************************************************************/
 MS3TraceID *
 mstl3_addID (MS3TraceList *mstl, MS3TraceID *id, MS3TraceID **prev)
 {
@@ -287,7 +287,7 @@ mstl3_addID (MS3TraceList *mstl, MS3TraceID *id, MS3TraceID **prev)
       return NULL;
     }
 
-    id->next[level] = prev[level]->next[level];
+    id->next[level]          = prev[level]->next[level];
     prev[level]->next[level] = id;
   }
 
@@ -296,79 +296,78 @@ mstl3_addID (MS3TraceList *mstl, MS3TraceID *id, MS3TraceID **prev)
   return id;
 } /* End of mstl3_addID() */
 
-
 /**********************************************************************/ /**
- * @brief Add data coverage from an ::MS3Record to a ::MS3TraceList
- *
- * Searching the list for the appropriate ::MS3TraceID and
- * ::MS3TraceSeg and either add data to existing entries or create new
- * ones as needed.
- *
- * As this routine adds data to a trace list it constructs continuous
- * time series, merging segments when possible.  The \a tolerance
- * pointer to a ::MS3Tolerance identifies function pointers that are
- * expected to return time tolerace, in seconds, and sample rate
- * tolerance, in Hertz, for the given ::MS3Record.  If \a tolerance is
- * NULL, or the function pointers it identifies are NULL, default
- * tolerances will be used as follows: - Default time tolerance is 1/2
- * the sampling period - Default sample rate (sr) tolerance is
- * abs(1‐sr1/sr2) < 0.0001
- *
- * In recommended usage, the \a splitversion flag is \b 0 and
- * different publication versions of otherwise matching data are
- * merged.  If more than one version contributes to a given source
- * identifer's segments, its ::MS3TraceID.pubversion will be the set to
- * the largest contributing version.  If the \a splitversion flag is
- * \b 1 the publication versions will be kept separate with each
- * version isolated in separate ::MS3TraceID entries.
- *
- * If the \a autoheal flag is true, extra processing is invoked to
- * conjoin trace segments that fit together after the ::MS3Record
- * coverage is added.  For segments that are removed, any memory at
- * the ::MS3TraceSeg.prvtptr will be freed.
- *
- * If the \a pprecptr is not NULL a @ref record-list will be
- * maintained for each segment.  If the value of \c *pprecptr is NULL,
- * a new ::MS3RecordPtr will be allocated, otherwise the supplied
- * structure will be updated.  The ::MS3RecordPtr will be added to the
- * appropriate record list and the values of ::MS3RecordPtr.msr and
- * ::MS3RecordPtr.endtime will be set, all other fields should be set
- * by the caller.
- *
- * The lists are always maintained in a sorted order.  An
- * ::MS3TraceList is maintained with the ::MS3TraceID entries in
- * ascending alphanumeric order of SID. If repeated SIDs are present
- * due to splitting on publication version, they are maintained in
- * order of ascending version.  A ::MS3TraceID is always maintained
- * with ::MS3TraceSeg entries in data time time order.
- *
- * @param[in] mstl Destination ::MS3TraceList to add data to
- * @param[in] msr ::MS3Record containing the data to add to list
- * @param[in] pprecptr Pointer to pointer to a ::MS3RecordPtr for @ref record-list
- * @param[in] splitversion Flag to control splitting of version/quality
- * @param[in] autoheal Flag to control automatic merging of segments
- * @param[in] flags Flags to control optional functionality (unused)
- * @param[in] tolerance Tolerance function pointers as ::MS3Tolerance
- *
- * @returns a pointer to the ::MS3TraceSeg updated or NULL on error.
- *
- * \sa mstl3_readbuffer()
- * \sa ms3_readtracelist()
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Add data coverage from an ::MS3Record to a ::MS3TraceList
+                                                                          *
+                                                                          * Searching the list for the appropriate ::MS3TraceID and
+                                                                          * ::MS3TraceSeg and either add data to existing entries or create new
+                                                                          * ones as needed.
+                                                                          *
+                                                                          * As this routine adds data to a trace list it constructs continuous
+                                                                          * time series, merging segments when possible.  The \a tolerance
+                                                                          * pointer to a ::MS3Tolerance identifies function pointers that are
+                                                                          * expected to return time tolerace, in seconds, and sample rate
+                                                                          * tolerance, in Hertz, for the given ::MS3Record.  If \a tolerance is
+                                                                          * NULL, or the function pointers it identifies are NULL, default
+                                                                          * tolerances will be used as follows: - Default time tolerance is 1/2
+                                                                          * the sampling period - Default sample rate (sr) tolerance is
+                                                                          * abs(1‐sr1/sr2) < 0.0001
+                                                                          *
+                                                                          * In recommended usage, the \a splitversion flag is \b 0 and
+                                                                          * different publication versions of otherwise matching data are
+                                                                          * merged.  If more than one version contributes to a given source
+                                                                          * identifer's segments, its ::MS3TraceID.pubversion will be the set to
+                                                                          * the largest contributing version.  If the \a splitversion flag is
+                                                                          * \b 1 the publication versions will be kept separate with each
+                                                                          * version isolated in separate ::MS3TraceID entries.
+                                                                          *
+                                                                          * If the \a autoheal flag is true, extra processing is invoked to
+                                                                          * conjoin trace segments that fit together after the ::MS3Record
+                                                                          * coverage is added.  For segments that are removed, any memory at
+                                                                          * the ::MS3TraceSeg.prvtptr will be freed.
+                                                                          *
+                                                                          * If the \a pprecptr is not NULL a @ref record-list will be
+                                                                          * maintained for each segment.  If the value of \c *pprecptr is NULL,
+                                                                          * a new ::MS3RecordPtr will be allocated, otherwise the supplied
+                                                                          * structure will be updated.  The ::MS3RecordPtr will be added to the
+                                                                          * appropriate record list and the values of ::MS3RecordPtr.msr and
+                                                                          * ::MS3RecordPtr.endtime will be set, all other fields should be set
+                                                                          * by the caller.
+                                                                          *
+                                                                          * The lists are always maintained in a sorted order.  An
+                                                                          * ::MS3TraceList is maintained with the ::MS3TraceID entries in
+                                                                          * ascending alphanumeric order of SID. If repeated SIDs are present
+                                                                          * due to splitting on publication version, they are maintained in
+                                                                          * order of ascending version.  A ::MS3TraceID is always maintained
+                                                                          * with ::MS3TraceSeg entries in data time time order.
+                                                                          *
+                                                                          * @param[in] mstl Destination ::MS3TraceList to add data to
+                                                                          * @param[in] msr ::MS3Record containing the data to add to list
+                                                                          * @param[in] pprecptr Pointer to pointer to a ::MS3RecordPtr for @ref record-list
+                                                                          * @param[in] splitversion Flag to control splitting of version/quality
+                                                                          * @param[in] autoheal Flag to control automatic merging of segments
+                                                                          * @param[in] flags Flags to control optional functionality (unused)
+                                                                          * @param[in] tolerance Tolerance function pointers as ::MS3Tolerance
+                                                                          *
+                                                                          * @returns a pointer to the ::MS3TraceSeg updated or NULL on error.
+                                                                          *
+                                                                          * \sa mstl3_readbuffer()
+                                                                          * \sa ms3_readtracelist()
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 MS3TraceSeg *
 mstl3_addmsr_recordptr (MS3TraceList *mstl, MS3Record *msr, MS3RecordPtr **pprecptr,
                         int8_t splitversion, int8_t autoheal, uint32_t flags,
                         MS3Tolerance *tolerance)
 {
-  MS3TraceID *id = 0;
+  MS3TraceID *id                                = 0;
   MS3TraceID *previd[MSTRACEID_SKIPLIST_HEIGHT] = {NULL};
 
-  MS3TraceSeg *seg = 0;
+  MS3TraceSeg *seg       = 0;
   MS3TraceSeg *searchseg = 0;
   MS3TraceSeg *segbefore = 0;
-  MS3TraceSeg *segafter = 0;
+  MS3TraceSeg *segafter  = 0;
   MS3TraceSeg *followseg = 0;
 
   nstime_t endtime;
@@ -377,7 +376,7 @@ mstl3_addmsr_recordptr (MS3TraceList *mstl, MS3Record *msr, MS3RecordPtr **pprec
   nstime_t lastgap;
   nstime_t firstgap;
   nstime_t nsdelta;
-  nstime_t nstimetol = 0;
+  nstime_t nstimetol  = 0;
   nstime_t nnstimetol = 0;
 
   double sampratehz;
@@ -416,10 +415,10 @@ mstl3_addmsr_recordptr (MS3TraceList *mstl, MS3Record *msr, MS3RecordPtr **pprec
     memset (id, 0, sizeof (MS3TraceID));
 
     /* Populate MS3TraceID */
-    memcpy (id->sid, msr->sid, sizeof(id->sid));
-    id->pubversion = msr->pubversion;
-    id->earliest = msr->starttime;
-    id->latest = endtime;
+    memcpy (id->sid, msr->sid, sizeof (id->sid));
+    id->pubversion  = msr->pubversion;
+    id->earliest    = msr->starttime;
+    id->latest      = endtime;
     id->numsegments = 1;
 
     if (!(seg = mstl3_msr2seg (msr, endtime)))
@@ -446,17 +445,17 @@ mstl3_addmsr_recordptr (MS3TraceList *mstl, MS3Record *msr, MS3RecordPtr **pprec
   {
     /* Calculate high-precision sample period, handling different rate notations */
     if (msr->samprate > 0.0)
-      nsdelta = (nstime_t) (NSTMODULUS / msr->samprate); /* samples/second */
+      nsdelta = (nstime_t)(NSTMODULUS / msr->samprate); /* samples/second */
     else if (msr->samprate < 0.0)
-      nsdelta = (nstime_t) (NSTMODULUS * -msr->samprate); /* period */
+      nsdelta = (nstime_t)(NSTMODULUS * -msr->samprate); /* period */
     else
       nsdelta = 0;
 
     /* Calculate high-precision time tolerance */
     if (tolerance && tolerance->time)
-      nstimetol = (nstime_t) (NSTMODULUS * tolerance->time (msr));
+      nstimetol = (nstime_t)(NSTMODULUS * tolerance->time (msr));
     else
-      nstimetol = (nstime_t) (0.5 * nsdelta); /* Default time tolerance is 1/2 sample period */
+      nstimetol = (nstime_t)(0.5 * nsdelta); /* Default time tolerance is 1/2 sample period */
 
     nnstimetol = (nstimetol) ? -nstimetol : 0;
 
@@ -464,7 +463,7 @@ mstl3_addmsr_recordptr (MS3TraceList *mstl, MS3Record *msr, MS3RecordPtr **pprec
     if (tolerance && tolerance->samprate)
       sampratetol = tolerance->samprate (msr);
 
-    sampratehz = msr3_sampratehz(msr);
+    sampratehz = msr3_sampratehz (msr);
 
     /* last/firstgap are negative when the record overlaps the trace
      * segment and positive when there is a time gap. */
@@ -478,12 +477,12 @@ mstl3_addmsr_recordptr (MS3TraceList *mstl, MS3Record *msr, MS3RecordPtr **pprec
     /* Sample rate tolerance checks for first and last segments */
     if (tolerance && tolerance->samprate)
     {
-      lastratecheck = (sampratetol < 0.0 || ms_dabs (sampratehz - id->last->samprate) > sampratetol) ? 0 : 1;
+      lastratecheck  = (sampratetol < 0.0 || ms_dabs (sampratehz - id->last->samprate) > sampratetol) ? 0 : 1;
       firstratecheck = (sampratetol < 0.0 || ms_dabs (sampratehz - id->first->samprate) > sampratetol) ? 0 : 1;
     }
     else
     {
-      lastratecheck = MS_ISRATETOLERABLE (sampratehz, id->last->samprate);
+      lastratecheck  = MS_ISRATETOLERABLE (sampratehz, id->last->samprate);
       firstratecheck = MS_ISRATETOLERABLE (sampratehz, id->first->samprate);
     }
 
@@ -519,8 +518,8 @@ mstl3_addmsr_recordptr (MS3TraceList *mstl, MS3Record *msr, MS3RecordPtr **pprec
 
       /* Add to end of list */
       id->last->next = seg;
-      seg->prev = id->last;
-      id->last = seg;
+      seg->prev      = id->last;
+      id->last       = seg;
       id->numsegments++;
 
       if (endtime > id->latest)
@@ -538,8 +537,8 @@ mstl3_addmsr_recordptr (MS3TraceList *mstl, MS3Record *msr, MS3RecordPtr **pprec
 
       /* Add to beginning of list */
       id->first->prev = seg;
-      seg->next = id->first;
-      id->first = seg;
+      seg->next       = id->first;
+      id->first       = seg;
       id->numsegments++;
 
       if (msr->starttime < id->earliest)
@@ -774,8 +773,8 @@ mstl3_addmsr_recordptr (MS3TraceList *mstl, MS3Record *msr, MS3RecordPtr **pprec
       segafter->next->prev = seg;
 
     segafter->prev = seg->prev;
-    seg->prev = segafter;
-    seg->next = segafter->next;
+    seg->prev      = segafter;
+    seg->next      = segafter->next;
     segafter->next = seg;
 
     /* Reset first and last segment pointers if replaced */
@@ -798,8 +797,8 @@ mstl3_addmsr_recordptr (MS3TraceList *mstl, MS3Record *msr, MS3RecordPtr **pprec
       segbefore->prev->next = seg;
 
     segbefore->next = seg->next;
-    seg->next = segbefore;
-    seg->prev = segbefore->prev;
+    seg->next       = segbefore;
+    seg->prev       = segbefore->prev;
     segbefore->prev = seg;
 
     /* Reset first and last segment pointers if replaced */
@@ -813,41 +812,40 @@ mstl3_addmsr_recordptr (MS3TraceList *mstl, MS3Record *msr, MS3RecordPtr **pprec
   return seg;
 } /* End of mstl3_addmsr_recordptr() */
 
-
 /****************************************************************/ /**
- * @brief Parse miniSEED from a buffer and populate a ::MS3TraceList
- *
- * For a full description of \a tolerance see mstl3_addmsr().
- *
- * If the ::MSF_UNPACKDATA flag is set in \a flags, the data samples
- * will be unpacked.  In most cases the caller probably wants this
- * flag set, without it the trace list will merely be a list of
- * channels.
- *
- * If the ::MSF_RECORDLIST flag is set in \a flags, a ::MS3RecordList
- * will be built for each ::MS3TraceSeg.  The ::MS3RecordPtr entries
- * contain the location of the data record, bit flags, extra headers, etc.
- *
- * @param[in] ppmstl Pointer-to-point to destination MS3TraceList
- * @param[in] buffer Source buffer to read miniSEED records from
- * @param[in] bufferlength Maximum length of \a buffer
- * @param[in] splitversion Flag to control splitting of version/quality
- * @param[in] flags Flags to control parsing and optional functionality:
- * @parblock
- *  - \c ::MSF_RECORDLIST : Build a ::MS3RecordList for each ::MS3TraceSeg
- *  - Flags supported by msr3_parse()
- *  - Flags supported by mstl3_addmsr()
- * @endparblock
- * @param[in] tolerance Tolerance function pointers as ::MS3Tolerance
- * @param[in] verbose Controls verbosity, 0 means no diagnostic output
- *
- * @returns The number of records parsed on success, otherwise a
- * negative library error code.
- *
- * \ref MessageOnError - this function logs a message on error
- *
- * \sa mstl3_addmsr()
- *********************************************************************/
+                                                                    * @brief Parse miniSEED from a buffer and populate a ::MS3TraceList
+                                                                    *
+                                                                    * For a full description of \a tolerance see mstl3_addmsr().
+                                                                    *
+                                                                    * If the ::MSF_UNPACKDATA flag is set in \a flags, the data samples
+                                                                    * will be unpacked.  In most cases the caller probably wants this
+                                                                    * flag set, without it the trace list will merely be a list of
+                                                                    * channels.
+                                                                    *
+                                                                    * If the ::MSF_RECORDLIST flag is set in \a flags, a ::MS3RecordList
+                                                                    * will be built for each ::MS3TraceSeg.  The ::MS3RecordPtr entries
+                                                                    * contain the location of the data record, bit flags, extra headers, etc.
+                                                                    *
+                                                                    * @param[in] ppmstl Pointer-to-point to destination MS3TraceList
+                                                                    * @param[in] buffer Source buffer to read miniSEED records from
+                                                                    * @param[in] bufferlength Maximum length of \a buffer
+                                                                    * @param[in] splitversion Flag to control splitting of version/quality
+                                                                    * @param[in] flags Flags to control parsing and optional functionality:
+                                                                    * @parblock
+                                                                    *  - \c ::MSF_RECORDLIST : Build a ::MS3RecordList for each ::MS3TraceSeg
+                                                                    *  - Flags supported by msr3_parse()
+                                                                    *  - Flags supported by mstl3_addmsr()
+                                                                    * @endparblock
+                                                                    * @param[in] tolerance Tolerance function pointers as ::MS3Tolerance
+                                                                    * @param[in] verbose Controls verbosity, 0 means no diagnostic output
+                                                                    *
+                                                                    * @returns The number of records parsed on success, otherwise a
+                                                                    * negative library error code.
+                                                                    *
+                                                                    * \ref MessageOnError - this function logs a message on error
+                                                                    *
+                                                                    * \sa mstl3_addmsr()
+                                                                    *********************************************************************/
 int64_t
 mstl3_readbuffer (MS3TraceList **ppmstl, char *buffer, uint64_t bufferlength,
                   int8_t splitversion, uint32_t flags,
@@ -859,52 +857,52 @@ mstl3_readbuffer (MS3TraceList **ppmstl, char *buffer, uint64_t bufferlength,
 } /* End of mstl3_readbuffer() */
 
 /****************************************************************/ /**
- * @brief Parse miniSEED from a buffer and populate a ::MS3TraceList
- *
- * For a full description of \a tolerance see mstl3_addmsr().
- *
- * If the ::MSF_UNPACKDATA flag is set in \a flags, the data samples
- * will be unpacked.  In most cases the caller probably wants this
- * flag set, without it the trace list will merely be a list of
- * channels.
- *
- * If the ::MSF_RECORDLIST flag is set in \a flags, a ::MS3RecordList
- * will be built for each ::MS3TraceSeg.  The ::MS3RecordPtr entries
- * contain the location of the data record, bit flags, extra headers, etc.
- *
- * If \a selections is not NULL, the ::MS3Selections will be used to
- * limit what is returned to the caller.  Any data not matching the
- * selections will be skipped.
- *
- * @param[in] ppmstl Pointer-to-point to destination MS3TraceList
- * @param[in] buffer Source buffer to read miniSEED records from
- * @param[in] bufferlength Maximum length of \a buffer
- * @param[in] splitversion Flag to control splitting of version/quality
- * @param[in] flags Flags to control parsing and optional functionality:
- * @parblock
- *  - \c ::MSF_RECORDLIST : Build a ::MS3RecordList for each ::MS3TraceSeg
- *  - Flags supported by msr3_parse()
- *  - Flags supported by mstl3_addmsr()
- * @endparblock
- * @param[in] tolerance Tolerance function pointers as ::MS3Tolerance
- * @param[in] selections Specify limits to which data should be returned, see @ref data-selections
- * @param[in] verbose Controls verbosity, 0 means no diagnostic output
- *
- * @returns The number of records parsed on success, otherwise a
- * negative library error code.
- *
- * \ref MessageOnError - this function logs a message on error
- *
- * \sa mstl3_addmsr()
- *********************************************************************/
+                                                                    * @brief Parse miniSEED from a buffer and populate a ::MS3TraceList
+                                                                    *
+                                                                    * For a full description of \a tolerance see mstl3_addmsr().
+                                                                    *
+                                                                    * If the ::MSF_UNPACKDATA flag is set in \a flags, the data samples
+                                                                    * will be unpacked.  In most cases the caller probably wants this
+                                                                    * flag set, without it the trace list will merely be a list of
+                                                                    * channels.
+                                                                    *
+                                                                    * If the ::MSF_RECORDLIST flag is set in \a flags, a ::MS3RecordList
+                                                                    * will be built for each ::MS3TraceSeg.  The ::MS3RecordPtr entries
+                                                                    * contain the location of the data record, bit flags, extra headers, etc.
+                                                                    *
+                                                                    * If \a selections is not NULL, the ::MS3Selections will be used to
+                                                                    * limit what is returned to the caller.  Any data not matching the
+                                                                    * selections will be skipped.
+                                                                    *
+                                                                    * @param[in] ppmstl Pointer-to-point to destination MS3TraceList
+                                                                    * @param[in] buffer Source buffer to read miniSEED records from
+                                                                    * @param[in] bufferlength Maximum length of \a buffer
+                                                                    * @param[in] splitversion Flag to control splitting of version/quality
+                                                                    * @param[in] flags Flags to control parsing and optional functionality:
+                                                                    * @parblock
+                                                                    *  - \c ::MSF_RECORDLIST : Build a ::MS3RecordList for each ::MS3TraceSeg
+                                                                    *  - Flags supported by msr3_parse()
+                                                                    *  - Flags supported by mstl3_addmsr()
+                                                                    * @endparblock
+                                                                    * @param[in] tolerance Tolerance function pointers as ::MS3Tolerance
+                                                                    * @param[in] selections Specify limits to which data should be returned, see @ref data-selections
+                                                                    * @param[in] verbose Controls verbosity, 0 means no diagnostic output
+                                                                    *
+                                                                    * @returns The number of records parsed on success, otherwise a
+                                                                    * negative library error code.
+                                                                    *
+                                                                    * \ref MessageOnError - this function logs a message on error
+                                                                    *
+                                                                    * \sa mstl3_addmsr()
+                                                                    *********************************************************************/
 int64_t
 mstl3_readbuffer_selection (MS3TraceList **ppmstl, char *buffer, uint64_t bufferlength,
                             int8_t splitversion, uint32_t flags,
                             MS3Tolerance *tolerance, MS3Selections *selections,
                             int8_t verbose)
 {
-  MS3Record *msr   = NULL;
-  MS3TraceSeg *seg = NULL;
+  MS3Record *msr          = NULL;
+  MS3TraceSeg *seg        = NULL;
   MS3RecordPtr *recordptr = NULL;
   uint32_t dataoffset;
   uint32_t datasize;
@@ -1024,7 +1022,7 @@ MS3TraceSeg *
 mstl3_msr2seg (MS3Record *msr, nstime_t endtime)
 {
   MS3TraceSeg *seg = 0;
-  size_t datasize = 0;
+  size_t datasize  = 0;
   int samplesize;
 
   if (!(seg = (MS3TraceSeg *)libmseed_memory.malloc (sizeof (MS3TraceSeg))))
@@ -1035,10 +1033,10 @@ mstl3_msr2seg (MS3Record *msr, nstime_t endtime)
   memset (seg, 0, sizeof (MS3TraceSeg));
 
   /* Populate MS3TraceSeg */
-  seg->starttime = msr->starttime;
-  seg->endtime = endtime;
-  seg->samprate = msr3_sampratehz(msr);
-  seg->samplecnt = msr->samplecnt;
+  seg->starttime  = msr->starttime;
+  seg->endtime    = endtime;
+  seg->samprate   = msr3_sampratehz (msr);
+  seg->samplecnt  = msr->samplecnt;
   seg->sampletype = msr->sampletype;
   seg->numsamples = msr->numsamples;
 
@@ -1053,7 +1051,7 @@ mstl3_msr2seg (MS3Record *msr, nstime_t endtime)
 
     datasize = samplesize * msr->numsamples;
 
-    if (!(seg->datasamples = libmseed_memory.malloc ((size_t) (datasize))))
+    if (!(seg->datasamples = libmseed_memory.malloc ((size_t)(datasize))))
     {
       ms_log (2, "Error allocating memory\n");
       return NULL;
@@ -1082,9 +1080,9 @@ mstl3_msr2seg (MS3Record *msr, nstime_t endtime)
 MS3TraceSeg *
 mstl3_addmsrtoseg (MS3TraceSeg *seg, MS3Record *msr, nstime_t endtime, int8_t whence)
 {
-  int samplesize = 0;
+  int samplesize       = 0;
   void *newdatasamples = NULL;
-  size_t newdatasize = 0;
+  size_t newdatasize   = 0;
 
   if (!seg || !msr)
   {
@@ -1117,7 +1115,7 @@ mstl3_addmsrtoseg (MS3TraceSeg *seg, MS3Record *msr, nstime_t endtime, int8_t wh
     else
     {
       newdatasamples = libmseed_memory.realloc (seg->datasamples, newdatasize);
-      seg->datasize = newdatasize;
+      seg->datasize  = newdatasize;
     }
 
     if (!newdatasamples)
@@ -1140,7 +1138,7 @@ mstl3_addmsrtoseg (MS3TraceSeg *seg, MS3Record *msr, nstime_t endtime, int8_t wh
     {
       memcpy ((char *)seg->datasamples + (seg->numsamples * samplesize),
               msr->datasamples,
-              (size_t) (msr->numsamples * samplesize));
+              (size_t)(msr->numsamples * samplesize));
 
       seg->numsamples += msr->numsamples;
     }
@@ -1155,11 +1153,11 @@ mstl3_addmsrtoseg (MS3TraceSeg *seg, MS3Record *msr, nstime_t endtime, int8_t wh
     {
       memmove ((char *)seg->datasamples + (msr->numsamples * samplesize),
                seg->datasamples,
-               (size_t) (seg->numsamples * samplesize));
+               (size_t)(seg->numsamples * samplesize));
 
       memcpy (seg->datasamples,
               msr->datasamples,
-              (size_t) (msr->numsamples * samplesize));
+              (size_t)(msr->numsamples * samplesize));
 
       seg->numsamples += msr->numsamples;
     }
@@ -1183,9 +1181,9 @@ mstl3_addmsrtoseg (MS3TraceSeg *seg, MS3Record *msr, nstime_t endtime, int8_t wh
 MS3TraceSeg *
 mstl3_addsegtoseg (MS3TraceSeg *seg1, MS3TraceSeg *seg2)
 {
-  int samplesize = 0;
+  int samplesize       = 0;
   void *newdatasamples = NULL;
-  size_t newdatasize = 0;
+  size_t newdatasize   = 0;
 
   if (!seg1 || !seg2)
   {
@@ -1239,7 +1237,7 @@ mstl3_addsegtoseg (MS3TraceSeg *seg1, MS3TraceSeg *seg2)
   {
     memcpy ((char *)seg1->datasamples + (seg1->numsamples * samplesize),
             seg2->datasamples,
-            (size_t) (seg2->numsamples * samplesize));
+            (size_t)(seg2->numsamples * samplesize));
 
     seg1->numsamples += seg2->numsamples;
   }
@@ -1255,7 +1253,7 @@ mstl3_addsegtoseg (MS3TraceSeg *seg1, MS3TraceSeg *seg2)
     else
     {
       seg1->recordlist->last->next = seg2->recordlist->first;
-      seg1->recordlist->last = seg2->recordlist->last;
+      seg1->recordlist->last       = seg2->recordlist->last;
       seg1->recordlist->recordcnt += seg2->recordlist->recordcnt;
     }
   }
@@ -1264,30 +1262,30 @@ mstl3_addsegtoseg (MS3TraceSeg *seg1, MS3TraceSeg *seg2)
 } /* End of mstl3_addsegtoseg() */
 
 /**********************************************************************/ /**
- * @brief Add a ::MS3RecordPtr to the ::MS3RecordList of a ::MS3TraceSeg
- *
- * @param[in] seg ::MS3TraceSeg to add record to
- * @param[in] msr ::MS3Record to be added, for record length and start/end times
- * @param[in] endtime Time of last sample in record
- * @param[in] whence Where to add record to list
- * @parblock
- *  - \c 0 : New entry for new list, only when seg->recordlist == NULL
- *  - \c 1 : Add record pointer to end of list
- *  - \c 2 : Add record pointer to beginning of list
- * @endparblock
- *
- * @returns Pointer to added ::MS3RecordPtr on success and NULL on error.
- *
- * \ref MessageOnError - this function logs a message on error
- *
- * \sa mstl3_unpack_recordlist()
- * \sa mstl3_readbuffer()
- * \sa mstl3_readbuffer_selection()
- * \sa ms3_readtracelist()
- * \sa ms3_readtracelist_timewin()
- * \sa ms3_readtracelist_selection()
- * \sa mstl3_addmsr()
- ***************************************************************************/
+                                                                          * @brief Add a ::MS3RecordPtr to the ::MS3RecordList of a ::MS3TraceSeg
+                                                                          *
+                                                                          * @param[in] seg ::MS3TraceSeg to add record to
+                                                                          * @param[in] msr ::MS3Record to be added, for record length and start/end times
+                                                                          * @param[in] endtime Time of last sample in record
+                                                                          * @param[in] whence Where to add record to list
+                                                                          * @parblock
+                                                                          *  - \c 0 : New entry for new list, only when seg->recordlist == NULL
+                                                                          *  - \c 1 : Add record pointer to end of list
+                                                                          *  - \c 2 : Add record pointer to beginning of list
+                                                                          * @endparblock
+                                                                          *
+                                                                          * @returns Pointer to added ::MS3RecordPtr on success and NULL on error.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          *
+                                                                          * \sa mstl3_unpack_recordlist()
+                                                                          * \sa mstl3_readbuffer()
+                                                                          * \sa mstl3_readbuffer_selection()
+                                                                          * \sa ms3_readtracelist()
+                                                                          * \sa ms3_readtracelist_timewin()
+                                                                          * \sa ms3_readtracelist_selection()
+                                                                          * \sa mstl3_addmsr()
+                                                                          ***************************************************************************/
 MS3RecordPtr *
 mstl3_add_recordptr (MS3TraceSeg *seg, MS3Record *msr, nstime_t endtime, int8_t whence)
 {
@@ -1313,7 +1311,7 @@ mstl3_add_recordptr (MS3TraceSeg *seg, MS3Record *msr, nstime_t endtime, int8_t 
     return NULL;
   }
 
-  memset (recordptr, 0, sizeof(MS3RecordPtr));
+  memset (recordptr, 0, sizeof (MS3RecordPtr));
   recordptr->msr     = msr3_duplicate (msr, 0);
   recordptr->endtime = endtime;
 
@@ -1346,14 +1344,14 @@ mstl3_add_recordptr (MS3TraceSeg *seg, MS3Record *msr, nstime_t endtime, int8_t 
     /* Beginning of list */
     if (whence == 2)
     {
-      recordptr->next = seg->recordlist->first;
+      recordptr->next        = seg->recordlist->first;
       seg->recordlist->first = recordptr;
     }
     /* End of list */
     else
     {
       seg->recordlist->last->next = recordptr;
-      seg->recordlist->last = recordptr;
+      seg->recordlist->last       = recordptr;
     }
 
     seg->recordlist->recordcnt += 1;
@@ -1363,38 +1361,38 @@ mstl3_add_recordptr (MS3TraceSeg *seg, MS3Record *msr, nstime_t endtime, int8_t 
 } /* End of mstl3_add_recordptr() */
 
 /**********************************************************************/ /**
- * @brief Convert the data samples associated with an MS3TraceSeg to another
- * data type
- *
- * ASCII data samples cannot be converted, if supplied or requested an
- * error will be returned.
- *
- * When converting float & double sample types to integer type a
- * simple rounding is applied by adding 0.5 to the sample value before
- * converting (truncating) to integer.  This compensates for common
- * machine representations of floating point values, e.g. "40.0"
- * represented by "39.99999999".
- *
- * If the \a truncate flag is true (non-zero) data samples will be
- * truncated to integers even if loss of sample precision is detected.
- * If the truncate flag is false (zero) and loss of precision is
- * detected an error is returned.  Loss of precision is determined by
- * testing that the difference between the floating point value and
- * the (truncated) integer value is greater than 0.000001.
- *
- * @param[in] seg The target ::MS3TraceSeg to convert
- * @param[in] type The desired data sample type:
- * @parblock
- *   - \c 'i' - 32-bit integer data type
- *   - \c 'f' - 32-bit float data type
- *   - \c 'd' - 64-bit float (double) data type
- * @endparblock
- * @param[in] truncate Control truncation of floating point values to integers
- *
- * @returns 0 on success, and -1 on failure.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Convert the data samples associated with an MS3TraceSeg to another
+                                                                          * data type
+                                                                          *
+                                                                          * ASCII data samples cannot be converted, if supplied or requested an
+                                                                          * error will be returned.
+                                                                          *
+                                                                          * When converting float & double sample types to integer type a
+                                                                          * simple rounding is applied by adding 0.5 to the sample value before
+                                                                          * converting (truncating) to integer.  This compensates for common
+                                                                          * machine representations of floating point values, e.g. "40.0"
+                                                                          * represented by "39.99999999".
+                                                                          *
+                                                                          * If the \a truncate flag is true (non-zero) data samples will be
+                                                                          * truncated to integers even if loss of sample precision is detected.
+                                                                          * If the truncate flag is false (zero) and loss of precision is
+                                                                          * detected an error is returned.  Loss of precision is determined by
+                                                                          * testing that the difference between the floating point value and
+                                                                          * the (truncated) integer value is greater than 0.000001.
+                                                                          *
+                                                                          * @param[in] seg The target ::MS3TraceSeg to convert
+                                                                          * @param[in] type The desired data sample type:
+                                                                          * @parblock
+                                                                          *   - \c 'i' - 32-bit integer data type
+                                                                          *   - \c 'f' - 32-bit float data type
+                                                                          *   - \c 'd' - 64-bit float (double) data type
+                                                                          * @endparblock
+                                                                          * @param[in] truncate Control truncation of floating point values to integers
+                                                                          *
+                                                                          * @returns 0 on success, and -1 on failure.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 mstl3_convertsamples (MS3TraceSeg *seg, char type, int8_t truncate)
 {
@@ -1438,7 +1436,7 @@ mstl3_convertsamples (MS3TraceSeg *seg, char type, int8_t truncate)
           return -1;
         }
 
-        idata[idx] = (int32_t) (fdata[idx] + 0.5);
+        idata[idx] = (int32_t)(fdata[idx] + 0.5);
       }
     }
     else if (seg->sampletype == 'd') /* Convert doubles to integers with simple rounding */
@@ -1453,14 +1451,14 @@ mstl3_convertsamples (MS3TraceSeg *seg, char type, int8_t truncate)
           return -1;
         }
 
-        idata[idx] = (int32_t) (ddata[idx] + 0.5);
+        idata[idx] = (int32_t)(ddata[idx] + 0.5);
       }
 
       /* Reallocate buffer for reduced size needed, only if not pre-allocating */
       if (libmseed_prealloc_block_size == 0)
       {
         if (!(seg->datasamples = libmseed_memory.realloc (seg->datasamples,
-                                                          (size_t) (seg->numsamples * sizeof (int32_t)))))
+                                                          (size_t)(seg->numsamples * sizeof (int32_t)))))
         {
           ms_log (2, "Cannot re-allocate buffer for sample conversion\n");
           return -1;
@@ -1489,7 +1487,7 @@ mstl3_convertsamples (MS3TraceSeg *seg, char type, int8_t truncate)
       if (libmseed_prealloc_block_size == 0)
       {
         if (!(seg->datasamples = libmseed_memory.realloc (seg->datasamples,
-                                                          (size_t) (seg->numsamples * sizeof (float)))))
+                                                          (size_t)(seg->numsamples * sizeof (float)))))
         {
           ms_log (2, "Cannot re-allocate buffer after sample conversion\n");
           return -1;
@@ -1504,7 +1502,7 @@ mstl3_convertsamples (MS3TraceSeg *seg, char type, int8_t truncate)
   /* Convert to 64-bit doubles */
   else if (type == 'd')
   {
-    if (!(ddata = (double *)libmseed_memory.malloc ((size_t) (seg->numsamples * sizeof (double)))))
+    if (!(ddata = (double *)libmseed_memory.malloc ((size_t)(seg->numsamples * sizeof (double)))))
     {
       ms_log (2, "Cannot allocate buffer for sample conversion to doubles\n");
       return -1;
@@ -1526,30 +1524,30 @@ mstl3_convertsamples (MS3TraceSeg *seg, char type, int8_t truncate)
     }
 
     seg->datasamples = ddata;
-    seg->datasize = seg->numsamples * sizeof (double);
-    seg->sampletype = 'd';
+    seg->datasize    = seg->numsamples * sizeof (double);
+    seg->sampletype  = 'd';
   } /* Done converting to 64-bit doubles */
 
   return 0;
 } /* End of mstl3_convertsamples() */
 
 /**********************************************************************/ /**
- * @brief Resize data sample buffers of ::MS3TraceList to what is needed
- *
- * This routine should only be used if pre-allocation of memory, via
- * ::libmseed_prealloc_block_size, was enabled to allocate the buffers.
- *
- * @param[in] mstl ::MS3TraceList to resize buffers
- *
- * @returns Return 0 on success, otherwise returns a libmseed error code.
- *
- * \ref MessageOnError - this function logs a message on error
- ***************************************************************************/
+                                                                          * @brief Resize data sample buffers of ::MS3TraceList to what is needed
+                                                                          *
+                                                                          * This routine should only be used if pre-allocation of memory, via
+                                                                          * ::libmseed_prealloc_block_size, was enabled to allocate the buffers.
+                                                                          *
+                                                                          * @param[in] mstl ::MS3TraceList to resize buffers
+                                                                          *
+                                                                          * @returns Return 0 on success, otherwise returns a libmseed error code.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          ***************************************************************************/
 int
 mstl3_resize_buffers (MS3TraceList *mstl)
 {
-  MS3TraceID *id = NULL;
-  MS3TraceSeg *seg = NULL;
+  MS3TraceID *id     = NULL;
+  MS3TraceSeg *seg   = NULL;
   uint8_t samplesize = 0;
   size_t datasize;
 
@@ -1566,11 +1564,11 @@ mstl3_resize_buffers (MS3TraceList *mstl)
     seg = id->first;
     while (seg)
     {
-      samplesize = ms_samplesize(seg->sampletype);
+      samplesize = ms_samplesize (seg->sampletype);
 
       if (samplesize && seg->datasamples && seg->numsamples > 0)
       {
-        datasize = (size_t) seg->numsamples * samplesize;
+        datasize = (size_t)seg->numsamples * samplesize;
 
         if (seg->datasize > datasize)
         {
@@ -1596,73 +1594,74 @@ mstl3_resize_buffers (MS3TraceList *mstl)
 } /* End of mstl3_resize_buffers() */
 
 /**********************************************************************/ /**
- * @brief Unpack data samples in a @ref record-list associated with a ::MS3TraceList
- *
- * Normally a record list is created calling by ms3_readtracelist() or
- * mstl3_readbuffer() with the ::MSF_RECORDLIST flag.
- *
- * Unpacked data samples are written to the provided \a output buffer
- * (up to \a outputsize bytes).  If \a output is NULL, a buffer will
- * be allocated and associated with the ::MS3TraceSeg, just as if the
- * data were unpacked while constructing the @ref trace-list.
- *
- * The sample type of the decoded data is stored at
- * ::MS3TraceSeg.sampletype (i.e. \c seg->sampletype).
- *
- * A record pointer entry has multiple ways to identify the location
- * of a record: memory buffer, open file (FILE *) or file name.  This
- * routine uses the first populated record location in the following
- * order:
- *   -# Buffer pointer (::MS3RecordPtr.bufferptr)
- *   -# Open file and offset (::MS3RecordPtr.fileptr and ::MS3RecordPtr.fileoffset)
- *   -# File name and offset (::MS3RecordPtr.filename and ::MS3RecordPtr.fileoffset)
- *
- * It would be unusual to build a record list outside of the library,
- * but should that ever occur note that the record list is assumed to
- * be in correct time order and represent a contiguous time series.
- *
- * @param[in] id ::MS3TraceID for relevant ::MS3TraceSeg
- * @param[in] seg ::MS3TraceSeg with associated @ref record-list to unpack
- * @param[out] output Output buffer for data samples, can be NULL
- * @param[in] outputsize Size of \a output buffer
- * @param[in] verbose Controls logging verbosity, 0 is no diagnostic output
- *
- * @returns the number of samples unpacked or -1 on error.
- *
- * \ref MessageOnError - this function logs a message on error
- *
- * \sa mstl3_readbuffer()
- * \sa mstl3_readbuffer_selection()
- * \sa ms3_readtracelist()
- * \sa ms3_readtracelist_selection()
- ***************************************************************************/
+                                                                          * @brief Unpack data samples in a @ref record-list associated with a ::MS3TraceList
+                                                                          *
+                                                                          * Normally a record list is created calling by ms3_readtracelist() or
+                                                                          * mstl3_readbuffer() with the ::MSF_RECORDLIST flag.
+                                                                          *
+                                                                          * Unpacked data samples are written to the provided \a output buffer
+                                                                          * (up to \a outputsize bytes).  If \a output is NULL, a buffer will
+                                                                          * be allocated and associated with the ::MS3TraceSeg, just as if the
+                                                                          * data were unpacked while constructing the @ref trace-list.
+                                                                          *
+                                                                          * The sample type of the decoded data is stored at
+                                                                          * ::MS3TraceSeg.sampletype (i.e. \c seg->sampletype).
+                                                                          *
+                                                                          * A record pointer entry has multiple ways to identify the location
+                                                                          * of a record: memory buffer, open file (FILE *) or file name.  This
+                                                                          * routine uses the first populated record location in the following
+                                                                          * order:
+                                                                          *   -# Buffer pointer (::MS3RecordPtr.bufferptr)
+                                                                          *   -# Open file and offset (::MS3RecordPtr.fileptr and ::MS3RecordPtr.fileoffset)
+                                                                          *   -# File name and offset (::MS3RecordPtr.filename and ::MS3RecordPtr.fileoffset)
+                                                                          *
+                                                                          * It would be unusual to build a record list outside of the library,
+                                                                          * but should that ever occur note that the record list is assumed to
+                                                                          * be in correct time order and represent a contiguous time series.
+                                                                          *
+                                                                          * @param[in] id ::MS3TraceID for relevant ::MS3TraceSeg
+                                                                          * @param[in] seg ::MS3TraceSeg with associated @ref record-list to unpack
+                                                                          * @param[out] output Output buffer for data samples, can be NULL
+                                                                          * @param[in] outputsize Size of \a output buffer
+                                                                          * @param[in] verbose Controls logging verbosity, 0 is no diagnostic output
+                                                                          *
+                                                                          * @returns the number of samples unpacked or -1 on error.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          *
+                                                                          * \sa mstl3_readbuffer()
+                                                                          * \sa mstl3_readbuffer_selection()
+                                                                          * \sa ms3_readtracelist()
+                                                                          * \sa ms3_readtracelist_selection()
+                                                                          ***************************************************************************/
 int64_t
 mstl3_unpack_recordlist (MS3TraceID *id, MS3TraceSeg *seg, void *output,
                          size_t outputsize, int8_t verbose)
 {
-  MS3RecordPtr *recordptr = NULL;
-  int64_t unpackedsamples = 0;
+  MS3RecordPtr *recordptr      = NULL;
+  int64_t unpackedsamples      = 0;
   int64_t totalunpackedsamples = 0;
 
-  char *filebuffer = NULL;
+  char *filebuffer      = NULL;
   size_t filebuffersize = 0;
 
   size_t outputoffset = 0;
-  size_t decodedsize = 0;
-  uint8_t samplesize = 0;
-  char sampletype = 0;
-  char recsampletype = 0;
+  size_t decodedsize  = 0;
+  uint8_t samplesize  = 0;
+  char sampletype     = 0;
+  char recsampletype  = 0;
 
-  FILE *fileptr = NULL;
+  FILE *fileptr     = NULL;
   const char *input = NULL;
 
   /* Linked list of open file pointers */
-  struct filelist_s {
+  struct filelist_s
+  {
     const char *filename;
     FILE *fileptr;
     struct filelist_s *next;
   };
-  struct filelist_s *filelist = NULL;
+  struct filelist_s *filelist    = NULL;
   struct filelist_s *filelistptr = NULL;
 
   if (!id || !seg)
@@ -1679,7 +1678,7 @@ mstl3_unpack_recordlist (MS3TraceID *id, MS3TraceSeg *seg, void *output,
 
   recordptr = seg->recordlist->first;
 
-  if (ms_encoding_sizetype(recordptr->msr->encoding, &samplesize, &sampletype))
+  if (ms_encoding_sizetype (recordptr->msr->encoding, &samplesize, &sampletype))
   {
     ms_log (2, "%s: Cannot determine sample size and type for encoding: %u\n",
             id->sid, recordptr->msr->encoding);
@@ -1694,7 +1693,7 @@ mstl3_unpack_recordlist (MS3TraceID *id, MS3TraceSeg *seg, void *output,
   {
     if (decodedsize > outputsize)
     {
-      ms_log (2, "%s: Output buffer (%"PRIsize_t" bytes) is not large enough for decoded data (%"PRIsize_t" bytes)\n",
+      ms_log (2, "%s: Output buffer (%" PRIsize_t " bytes) is not large enough for decoded data (%" PRIsize_t " bytes)\n",
               id->sid, decodedsize, outputsize);
       return -1;
     }
@@ -1716,7 +1715,7 @@ mstl3_unpack_recordlist (MS3TraceID *id, MS3TraceSeg *seg, void *output,
 
     /* Associate allocated memory with segment */
     seg->datasamples = output;
-    seg->datasize = decodedsize;
+    seg->datasize    = decodedsize;
   }
 
   /* Iterate through record list and unpack data samples */
@@ -1729,7 +1728,7 @@ mstl3_unpack_recordlist (MS3TraceID *id, MS3TraceSeg *seg, void *output,
       continue;
     }
 
-    if (ms_encoding_sizetype(recordptr->msr->encoding, NULL, &recsampletype))
+    if (ms_encoding_sizetype (recordptr->msr->encoding, NULL, &recsampletype))
     {
       ms_log (2, "%s: Cannot determine sample type for encoding: %u\n", id->sid, recordptr->msr->encoding);
 
@@ -1782,14 +1781,14 @@ mstl3_unpack_recordlist (MS3TraceID *id, MS3TraceSeg *seg, void *output,
 
           if ((filelistptr->fileptr = fopen (recordptr->filename, "r")) == NULL)
           {
-            ms_log (2, "%s: Cannot open file (%s): %s\n", id->sid, recordptr->filename, strerror(errno));
+            ms_log (2, "%s: Cannot open file (%s): %s\n", id->sid, recordptr->filename, strerror (errno));
 
             totalunpackedsamples = -1;
             break;
           }
 
           filelistptr->filename = recordptr->filename;
-          filelistptr->next = filelist;
+          filelistptr->next     = filelist;
 
           filelist = filelistptr;
         }
@@ -1833,7 +1832,6 @@ mstl3_unpack_recordlist (MS3TraceID *id, MS3TraceSeg *seg, void *output,
 
         totalunpackedsamples = -1;
         break;
-
       }
 
       input = filebuffer + recordptr->dataoffset;
@@ -1900,78 +1898,78 @@ mstl3_unpack_recordlist (MS3TraceID *id, MS3TraceSeg *seg, void *output,
 } /* End of mstl3_unpack_recordlist() */
 
 /**********************************************************************/ /**
- * @brief Pack ::MS3TraceList data into miniSEED records
- *
- * The datasamples array, numsamples and starttime fields of each
- * trace segment will be adjusted as data are packed unless the
- * ::MSF_MAINTAINMSTL flag is specified in \a flags. If
- * ::MSF_MAINTAINMSTL is specified a caller would also normally set
- * the ::MSF_FLUSHDATA flag to pack all data in the trace list.
- *
- * <b>Use as a rolling buffer to generate data records:</b>
- * The behavior of adjusting the trace list as data are packed is
- * intended to allow using a ::MS3TraceList as an intermediate
- * collection of data buffers to generate data records from an
- * arbitrarily large data source, e.g. continuous data.  In this
- * pattern, data are added to a ::MS3TraceList and mstl3_pack() is
- * called repeatedly.  Data records are only produced if a complete
- * record can be generated, which often leaves small amounts of data
- * in each segment buffer.  On completion or shutdown the caller
- * usually makes a final call to mst3_pack() with the ::MSF_FLUSHDATA
- * flag set to flush all data from the buffers.
- *
- * As each record is filled and finished they are passed to \a
- * record_handler() which should expect 1) a \c char* to the record,
- * 2) the length of the record and 3) a pointer supplied by the
- * original caller containing optional private data (\a handlerdata).
- * It is the responsibility of \a record_handler() to process the
- * record, the memory will be re-used or freed when \a
- * record_handler() returns.
- *
- * The requested \a encoding value is currently only used for integer
- * data samples. The encoding is set automatially for text (ASCII) and
- * floating point data samples as there is only a single encoding for
- * them.  A value of \c -1 can be used to request the default.
- *
- * If \a extra is not NULL it is expected to contain extraheaders, a
- * string containing (compact) JSON, that will be added to each output
- * record.
- *
- * @param[in] mstl ::MS3TraceList containing data to pack
- * @param[in] record_handler() Callback function called for each record
- * @param[in] handlerdata A pointer that will be provided to the \a record_handler()
- * @param[in] reclen Maximum record length to create
- * @param[in] encoding Encoding for data samples, see msr3_pack()
- * @param[out] packedsamples The number of samples packed, returned to caller
- * @param[in] flags Bit flags to control packing:
- * @parblock
- *  - \c ::MSF_FLUSHDATA : Pack all data in the buffer
- *  - \c ::MSF_MAINTAINMSTL : Do not remove packe data from the buffer
- *  - \c ::MSF_PACKVER2 : Pack miniSEED version 2 instead of default 3
- * @endparblock
- * @param[in] verbose Controls logging verbosity, 0 is no diagnostic output
- * @param[in] extra If not NULL, add this buffer of extra headers to all records
- *
- * @returns the number of records created on success and -1 on error.
- *
- * \ref MessageOnError - this function logs a message on error
- *
- * \sa msr3_pack()
- ***************************************************************************/
+                                                                          * @brief Pack ::MS3TraceList data into miniSEED records
+                                                                          *
+                                                                          * The datasamples array, numsamples and starttime fields of each
+                                                                          * trace segment will be adjusted as data are packed unless the
+                                                                          * ::MSF_MAINTAINMSTL flag is specified in \a flags. If
+                                                                          * ::MSF_MAINTAINMSTL is specified a caller would also normally set
+                                                                          * the ::MSF_FLUSHDATA flag to pack all data in the trace list.
+                                                                          *
+                                                                          * <b>Use as a rolling buffer to generate data records:</b>
+                                                                          * The behavior of adjusting the trace list as data are packed is
+                                                                          * intended to allow using a ::MS3TraceList as an intermediate
+                                                                          * collection of data buffers to generate data records from an
+                                                                          * arbitrarily large data source, e.g. continuous data.  In this
+                                                                          * pattern, data are added to a ::MS3TraceList and mstl3_pack() is
+                                                                          * called repeatedly.  Data records are only produced if a complete
+                                                                          * record can be generated, which often leaves small amounts of data
+                                                                          * in each segment buffer.  On completion or shutdown the caller
+                                                                          * usually makes a final call to mst3_pack() with the ::MSF_FLUSHDATA
+                                                                          * flag set to flush all data from the buffers.
+                                                                          *
+                                                                          * As each record is filled and finished they are passed to \a
+                                                                          * record_handler() which should expect 1) a \c char* to the record,
+                                                                          * 2) the length of the record and 3) a pointer supplied by the
+                                                                          * original caller containing optional private data (\a handlerdata).
+                                                                          * It is the responsibility of \a record_handler() to process the
+                                                                          * record, the memory will be re-used or freed when \a
+                                                                          * record_handler() returns.
+                                                                          *
+                                                                          * The requested \a encoding value is currently only used for integer
+                                                                          * data samples. The encoding is set automatially for text (ASCII) and
+                                                                          * floating point data samples as there is only a single encoding for
+                                                                          * them.  A value of \c -1 can be used to request the default.
+                                                                          *
+                                                                          * If \a extra is not NULL it is expected to contain extraheaders, a
+                                                                          * string containing (compact) JSON, that will be added to each output
+                                                                          * record.
+                                                                          *
+                                                                          * @param[in] mstl ::MS3TraceList containing data to pack
+                                                                          * @param[in] record_handler() Callback function called for each record
+                                                                          * @param[in] handlerdata A pointer that will be provided to the \a record_handler()
+                                                                          * @param[in] reclen Maximum record length to create
+                                                                          * @param[in] encoding Encoding for data samples, see msr3_pack()
+                                                                          * @param[out] packedsamples The number of samples packed, returned to caller
+                                                                          * @param[in] flags Bit flags to control packing:
+                                                                          * @parblock
+                                                                          *  - \c ::MSF_FLUSHDATA : Pack all data in the buffer
+                                                                          *  - \c ::MSF_MAINTAINMSTL : Do not remove packe data from the buffer
+                                                                          *  - \c ::MSF_PACKVER2 : Pack miniSEED version 2 instead of default 3
+                                                                          * @endparblock
+                                                                          * @param[in] verbose Controls logging verbosity, 0 is no diagnostic output
+                                                                          * @param[in] extra If not NULL, add this buffer of extra headers to all records
+                                                                          *
+                                                                          * @returns the number of records created on success and -1 on error.
+                                                                          *
+                                                                          * \ref MessageOnError - this function logs a message on error
+                                                                          *
+                                                                          * \sa msr3_pack()
+                                                                          ***************************************************************************/
 int64_t
 mstl3_pack (MS3TraceList *mstl, void (*record_handler) (char *, int, void *),
             void *handlerdata, int reclen, int8_t encoding,
             int64_t *packedsamples, uint32_t flags, int8_t verbose,
             char *extra)
 {
-  MS3Record *msr = NULL;
-  MS3TraceID *id = NULL;
+  MS3Record *msr   = NULL;
+  MS3TraceID *id   = NULL;
   MS3TraceSeg *seg = NULL;
 
   int64_t totalpackedrecords = 0;
   int64_t totalpackedsamples = 0;
-  int segpackedrecords = 0;
-  int64_t segpackedsamples = 0;
+  int segpackedrecords       = 0;
+  int64_t segpackedsamples   = 0;
   int samplesize;
   size_t bufsize;
   size_t extralength;
@@ -1999,17 +1997,17 @@ mstl3_pack (MS3TraceList *mstl, void (*record_handler) (char *, int, void *),
     return -1;
   }
 
-  msr->reclen = reclen;
+  msr->reclen   = reclen;
   msr->encoding = encoding;
 
   if (extra)
   {
-    msr->extra = extra;
-    extralength = strlen(extra);
+    msr->extra  = extra;
+    extralength = strlen (extra);
 
     if (extralength > UINT16_MAX)
     {
-      ms_log (2, "Extra headers are too long: %"PRIsize_t"\n", extralength);
+      ms_log (2, "Extra headers are too long: %" PRIsize_t "\n", extralength);
       return -1;
     }
 
@@ -2020,19 +2018,19 @@ mstl3_pack (MS3TraceList *mstl, void (*record_handler) (char *, int, void *),
   id = mstl->traces.next[0];
   while (id)
   {
-    memcpy (msr->sid, id->sid, sizeof(msr->sid));
+    memcpy (msr->sid, id->sid, sizeof (msr->sid));
     msr->pubversion = id->pubversion;
 
     /* Loop through segment list */
     seg = id->first;
     while (seg)
     {
-      msr->starttime = seg->starttime;
-      msr->samprate = seg->samprate;
-      msr->samplecnt = seg->samplecnt;
+      msr->starttime   = seg->starttime;
+      msr->samprate    = seg->samprate;
+      msr->samplecnt   = seg->samplecnt;
       msr->datasamples = seg->datasamples;
-      msr->numsamples = seg->numsamples;
-      msr->sampletype = seg->sampletype;
+      msr->numsamples  = seg->numsamples;
+      msr->sampletype  = seg->sampletype;
 
       /* Set encoding for data types with only one encoding, otherwise requested */
       switch (seg->sampletype)
@@ -2100,7 +2098,7 @@ mstl3_pack (MS3TraceList *mstl, void (*record_handler) (char *, int, void *),
           if (seg->datasamples)
             libmseed_memory.free (seg->datasamples);
           seg->datasamples = NULL;
-          seg->datasize = 0;
+          seg->datasize    = 0;
         }
 
         seg->samplecnt -= segpackedsamples;
@@ -2127,26 +2125,26 @@ mstl3_pack (MS3TraceList *mstl, void (*record_handler) (char *, int, void *),
 } /* End of mstl3_pack() */
 
 /**********************************************************************/ /**
- * @brief Print trace list summary information for a ::MS3TraceList
- *
- * By default only print the source ID, starttime and endtime for each
- * trace.  If \a details is greater than 0 include the sample rate,
- * number of samples and a total trace count.  If \a gaps is greater than
- * 0 and the previous trace matches (SID & samprate) include the
- * gap between the endtime of the last trace and the starttime of the
- * current trace.
- *
- * @param[in] mstl ::MS3TraceList to print
- * @param[in] timeformat Time string format, one of @ref ms_timeformat_t
- * @param[in] details Flag to control inclusion of more details
- * @param[in] gaps Flag to control inclusion of gap/overlap between segments
- * @param[in] versions Flag to control inclusion of publication version on SourceIDs
- ***************************************************************************/
+                                                                          * @brief Print trace list summary information for a ::MS3TraceList
+                                                                          *
+                                                                          * By default only print the source ID, starttime and endtime for each
+                                                                          * trace.  If \a details is greater than 0 include the sample rate,
+                                                                          * number of samples and a total trace count.  If \a gaps is greater than
+                                                                          * 0 and the previous trace matches (SID & samprate) include the
+                                                                          * gap between the endtime of the last trace and the starttime of the
+                                                                          * current trace.
+                                                                          *
+                                                                          * @param[in] mstl ::MS3TraceList to print
+                                                                          * @param[in] timeformat Time string format, one of @ref ms_timeformat_t
+                                                                          * @param[in] details Flag to control inclusion of more details
+                                                                          * @param[in] gaps Flag to control inclusion of gap/overlap between segments
+                                                                          * @param[in] versions Flag to control inclusion of publication version on SourceIDs
+                                                                          ***************************************************************************/
 void
 mstl3_printtracelist (MS3TraceList *mstl, ms_timeformat_t timeformat,
                       int8_t details, int8_t gaps, int8_t versions)
 {
-  MS3TraceID *id = 0;
+  MS3TraceID *id   = 0;
   MS3TraceSeg *seg = 0;
   char stime[40];
   char etime[40];
@@ -2155,10 +2153,10 @@ mstl3_printtracelist (MS3TraceList *mstl, ms_timeformat_t timeformat,
   double gap;
   double delta;
   int tracecnt = 0;
-  int segcnt = 0;
+  int segcnt   = 0;
 
   char versioned_sid[LM_SIDLEN] = {0};
-  char *display_sid = NULL;
+  char *display_sid             = NULL;
 
   if (!mstl)
   {
@@ -2204,7 +2202,7 @@ mstl3_printtracelist (MS3TraceList *mstl, ms_timeformat_t timeformat,
       /* Print segment info at varying levels */
       if (gaps > 0)
       {
-        gap = 0.0;
+        gap   = 0.0;
         nogap = 0;
 
         if (seg->prev)
@@ -2261,30 +2259,30 @@ mstl3_printtracelist (MS3TraceList *mstl, ms_timeformat_t timeformat,
 } /* End of mstl3_printtracelist() */
 
 /**********************************************************************/ /**
- * @brief Print SYNC trace list summary information for a ::MS3TraceList
- *
- * The SYNC header line will be created using the supplied dccid, if
- * the pointer is NULL the string "DCC" will be used instead.
- *
- * If the \a subsecond flag is true the segment start and end times will
- * include subsecond precision, otherwise they will be truncated to
- * integer seconds.
- *
- * @param[in] mstl ::MS3TraceList to print
- * @param[in] dccid The DCC identifier to include in the output
- * @param[in] subseconds Inclusion of subseconds, one of @ref ms_subseconds_t
- ***************************************************************************/
+                                                                          * @brief Print SYNC trace list summary information for a ::MS3TraceList
+                                                                          *
+                                                                          * The SYNC header line will be created using the supplied dccid, if
+                                                                          * the pointer is NULL the string "DCC" will be used instead.
+                                                                          *
+                                                                          * If the \a subsecond flag is true the segment start and end times will
+                                                                          * include subsecond precision, otherwise they will be truncated to
+                                                                          * integer seconds.
+                                                                          *
+                                                                          * @param[in] mstl ::MS3TraceList to print
+                                                                          * @param[in] dccid The DCC identifier to include in the output
+                                                                          * @param[in] subseconds Inclusion of subseconds, one of @ref ms_subseconds_t
+                                                                          ***************************************************************************/
 void
 mstl3_printsynclist (MS3TraceList *mstl, char *dccid, ms_subseconds_t subseconds)
 {
-  MS3TraceID *id = 0;
+  MS3TraceID *id   = 0;
   MS3TraceSeg *seg = 0;
   char starttime[40];
   char endtime[40];
   char yearday[32];
-  char net[11] = {0};
-  char sta[11] = {0};
-  char loc[11] = {0};
+  char net[11]  = {0};
+  char sta[11]  = {0};
+  char loc[11]  = {0};
   char chan[11] = {0};
   time_t now;
   struct tm *nt;
@@ -2296,7 +2294,7 @@ mstl3_printsynclist (MS3TraceList *mstl, char *dccid, ms_subseconds_t subseconds
 
   /* Generate current time stamp */
   now = time (NULL);
-  nt = localtime (&now);
+  nt  = localtime (&now);
   nt->tm_year += 1900;
   nt->tm_yday += 1;
   snprintf (yearday, sizeof (yearday), "%04d,%03d", nt->tm_year, nt->tm_yday);
@@ -2334,24 +2332,24 @@ mstl3_printsynclist (MS3TraceList *mstl, char *dccid, ms_subseconds_t subseconds
 } /* End of mstl3_printsynclist() */
 
 /**********************************************************************/ /**
- * @brief Print gap/overlap list summary information for a ::MS3TraceList.
- *
- * Overlaps are printed as negative gaps.
- *
- * If \a mingap and \a maxgap are not NULL their values will be
- * enforced and only gaps/overlaps matching their implied criteria
- * will be printed.
- *
- * @param[in] mstl ::MS3TraceList to print
- * @param[in] timeformat Time string format, one of @ref ms_timeformat_t
- * @param[in] mingap Minimum gap to print in seconds (pointer to value)
- * @param[in] maxgap Maximum gap to print in seconds (pointer to value)
- ***************************************************************************/
+                                                                          * @brief Print gap/overlap list summary information for a ::MS3TraceList.
+                                                                          *
+                                                                          * Overlaps are printed as negative gaps.
+                                                                          *
+                                                                          * If \a mingap and \a maxgap are not NULL their values will be
+                                                                          * enforced and only gaps/overlaps matching their implied criteria
+                                                                          * will be printed.
+                                                                          *
+                                                                          * @param[in] mstl ::MS3TraceList to print
+                                                                          * @param[in] timeformat Time string format, one of @ref ms_timeformat_t
+                                                                          * @param[in] mingap Minimum gap to print in seconds (pointer to value)
+                                                                          * @param[in] maxgap Maximum gap to print in seconds (pointer to value)
+                                                                          ***************************************************************************/
 void
 mstl3_printgaplist (MS3TraceList *mstl, ms_timeformat_t timeformat,
                     double *mingap, double *maxgap)
 {
-  MS3TraceID *id = 0;
+  MS3TraceID *id   = 0;
   MS3TraceSeg *seg = 0;
 
   char time1[40], time2[40];

--- a/unpack.c
+++ b/unpack.c
@@ -24,11 +24,11 @@
  * limitations under the License.
  ***************************************************************************/
 #include <ctype.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <math.h>
 
 #include "libmseed.h"
 #include "mseedformat.h"
@@ -40,7 +40,7 @@ static nstime_t ms_btime2nstime (uint8_t *btime, int8_t swapflag);
 
 /* Test POINTER for alignment with BYTE_COUNT sized quantities */
 #define is_aligned(POINTER, BYTE_COUNT) \
-  (((uintptr_t) (const void *)(POINTER)) % (BYTE_COUNT) == 0)
+  (((uintptr_t)(const void *)(POINTER)) % (BYTE_COUNT) == 0)
 
 /***************************************************************************
  * Unpack a miniSEED 3.x data record and populate a MS3Record struct.
@@ -129,9 +129,9 @@ msr3_unpack_mseed3 (char *record, int reclen, MS3Record **ppmsr,
   {
     /* Save header CRC, set value to 0, calculate CRC, restore CRC */
     header_crc = HO4u (*pMS3FSDH_CRC (record), swapflag);
-    memset (pMS3FSDH_CRC(record), 0, sizeof(uint32_t));
-    calculated_crc = ms_crc32c ((const uint8_t*)record, reclen, 0);
-    *pMS3FSDH_CRC(record) = HO4u (header_crc, swapflag);
+    memset (pMS3FSDH_CRC (record), 0, sizeof (uint32_t));
+    calculated_crc         = ms_crc32c ((const uint8_t *)record, reclen, 0);
+    *pMS3FSDH_CRC (record) = HO4u (header_crc, swapflag);
 
     if (header_crc != calculated_crc)
     {
@@ -153,9 +153,9 @@ msr3_unpack_mseed3 (char *record, int reclen, MS3Record **ppmsr,
   msr->reclen = reclen;
 
   /* Populate the header fields */
-  msr->swapflag = (swapflag) ? MSSWAP_HEADER : 0;
+  msr->swapflag      = (swapflag) ? MSSWAP_HEADER : 0;
   msr->formatversion = *pMS3FSDH_FORMATVERSION (record);
-  msr->flags = *pMS3FSDH_FLAGS (record);
+  msr->flags         = *pMS3FSDH_FLAGS (record);
 
   memcpy (msr->sid, pMS3FSDH_SID (record), sidlength);
   msr->starttime = ms_time2nstime (HO2u (*pMS3FSDH_YEAR (record), msr->swapflag),
@@ -171,10 +171,10 @@ msr3_unpack_mseed3 (char *record, int reclen, MS3Record **ppmsr,
     return MS_GENERROR;
   }
 
-  msr->encoding = *pMS3FSDH_ENCODING (record);
-  msr->samprate = HO8f (*pMS3FSDH_SAMPLERATE (record), msr->swapflag);
-  msr->samplecnt = HO4u (*pMS3FSDH_NUMSAMPLES (record), msr->swapflag);
-  msr->crc = HO4u (*pMS3FSDH_CRC (record), msr->swapflag);
+  msr->encoding   = *pMS3FSDH_ENCODING (record);
+  msr->samprate   = HO8f (*pMS3FSDH_SAMPLERATE (record), msr->swapflag);
+  msr->samplecnt  = HO4u (*pMS3FSDH_NUMSAMPLES (record), msr->swapflag);
+  msr->crc        = HO4u (*pMS3FSDH_CRC (record), msr->swapflag);
   msr->pubversion = *pMS3FSDH_PUBVERSION (record);
 
   /* Copy extra headers into a NULL-terminated string */
@@ -198,7 +198,7 @@ msr3_unpack_mseed3 (char *record, int reclen, MS3Record **ppmsr,
      All other encodings are little endian, matching the header. */
   if (msr->encoding == DE_STEIM1 || msr->encoding == DE_STEIM2)
   {
-    if (! bigendianhost)
+    if (!bigendianhost)
       msr->swapflag |= MSSWAP_PAYLOAD;
   }
   else if (msr->swapflag & MSSWAP_HEADER)
@@ -222,8 +222,8 @@ msr3_unpack_mseed3 (char *record, int reclen, MS3Record **ppmsr,
       libmseed_memory.free (msr->datasamples);
 
     msr->datasamples = NULL;
-    msr->datasize = 0;
-    msr->numsamples = 0;
+    msr->datasize    = 0;
+    msr->numsamples  = 0;
   }
 
   return MS_NOERROR;
@@ -258,8 +258,8 @@ int64_t
 msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
                     uint32_t flags, int8_t verbose)
 {
-  int B1000offset = 0;
-  int B1001offset = 0;
+  int B1000offset   = 0;
+  int B1001offset   = 0;
   int bigendianhost = ms_bigendianhost ();
   int64_t retval;
 
@@ -334,9 +334,9 @@ msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
   /* Populate some of the common header fields */
   ms2_recordsid (record, msr->sid, sizeof (msr->sid));
   msr->formatversion = 2;
-  msr->samprate = ms_nomsamprate (HO2d (*pMS2FSDH_SAMPLERATEFACT (record), msr->swapflag),
-                                  HO2d (*pMS2FSDH_SAMPLERATEMULT (record), msr->swapflag));
-  msr->samplecnt = HO2u (*pMS2FSDH_NUMSAMPLES (record), msr->swapflag);
+  msr->samprate      = ms_nomsamprate (HO2d (*pMS2FSDH_SAMPLERATEFACT (record), msr->swapflag),
+                                       HO2d (*pMS2FSDH_SAMPLERATEMULT (record), msr->swapflag));
+  msr->samplecnt     = HO2u (*pMS2FSDH_NUMSAMPLES (record), msr->swapflag);
 
   /* Map data quality indicator to publication version */
   if (*pMS2FSDH_DATAQUALITY (record) == 'M')
@@ -452,12 +452,12 @@ msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
     /* Blockette 200, generic event detection */
     else if (blkt_type == 200)
     {
-      memset (&eventdetection, 0, sizeof(eventdetection));
+      memset (&eventdetection, 0, sizeof (eventdetection));
 
       strncpy (eventdetection.type, "GENERIC", sizeof (eventdetection.type));
       ms_strncpcleantail (eventdetection.detector, pMS2B200_DETECTOR (record + blkt_offset), 24);
-      eventdetection.signalamplitude = HO4f (*pMS2B200_AMPLITUDE (record + blkt_offset), msr->swapflag);
-      eventdetection.signalperiod = HO4f (*pMS2B200_PERIOD (record + blkt_offset), msr->swapflag);
+      eventdetection.signalamplitude    = HO4f (*pMS2B200_AMPLITUDE (record + blkt_offset), msr->swapflag);
+      eventdetection.signalperiod       = HO4f (*pMS2B200_PERIOD (record + blkt_offset), msr->swapflag);
       eventdetection.backgroundestimate = HO4f (*pMS2B200_BACKGROUNDEST (record + blkt_offset), msr->swapflag);
 
       /* If bit 2 is set, set compression wave according to bit 0 */
@@ -476,14 +476,14 @@ msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
       else
         strncpy (eventdetection.units, "COUNTS", sizeof (eventdetection.units));
 
-      eventdetection.onsettime = ms_btime2nstime ((uint8_t*)pMS2B200_YEAR (record + blkt_offset), msr->swapflag);
+      eventdetection.onsettime = ms_btime2nstime ((uint8_t *)pMS2B200_YEAR (record + blkt_offset), msr->swapflag);
       if (eventdetection.onsettime == NSTERROR)
         return MS_GENERROR;
 
       memset (eventdetection.medsnr, 0, 6);
-      eventdetection.medlookback = -1;
+      eventdetection.medlookback      = -1;
       eventdetection.medpickalgorithm = -1;
-      eventdetection.next = NULL;
+      eventdetection.next             = NULL;
 
       if (mseh_add_event_detection_r (msr, NULL, &eventdetection, &parsestate))
       {
@@ -495,12 +495,12 @@ msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
     /* Blockette 201, Murdock event detection */
     else if (blkt_type == 201)
     {
-      memset (&eventdetection, 0, sizeof(eventdetection));
+      memset (&eventdetection, 0, sizeof (eventdetection));
 
       strncpy (eventdetection.type, "MURDOCK", sizeof (eventdetection.type));
       ms_strncpcleantail (eventdetection.detector, pMS2B201_DETECTOR (record + blkt_offset), 24);
-      eventdetection.signalamplitude = HO4f (*pMS2B201_AMPLITUDE (record + blkt_offset), msr->swapflag);
-      eventdetection.signalperiod = HO4f (*pMS2B201_PERIOD (record + blkt_offset), msr->swapflag);
+      eventdetection.signalamplitude    = HO4f (*pMS2B201_AMPLITUDE (record + blkt_offset), msr->swapflag);
+      eventdetection.signalperiod       = HO4f (*pMS2B201_PERIOD (record + blkt_offset), msr->swapflag);
       eventdetection.backgroundestimate = HO4f (*pMS2B201_BACKGROUNDEST (record + blkt_offset), msr->swapflag);
 
       /* If bit 0 is set, dilatation wave otherwise compression */
@@ -509,14 +509,14 @@ msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
       else
         strncpy (eventdetection.wave, "COMPRESSION", sizeof (eventdetection.wave));
 
-      eventdetection.onsettime = ms_btime2nstime ((uint8_t*)pMS2B201_YEAR (record + blkt_offset), msr->swapflag);
+      eventdetection.onsettime = ms_btime2nstime ((uint8_t *)pMS2B201_YEAR (record + blkt_offset), msr->swapflag);
       if (eventdetection.onsettime == NSTERROR)
         return MS_GENERROR;
 
       memcpy (eventdetection.medsnr, pMS2B201_MEDSNR (record + blkt_offset), 6);
-      eventdetection.medlookback = *pMS2B201_LOOPBACK (record + blkt_offset);
+      eventdetection.medlookback      = *pMS2B201_LOOPBACK (record + blkt_offset);
       eventdetection.medpickalgorithm = *pMS2B201_PICKALGORITHM (record + blkt_offset);
-      eventdetection.next = NULL;
+      eventdetection.next             = NULL;
 
       if (mseh_add_event_detection_r (msr, NULL, &eventdetection, &parsestate))
       {
@@ -528,16 +528,16 @@ msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
     /* Blockette 300, step calibration */
     else if (blkt_type == 300)
     {
-      memset (&calibration, 0, sizeof(calibration));
+      memset (&calibration, 0, sizeof (calibration));
 
       strncpy (calibration.type, "STEP", sizeof (calibration.type));
 
-      calibration.begintime = ms_btime2nstime ((uint8_t*)pMS2B300_YEAR (record + blkt_offset), msr->swapflag);
+      calibration.begintime = ms_btime2nstime ((uint8_t *)pMS2B300_YEAR (record + blkt_offset), msr->swapflag);
       if (calibration.begintime == NSTERROR)
         return MS_GENERROR;
 
       calibration.endtime = NSTERROR;
-      calibration.steps = *pMS2B300_NUMCALIBRATIONS (record + blkt_offset);
+      calibration.steps   = *pMS2B300_NUMCALIBRATIONS (record + blkt_offset);
 
       /* If bit 0 is set, first puluse is positive */
       calibration.firstpulsepositive = -1;
@@ -560,18 +560,18 @@ msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
       if (*pMS2B300_FLAGS (record + blkt_offset) & 0x08)
         calibration.continued = 1;
 
-      calibration.duration = (double)(HO4u (*pMS2B300_STEPDURATION (record + blkt_offset), msr->swapflag) / 10000.0);
+      calibration.duration    = (double)(HO4u (*pMS2B300_STEPDURATION (record + blkt_offset), msr->swapflag) / 10000.0);
       calibration.stepbetween = (double)(HO4u (*pMS2B300_INTERVALDURATION (record + blkt_offset), msr->swapflag) / 10000.0);
-      calibration.amplitude = HO4f (*pMS2B300_AMPLITUDE (record + blkt_offset), msr->swapflag);
+      calibration.amplitude   = HO4f (*pMS2B300_AMPLITUDE (record + blkt_offset), msr->swapflag);
       ms_strncpcleantail (calibration.inputchannel, pMS2B300_INPUTCHANNEL (record + blkt_offset), 3);
-      calibration.inputunits[0] = '\0';
+      calibration.inputunits[0]     = '\0';
       calibration.amplituderange[0] = '\0';
-      calibration.sineperiod = 0.0;
-      calibration.refamplitude = (double)(HO4u (*pMS2B300_REFERENCEAMPLITUDE (record + blkt_offset), msr->swapflag));
+      calibration.sineperiod        = 0.0;
+      calibration.refamplitude      = (double)(HO4u (*pMS2B300_REFERENCEAMPLITUDE (record + blkt_offset), msr->swapflag));
       ms_strncpcleantail (calibration.coupling, pMS2B300_COUPLING (record + blkt_offset), 12);
       ms_strncpcleantail (calibration.rolloff, pMS2B300_ROLLOFF (record + blkt_offset), 12);
       calibration.noise[0] = '\0';
-      calibration.next = NULL;
+      calibration.next     = NULL;
 
       if (mseh_add_calibration_r (msr, NULL, &calibration, &parsestate))
       {
@@ -583,18 +583,18 @@ msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
     /* Blockette 310, sine calibration */
     else if (blkt_type == 310)
     {
-      memset (&calibration, 0, sizeof(calibration));
+      memset (&calibration, 0, sizeof (calibration));
 
       strncpy (calibration.type, "SINE", sizeof (calibration.type));
 
-      calibration.begintime = ms_btime2nstime ((uint8_t*)pMS2B310_YEAR (record + blkt_offset), msr->swapflag);
+      calibration.begintime = ms_btime2nstime ((uint8_t *)pMS2B310_YEAR (record + blkt_offset), msr->swapflag);
       if (calibration.begintime == NSTERROR)
         return MS_GENERROR;
 
-      calibration.endtime = NSTERROR;
-      calibration.steps = -1;
+      calibration.endtime            = NSTERROR;
+      calibration.steps              = -1;
       calibration.firstpulsepositive = -1;
-      calibration.alternatesign = -1;
+      calibration.alternatesign      = -1;
 
       /* If bit 2 is set, calibration is automatic, otherwise manual */
       if (*pMS2B310_FLAGS (record + blkt_offset) & 0x04)
@@ -618,17 +618,17 @@ msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
       else if (*pMS2B310_FLAGS (record + blkt_offset) & 0x40)
         strncpy (calibration.amplituderange, "RMS", sizeof (calibration.amplituderange));
 
-      calibration.duration = (double)(HO4u (*pMS2B310_DURATION (record + blkt_offset), msr->swapflag) / 10000.0);
+      calibration.duration   = (double)(HO4u (*pMS2B310_DURATION (record + blkt_offset), msr->swapflag) / 10000.0);
       calibration.sineperiod = HO4f (*pMS2B310_PERIOD (record + blkt_offset), msr->swapflag);
-      calibration.amplitude = HO4f (*pMS2B310_AMPLITUDE (record + blkt_offset), msr->swapflag);
+      calibration.amplitude  = HO4f (*pMS2B310_AMPLITUDE (record + blkt_offset), msr->swapflag);
       ms_strncpcleantail (calibration.inputchannel, pMS2B310_INPUTCHANNEL (record + blkt_offset), 3);
-      calibration.refamplitude = (double)(HO4u (*pMS2B310_REFERENCEAMPLITUDE (record + blkt_offset), msr->swapflag));
-      calibration.stepbetween = 0.0;
+      calibration.refamplitude  = (double)(HO4u (*pMS2B310_REFERENCEAMPLITUDE (record + blkt_offset), msr->swapflag));
+      calibration.stepbetween   = 0.0;
       calibration.inputunits[0] = '\0';
       ms_strncpcleantail (calibration.coupling, pMS2B310_COUPLING (record + blkt_offset), 12);
       ms_strncpcleantail (calibration.rolloff, pMS2B310_ROLLOFF (record + blkt_offset), 12);
       calibration.noise[0] = '\0';
-      calibration.next = NULL;
+      calibration.next     = NULL;
 
       if (mseh_add_calibration_r (msr, NULL, &calibration, &parsestate))
       {
@@ -640,18 +640,18 @@ msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
     /* Blockette 320, pseudo-random calibration */
     else if (blkt_type == 320)
     {
-      memset (&calibration, 0, sizeof(calibration));
+      memset (&calibration, 0, sizeof (calibration));
 
       strncpy (calibration.type, "PSEUDORANDOM", sizeof (calibration.type));
 
-      calibration.begintime = ms_btime2nstime ((uint8_t*)pMS2B320_YEAR (record + blkt_offset), msr->swapflag);
+      calibration.begintime = ms_btime2nstime ((uint8_t *)pMS2B320_YEAR (record + blkt_offset), msr->swapflag);
       if (calibration.begintime == NSTERROR)
         return MS_GENERROR;
 
-      calibration.endtime = NSTERROR;
-      calibration.steps = -1;
+      calibration.endtime            = NSTERROR;
+      calibration.steps              = -1;
       calibration.firstpulsepositive = -1;
-      calibration.alternatesign = -1;
+      calibration.alternatesign      = -1;
 
       /* If bit 2 is set, calibration is automatic, otherwise manual */
       if (*pMS2B320_FLAGS (record + blkt_offset) & 0x04)
@@ -669,12 +669,12 @@ msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
       if (*pMS2B320_FLAGS (record + blkt_offset) & 0x10)
         strncpy (calibration.amplituderange, "RANDOM", sizeof (calibration.amplituderange));
 
-      calibration.duration = (double)(HO4u (*pMS2B320_DURATION (record + blkt_offset), msr->swapflag) / 10000.0);
+      calibration.duration  = (double)(HO4u (*pMS2B320_DURATION (record + blkt_offset), msr->swapflag) / 10000.0);
       calibration.amplitude = HO4f (*pMS2B320_PTPAMPLITUDE (record + blkt_offset), msr->swapflag);
       ms_strncpcleantail (calibration.inputchannel, pMS2B320_INPUTCHANNEL (record + blkt_offset), 3);
-      calibration.refamplitude = (double)(HO4u (*pMS2B320_REFERENCEAMPLITUDE (record + blkt_offset), msr->swapflag));
-      calibration.sineperiod = 0.0;
-      calibration.stepbetween = 0.0;
+      calibration.refamplitude  = (double)(HO4u (*pMS2B320_REFERENCEAMPLITUDE (record + blkt_offset), msr->swapflag));
+      calibration.sineperiod    = 0.0;
+      calibration.stepbetween   = 0.0;
       calibration.inputunits[0] = '\0';
       ms_strncpcleantail (calibration.coupling, pMS2B320_COUPLING (record + blkt_offset), 12);
       ms_strncpcleantail (calibration.rolloff, pMS2B320_ROLLOFF (record + blkt_offset), 12);
@@ -691,18 +691,18 @@ msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
     /* Blockette 390, generic calibration */
     else if (blkt_type == 390)
     {
-      memset (&calibration, 0, sizeof(calibration));
+      memset (&calibration, 0, sizeof (calibration));
 
       strncpy (calibration.type, "GENERIC", sizeof (calibration.type));
 
-      calibration.begintime = ms_btime2nstime ((uint8_t*)pMS2B390_YEAR (record + blkt_offset), msr->swapflag);
+      calibration.begintime = ms_btime2nstime ((uint8_t *)pMS2B390_YEAR (record + blkt_offset), msr->swapflag);
       if (calibration.begintime == NSTERROR)
         return MS_GENERROR;
 
-      calibration.endtime = NSTERROR;
-      calibration.steps = -1;
+      calibration.endtime            = NSTERROR;
+      calibration.steps              = -1;
       calibration.firstpulsepositive = -1;
-      calibration.alternatesign = -1;
+      calibration.alternatesign      = -1;
 
       /* If bit 2 is set, calibration is automatic, otherwise manual */
       if (*pMS2B390_FLAGS (record + blkt_offset) & 0x04)
@@ -716,17 +716,17 @@ msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
         calibration.continued = 1;
 
       calibration.amplituderange[0] = '\0';
-      calibration.duration = (double)(HO4u (*pMS2B390_DURATION (record + blkt_offset), msr->swapflag) / 10000.0);
-      calibration.amplitude = HO4f (*pMS2B390_AMPLITUDE (record + blkt_offset), msr->swapflag);
+      calibration.duration          = (double)(HO4u (*pMS2B390_DURATION (record + blkt_offset), msr->swapflag) / 10000.0);
+      calibration.amplitude         = HO4f (*pMS2B390_AMPLITUDE (record + blkt_offset), msr->swapflag);
       ms_strncpcleantail (calibration.inputchannel, pMS2B390_INPUTCHANNEL (record + blkt_offset), 3);
-      calibration.refamplitude = 0.0;
-      calibration.sineperiod = 0.0;
-      calibration.stepbetween = 0.0;
+      calibration.refamplitude  = 0.0;
+      calibration.sineperiod    = 0.0;
+      calibration.stepbetween   = 0.0;
       calibration.inputunits[0] = '\0';
-      calibration.coupling[0] = '\0';
-      calibration.rolloff[0] = '\0';
-      calibration.noise[0] = '\0';
-      calibration.next = NULL;
+      calibration.coupling[0]   = '\0';
+      calibration.rolloff[0]    = '\0';
+      calibration.noise[0]      = '\0';
+      calibration.next          = NULL;
 
       if (mseh_add_calibration_r (msr, NULL, &calibration, &parsestate))
       {
@@ -738,33 +738,33 @@ msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
     /* Blockette 395, calibration abort */
     else if (blkt_type == 395)
     {
-      memset (&calibration, 0, sizeof(calibration));
+      memset (&calibration, 0, sizeof (calibration));
 
       strncpy (calibration.type, "ABORT", sizeof (calibration.type));
 
       calibration.begintime = NSTERROR;
 
-      calibration.endtime = ms_btime2nstime ((uint8_t*)pMS2B395_YEAR (record + blkt_offset), msr->swapflag);
+      calibration.endtime = ms_btime2nstime ((uint8_t *)pMS2B395_YEAR (record + blkt_offset), msr->swapflag);
       if (calibration.endtime == NSTERROR)
         return MS_GENERROR;
 
-      calibration.steps = -1;
+      calibration.steps              = -1;
       calibration.firstpulsepositive = -1;
-      calibration.alternatesign = -1;
-      calibration.trigger[0] = '\0';
-      calibration.continued = -1;
-      calibration.amplituderange[0] = '\0';
-      calibration.duration = 0.0;
-      calibration.amplitude = 0.0;
-      calibration.inputchannel[0] = '\0';
-      calibration.refamplitude = 0.0;
-      calibration.sineperiod = 0.0;
-      calibration.stepbetween = 0.0;
-      calibration.inputunits[0] = '\0';
-      calibration.coupling[0] = '\0';
-      calibration.rolloff[0] = '\0';
-      calibration.noise[0] = '\0';
-      calibration.next = NULL;
+      calibration.alternatesign      = -1;
+      calibration.trigger[0]         = '\0';
+      calibration.continued          = -1;
+      calibration.amplituderange[0]  = '\0';
+      calibration.duration           = 0.0;
+      calibration.amplitude          = 0.0;
+      calibration.inputchannel[0]    = '\0';
+      calibration.refamplitude       = 0.0;
+      calibration.sineperiod         = 0.0;
+      calibration.stepbetween        = 0.0;
+      calibration.inputunits[0]      = '\0';
+      calibration.coupling[0]        = '\0';
+      calibration.rolloff[0]         = '\0';
+      calibration.noise[0]           = '\0';
+      calibration.next               = NULL;
 
       if (mseh_add_calibration_r (msr, NULL, &calibration, &parsestate))
       {
@@ -788,17 +788,17 @@ msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
     /* Blockette 500, timing blockette */
     else if (blkt_type == 500)
     {
-      memset (&exception, 0, sizeof(exception));
+      memset (&exception, 0, sizeof (exception));
 
       exception.vcocorrection = HO4f (*pMS2B500_VCOCORRECTION (record + blkt_offset), msr->swapflag);
 
-      exception.time = ms_btime2nstime ((uint8_t*)pMS2B500_YEAR (record + blkt_offset), msr->swapflag);
+      exception.time = ms_btime2nstime ((uint8_t *)pMS2B500_YEAR (record + blkt_offset), msr->swapflag);
       if (exception.time == NSTERROR)
         return MS_GENERROR;
 
-      exception.usec = *pMS2B500_MICROSECOND (record + blkt_offset);
+      exception.usec             = *pMS2B500_MICROSECOND (record + blkt_offset);
       exception.receptionquality = *pMS2B500_RECEPTIONQUALITY (record + blkt_offset);
-      exception.count = HO4u (*pMS2B500_EXCEPTIONCOUNT (record + blkt_offset), msr->swapflag);
+      exception.count            = HO4u (*pMS2B500_EXCEPTIONCOUNT (record + blkt_offset), msr->swapflag);
       ms_strncpcleantail (exception.type, pMS2B500_EXCEPTIONTYPE (record + blkt_offset), 16);
       ms_strncpcleantail (exception.clockstatus, pMS2B500_CLOCKSTATUS (record + blkt_offset), 128);
 
@@ -837,7 +837,7 @@ msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
       /* Optimization: if no other extra headers yet, directly print this common value */
       if (parsestate == NULL)
       {
-        length = snprintf (sval, sizeof(sval), "{\"FDSN\":{\"Time\":{\"Quality\":%d}}}",
+        length = snprintf (sval, sizeof (sval), "{\"FDSN\":{\"Time\":{\"Quality\":%d}}}",
                            *pMS2B1001_TIMINGQUALITY (record + blkt_offset));
 
         if (!(msr->extra = (char *)libmseed_memory.malloc (length + 1)))
@@ -923,7 +923,7 @@ msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
   }
 
   /* Calculate start time */
-  msr->starttime = ms_btime2nstime ((uint8_t*)pMS2FSDH_YEAR (record), msr->swapflag);
+  msr->starttime = ms_btime2nstime ((uint8_t *)pMS2FSDH_YEAR (record), msr->swapflag);
   if (msr->starttime == NSTERROR)
   {
     ms_log (2, "%s: Cannot convert start time to internal time stamp\n", msr->sid);
@@ -985,41 +985,41 @@ msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
       libmseed_memory.free (msr->datasamples);
 
     msr->datasamples = NULL;
-    msr->datasize = 0;
-    msr->numsamples = 0;
+    msr->datasize    = 0;
+    msr->numsamples  = 0;
   }
 
   return MS_NOERROR;
 } /* End of msr3_unpack_mseed2() */
 
 /*******************************************************************/ /**
- * @brief Determine the data payload bounds for a MS3Record
- *
- * Bounds are the starting offset in record and size.  For miniSEED
- * 2.x the raw record is expected to be located at the
- * ::MS3Record.record pointer.
- *
- * When the encoding is a fixed length per sample (text/ASCII,
- * integers or floats), calculate the data size based on the sample
- * count and use if less than size determined otherwise.
- *
- * When the encoding is Steim1 or Steim2, search for 64-byte padding
- * frames (all zeros) at the end of the payload and remove from the
- * reported size.
- *
- * @param[in] msr The ::MS3Record to determine payload bounds for
- * @param[out] dataoffset Offset from start of record to start of payload
- * @param[out] datasize Payload size in bytes
- *
- * @return 0 on success or negative library error code.
- *
- * \ref MessageOnError - this function logs a message on error
- ************************************************************************/
+                                                                       * @brief Determine the data payload bounds for a MS3Record
+                                                                       *
+                                                                       * Bounds are the starting offset in record and size.  For miniSEED
+                                                                       * 2.x the raw record is expected to be located at the
+                                                                       * ::MS3Record.record pointer.
+                                                                       *
+                                                                       * When the encoding is a fixed length per sample (text/ASCII,
+                                                                       * integers or floats), calculate the data size based on the sample
+                                                                       * count and use if less than size determined otherwise.
+                                                                       *
+                                                                       * When the encoding is Steim1 or Steim2, search for 64-byte padding
+                                                                       * frames (all zeros) at the end of the payload and remove from the
+                                                                       * reported size.
+                                                                       *
+                                                                       * @param[in] msr The ::MS3Record to determine payload bounds for
+                                                                       * @param[out] dataoffset Offset from start of record to start of payload
+                                                                       * @param[out] datasize Payload size in bytes
+                                                                       *
+                                                                       * @return 0 on success or negative library error code.
+                                                                       *
+                                                                       * \ref MessageOnError - this function logs a message on error
+                                                                       ************************************************************************/
 int
 msr3_data_bounds (MS3Record *msr, uint32_t *dataoffset, uint32_t *datasize)
 {
   uint8_t nullframe[64] = {0};
-  uint8_t samplebytes = 0;
+  uint8_t samplebytes   = 0;
   uint64_t rawsize;
 
   if (!msr || !dataoffset || !datasize)
@@ -1032,12 +1032,12 @@ msr3_data_bounds (MS3Record *msr, uint32_t *dataoffset, uint32_t *datasize)
   if (msr->formatversion == 3)
   {
     *dataoffset = MS3FSDH_LENGTH + strlen (msr->sid) + msr->extralength;
-    *datasize = msr->datalength;
+    *datasize   = msr->datalength;
   }
   else if (msr->formatversion == 2)
   {
     *dataoffset = HO2u (*pMS2FSDH_DATAOFFSET (msr->record), msr->swapflag & MSSWAP_HEADER);
-    *datasize = msr->reclen - *dataoffset;
+    *datasize   = msr->reclen - *dataoffset;
   }
   else
   {
@@ -1090,38 +1090,38 @@ msr3_data_bounds (MS3Record *msr, uint32_t *dataoffset, uint32_t *datasize)
 } /* End of msr3_data_bounds() */
 
 /*******************************************************************/ /**
- * @brief Unpack data samples for a ::MS3Record
- *
- * This routine can be used to unpack the data samples for a
- * ::MS3Record that was earlier parsed without the data samples being
- * decoded.
- *
- * The packed/encoded data is accessed in the record indicated by
- * ::MS3Record.record and the unpacked samples are placed in
- * ::MS3Record.datasamples.  The resulting data samples are either
- * text (ASCII) characters, 32-bit integers, 32-bit floats or 64-bit
- * floats in host byte order.
- *
- * An internal buffer is allocated if the encoded data is not aligned
- * for the sample size, which is a decent indicator of the alignment
- * needed for decoding efficiently.
- *
- * @param[in] msr Target ::MS3Record to unpack data samples
- * @param[in] verbose Flag to control verbosity, 0 means no diagnostic output
- *
- * @return number of samples unpacked or negative libmseed error code.
- *
- * \ref MessageOnError - this function logs a message on error
- ************************************************************************/
+                                                                       * @brief Unpack data samples for a ::MS3Record
+                                                                       *
+                                                                       * This routine can be used to unpack the data samples for a
+                                                                       * ::MS3Record that was earlier parsed without the data samples being
+                                                                       * decoded.
+                                                                       *
+                                                                       * The packed/encoded data is accessed in the record indicated by
+                                                                       * ::MS3Record.record and the unpacked samples are placed in
+                                                                       * ::MS3Record.datasamples.  The resulting data samples are either
+                                                                       * text (ASCII) characters, 32-bit integers, 32-bit floats or 64-bit
+                                                                       * floats in host byte order.
+                                                                       *
+                                                                       * An internal buffer is allocated if the encoded data is not aligned
+                                                                       * for the sample size, which is a decent indicator of the alignment
+                                                                       * needed for decoding efficiently.
+                                                                       *
+                                                                       * @param[in] msr Target ::MS3Record to unpack data samples
+                                                                       * @param[in] verbose Flag to control verbosity, 0 means no diagnostic output
+                                                                       *
+                                                                       * @return number of samples unpacked or negative libmseed error code.
+                                                                       *
+                                                                       * \ref MessageOnError - this function logs a message on error
+                                                                       ************************************************************************/
 int64_t
 msr3_unpack_data (MS3Record *msr, int8_t verbose)
 {
-  uint32_t datasize; /* byte size of data samples in record */
-  int64_t nsamples; /* number of samples unpacked */
-  size_t unpacksize; /* byte size of unpacked samples */
-  uint8_t samplesize = 0; /* size of the data samples in bytes */
-  uint32_t dataoffset = 0;
-  const char *encoded = NULL;
+  uint32_t datasize;           /* byte size of data samples in record */
+  int64_t nsamples;            /* number of samples unpacked */
+  size_t unpacksize;           /* byte size of unpacked samples */
+  uint8_t samplesize      = 0; /* size of the data samples in bytes */
+  uint32_t dataoffset     = 0;
+  const char *encoded     = NULL;
   char *encoded_allocated = NULL;
 
   if (!msr)
@@ -1177,7 +1177,7 @@ msr3_unpack_data (MS3Record *msr, int8_t verbose)
     msr->encoding = DE_STEIM1;
   }
 
-  if (ms_encoding_sizetype(msr->encoding, &samplesize, NULL))
+  if (ms_encoding_sizetype (msr->encoding, &samplesize, NULL))
   {
     ms_log (2, "%s: Cannot determine sample size for encoding: %u\n", msr->sid, msr->encoding);
     return MS_GENERROR;
@@ -1188,7 +1188,7 @@ msr3_unpack_data (MS3Record *msr, int8_t verbose)
   /* Copy encoded data to aligned/malloc'd buffer if not aligned for sample size */
   if (samplesize && !is_aligned (encoded, samplesize))
   {
-    if ((encoded_allocated = (char *) libmseed_memory.malloc (datasize)) == NULL)
+    if ((encoded_allocated = (char *)libmseed_memory.malloc (datasize)) == NULL)
     {
       ms_log (2, "Cannot allocate memory for encoded data\n");
       return MS_GENERROR;
@@ -1211,7 +1211,7 @@ msr3_unpack_data (MS3Record *msr, int8_t verbose)
     else
     {
       msr->datasamples = libmseed_memory.realloc (msr->datasamples, unpacksize);
-      msr->datasize = unpacksize;
+      msr->datasize    = unpacksize;
     }
 
     if (msr->datasamples == NULL)
@@ -1228,8 +1228,8 @@ msr3_unpack_data (MS3Record *msr, int8_t verbose)
     if (msr->datasamples)
       libmseed_memory.free (msr->datasamples);
     msr->datasamples = NULL;
-    msr->datasize = 0;
-    msr->numsamples = 0;
+    msr->datasize    = 0;
+    msr->numsamples  = 0;
   }
 
   if (verbose > 2)
@@ -1249,30 +1249,30 @@ msr3_unpack_data (MS3Record *msr, int8_t verbose)
 } /* End of msr3_unpack_data() */
 
 /*******************************************************************/ /**
- * @brief Decode data samples to a supplied buffer
- *
- * @param[in] input Encoded data
- * @param[in] inputsize Size of \a input buffer in bytes
- * @param[in] encoding Data encoding
- * @param[in] samplecount Number of samples to decode
- * @param[out] output Decoded data
- * @param[in] outputsize Size of \a output buffer in bytes
- * @param[out] sampletype Pointer to (single character) sample type of decoded data
- * @param[in] swapflag Flag indicating if encoded data needs swapping
- * @param[in] sid Source identifier to include in diagnostic/error messages
- * @param[in] verbose Flag to control verbosity, 0 means no diagnostic output
- *
- * @return number of samples decoded or negative libmseed error code.
- *
- * \ref MessageOnError - this function logs a message on error
- ************************************************************************/
+                                                                       * @brief Decode data samples to a supplied buffer
+                                                                       *
+                                                                       * @param[in] input Encoded data
+                                                                       * @param[in] inputsize Size of \a input buffer in bytes
+                                                                       * @param[in] encoding Data encoding
+                                                                       * @param[in] samplecount Number of samples to decode
+                                                                       * @param[out] output Decoded data
+                                                                       * @param[in] outputsize Size of \a output buffer in bytes
+                                                                       * @param[out] sampletype Pointer to (single character) sample type of decoded data
+                                                                       * @param[in] swapflag Flag indicating if encoded data needs swapping
+                                                                       * @param[in] sid Source identifier to include in diagnostic/error messages
+                                                                       * @param[in] verbose Flag to control verbosity, 0 means no diagnostic output
+                                                                       *
+                                                                       * @return number of samples decoded or negative libmseed error code.
+                                                                       *
+                                                                       * \ref MessageOnError - this function logs a message on error
+                                                                       ************************************************************************/
 int64_t
 ms_decode_data (const void *input, size_t inputsize, uint8_t encoding,
                 int64_t samplecount, void *output, size_t outputsize,
                 char *sampletype, int8_t swapflag, char *sid, int8_t verbose)
 {
-  size_t decodedsize; /* byte size of decodeded samples */
-  int32_t nsamples; /* number of samples unpacked */
+  size_t decodedsize;     /* byte size of decodeded samples */
+  int32_t nsamples;       /* number of samples unpacked */
   uint8_t samplesize = 0; /* size of the data samples in bytes */
 
   if (!input || !output || !sampletype)
@@ -1293,7 +1293,7 @@ ms_decode_data (const void *input, size_t inputsize, uint8_t encoding,
       libmseed_decodedebug = 0;
   }
 
-  if (ms_encoding_sizetype(encoding, &samplesize, sampletype))
+  if (ms_encoding_sizetype (encoding, &samplesize, sampletype))
     samplesize = 0;
 
   /* Calculate buffer size needed for unpacked samples */
@@ -1301,7 +1301,7 @@ ms_decode_data (const void *input, size_t inputsize, uint8_t encoding,
 
   if (decodedsize > outputsize)
   {
-    ms_log (2, "%s: Output buffer (%"PRIsize_t" bytes) is not large enought for decoded data (%"PRIsize_t" bytes)\n",
+    ms_log (2, "%s: Output buffer (%" PRIsize_t " bytes) is not large enought for decoded data (%" PRIsize_t " bytes)\n",
             (sid) ? sid : "", decodedsize, outputsize);
     return MS_GENERROR;
   }
@@ -1479,9 +1479,9 @@ ms_nomsamprate (int factor, int multiplier)
 char *
 ms2_recordsid (char *record, char *sid, int sidlen)
 {
-  char net[3] = {0};
-  char sta[6] = {0};
-  char loc[3] = {0};
+  char net[3]  = {0};
+  char sta[6]  = {0};
+  char loc[3]  = {0};
   char chan[6] = {0};
 
   if (!record || !sid)
@@ -1653,7 +1653,7 @@ ms_btime2nstime (uint8_t *btime, int8_t swapflag)
     return NSTERROR;
   }
 
-  year = HO2u (*((uint16_t*)(btime)), swapflag);
+  year = HO2u (*((uint16_t *)(btime)), swapflag);
 
   /* Special case, if year 0 return unset value */
   if (year == 0)

--- a/unpack.h
+++ b/unpack.h
@@ -22,20 +22,21 @@
 #define UNPACK_H 1
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #include "libmseed.h"
 
-extern int64_t msr3_unpack_mseed3 (char *record, int reclen, MS3Record **ppmsr,
-                                   uint32_t flags, int8_t verbose);
-extern int64_t msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
-                                   uint32_t flags, int8_t verbose);
+  extern int64_t msr3_unpack_mseed3 (char *record, int reclen, MS3Record **ppmsr,
+                                     uint32_t flags, int8_t verbose);
+  extern int64_t msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
+                                     uint32_t flags, int8_t verbose);
 
-extern double ms_nomsamprate (int factor, int multiplier);
-extern char *ms2_recordsid (char *record, char *sid, int sidlen);
-extern const char *ms2_blktdesc (uint16_t blkttype);
-uint16_t ms2_blktlen (uint16_t blkttype, const char *blkt, int8_t swapflag);
+  extern double ms_nomsamprate (int factor, int multiplier);
+  extern char *ms2_recordsid (char *record, char *sid, int sidlen);
+  extern const char *ms2_blktdesc (uint16_t blkttype);
+  uint16_t ms2_blktlen (uint16_t blkttype, const char *blkt, int8_t swapflag);
 
 #ifdef __cplusplus
 }

--- a/unpackdata.h
+++ b/unpackdata.h
@@ -23,37 +23,38 @@
 #define UNPACKDATA_H 1
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #include "libmseed.h"
 
-/* Control for printing debugging information, declared in unpackdata.c */
-extern int libmseed_decodedebug;
+  /* Control for printing debugging information, declared in unpackdata.c */
+  extern int libmseed_decodedebug;
 
-extern int msr_decode_int16 (int16_t *input, int64_t samplecount, int32_t *output,
-                             int64_t outputlength, int swapflag);
-extern int msr_decode_int32 (int32_t *input, int64_t samplecount, int32_t *output,
-                             int64_t outputlength, int swapflag);
-extern int msr_decode_float32 (float *input, int64_t samplecount, float *output,
+  extern int msr_decode_int16 (int16_t *input, int64_t samplecount, int32_t *output,
                                int64_t outputlength, int swapflag);
-extern int msr_decode_float64 (double *input, int64_t samplecount, double *output,
+  extern int msr_decode_int32 (int32_t *input, int64_t samplecount, int32_t *output,
                                int64_t outputlength, int swapflag);
-extern int msr_decode_steim1 (int32_t *input, int inputlength, int64_t samplecount,
-                              int32_t *output, int64_t outputlength, char *srcname,
-                              int swapflag);
-extern int msr_decode_steim2 (int32_t *input, int inputlength, int64_t samplecount,
-                              int32_t *output, int64_t outputlength, char *srcname,
-                              int swapflag);
-extern int msr_decode_geoscope (char *input, int64_t samplecount, float *output,
-                                int64_t outputlength, int encoding, char *srcname,
+  extern int msr_decode_float32 (float *input, int64_t samplecount, float *output,
+                                 int64_t outputlength, int swapflag);
+  extern int msr_decode_float64 (double *input, int64_t samplecount, double *output,
+                                 int64_t outputlength, int swapflag);
+  extern int msr_decode_steim1 (int32_t *input, int inputlength, int64_t samplecount,
+                                int32_t *output, int64_t outputlength, char *srcname,
                                 int swapflag);
-extern int msr_decode_cdsn (int16_t *input, int64_t samplecount, int32_t *output,
-                            int64_t outputlength, int swapflag);
-extern int msr_decode_sro (int16_t *input, int64_t samplecount, int32_t *output,
-                           int64_t outputlength, char *srcname, int swapflag);
-extern int msr_decode_dwwssn (int16_t *input, int64_t samplecount, int32_t *output,
+  extern int msr_decode_steim2 (int32_t *input, int inputlength, int64_t samplecount,
+                                int32_t *output, int64_t outputlength, char *srcname,
+                                int swapflag);
+  extern int msr_decode_geoscope (char *input, int64_t samplecount, float *output,
+                                  int64_t outputlength, int encoding, char *srcname,
+                                  int swapflag);
+  extern int msr_decode_cdsn (int16_t *input, int64_t samplecount, int32_t *output,
                               int64_t outputlength, int swapflag);
+  extern int msr_decode_sro (int16_t *input, int64_t samplecount, int32_t *output,
+                             int64_t outputlength, char *srcname, int swapflag);
+  extern int msr_decode_dwwssn (int16_t *input, int64_t samplecount, int32_t *output,
+                                int64_t outputlength, int swapflag);
 
 #ifdef __cplusplus
 }

--- a/yyjson.c
+++ b/yyjson.c
@@ -7,10 +7,8 @@
  *============================================================================*/
 
 #include "yyjson.h"
-#include <stdio.h>
 #include <math.h>
-
-
+#include <stdio.h>
 
 /*==============================================================================
  * Compile Hint Begin
@@ -18,38 +16,36 @@
 
 /* warning suppress begin */
 #if defined(__clang__)
-#   pragma clang diagnostic push
-#   pragma clang diagnostic ignored "-Wunused-function"
-#   pragma clang diagnostic ignored "-Wunused-parameter"
-#   pragma clang diagnostic ignored "-Wunused-label"
-#   pragma clang diagnostic ignored "-Wunused-macros"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wunused-label"
+#pragma clang diagnostic ignored "-Wunused-macros"
 #elif defined(__GNUC__)
-#   if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
-#   pragma GCC diagnostic push
-#   endif
-#   pragma GCC diagnostic ignored "-Wunused-function"
-#   pragma GCC diagnostic ignored "-Wunused-parameter"
-#   pragma GCC diagnostic ignored "-Wunused-label"
-#   pragma GCC diagnostic ignored "-Wunused-macros"
-#elif defined(_MSC_VER)
-#   pragma warning(push)
-#   pragma warning(disable:4100) /* unreferenced formal parameter */
-#   pragma warning(disable:4102) /* unreferenced label */
-#   pragma warning(disable:4127) /* conditional expression is constant */
-#   pragma warning(disable:4706) /* assignment within conditional expression */
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+#pragma GCC diagnostic push
 #endif
-
-
+#pragma GCC diagnostic ignored "-Wunused-function"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-label"
+#pragma GCC diagnostic ignored "-Wunused-macros"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4100) /* unreferenced formal parameter */
+#pragma warning(disable : 4102) /* unreferenced label */
+#pragma warning(disable : 4127) /* conditional expression is constant */
+#pragma warning(disable : 4706) /* assignment within conditional expression */
+#endif
 
 /*==============================================================================
  * Version
  *============================================================================*/
 
-yyjson_api uint32_t yyjson_version(void) {
-    return YYJSON_VERSION_HEX;
+yyjson_api uint32_t
+yyjson_version (void)
+{
+  return YYJSON_VERSION_HEX;
 }
-
-
 
 /*==============================================================================
  * Flags
@@ -57,286 +53,284 @@ yyjson_api uint32_t yyjson_version(void) {
 
 /* gcc version check */
 #if defined(__GNUC__)
-#   if defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
-#       define yyjson_gcc_available(major, minor, patch) \
-            ((__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) \
-            >= (major * 10000 + minor * 100 + patch))
-#   elif defined(__GNUC_MINOR__)
-#       define yyjson_gcc_available(major, minor, patch) \
-            ((__GNUC__ * 10000 + __GNUC_MINOR__ * 100) \
-            >= (major * 10000 + minor * 100 + patch))
-#   else
-#       define yyjson_gcc_available(major, minor, patch) \
-            ((__GNUC__ * 10000) >= (major * 10000 + minor * 100 + patch))
-#   endif
+#if defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
+#define yyjson_gcc_available(major, minor, patch) \
+  ((__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) >= (major * 10000 + minor * 100 + patch))
+#elif defined(__GNUC_MINOR__)
+#define yyjson_gcc_available(major, minor, patch) \
+  ((__GNUC__ * 10000 + __GNUC_MINOR__ * 100) >= (major * 10000 + minor * 100 + patch))
 #else
-#       define yyjson_gcc_available(major, minor, patch) 0
+#define yyjson_gcc_available(major, minor, patch) \
+  ((__GNUC__ * 10000) >= (major * 10000 + minor * 100 + patch))
+#endif
+#else
+#define yyjson_gcc_available(major, minor, patch) 0
 #endif
 
 /* real gcc check */
 #if !defined(__clang__) && !defined(__INTEL_COMPILER) && !defined(__ICC) && \
     defined(__GNUC__) && defined(__GNUC_MINOR__)
-#   define YYJSON_IS_REAL_GCC 1
+#define YYJSON_IS_REAL_GCC 1
 #else
-#   define YYJSON_IS_REAL_GCC 0
+#define YYJSON_IS_REAL_GCC 0
 #endif
 
 /* msvc intrinsic */
 #if YYJSON_MSC_VER >= 1400
-#   include <intrin.h>
-#   if defined(_M_AMD64) || defined(_M_ARM64)
-#       define MSC_HAS_BIT_SCAN_64 1
-#       pragma intrinsic(_BitScanForward64)
-#       pragma intrinsic(_BitScanReverse64)
-#   else
-#       define MSC_HAS_BIT_SCAN_64 0
-#   endif
-#   if defined(_M_AMD64) || defined(_M_ARM64) || \
-        defined(_M_IX86) || defined(_M_ARM)
-#       define MSC_HAS_BIT_SCAN 1
-#       pragma intrinsic(_BitScanForward)
-#       pragma intrinsic(_BitScanReverse)
-#   else
-#       define MSC_HAS_BIT_SCAN 0
-#   endif
-#   if defined(_M_AMD64)
-#       define MSC_HAS_UMUL128 1
-#       pragma intrinsic(_umul128)
-#   else
-#       define MSC_HAS_UMUL128 0
-#   endif
+#include <intrin.h>
+#if defined(_M_AMD64) || defined(_M_ARM64)
+#define MSC_HAS_BIT_SCAN_64 1
+#pragma intrinsic(_BitScanForward64)
+#pragma intrinsic(_BitScanReverse64)
 #else
-#   define MSC_HAS_BIT_SCAN_64 0
-#   define MSC_HAS_BIT_SCAN 0
-#   define MSC_HAS_UMUL128 0
+#define MSC_HAS_BIT_SCAN_64 0
+#endif
+#if defined(_M_AMD64) || defined(_M_ARM64) || \
+    defined(_M_IX86) || defined(_M_ARM)
+#define MSC_HAS_BIT_SCAN 1
+#pragma intrinsic(_BitScanForward)
+#pragma intrinsic(_BitScanReverse)
+#else
+#define MSC_HAS_BIT_SCAN 0
+#endif
+#if defined(_M_AMD64)
+#define MSC_HAS_UMUL128 1
+#pragma intrinsic(_umul128)
+#else
+#define MSC_HAS_UMUL128 0
+#endif
+#else
+#define MSC_HAS_BIT_SCAN_64 0
+#define MSC_HAS_BIT_SCAN 0
+#define MSC_HAS_UMUL128 0
 #endif
 
 /* gcc builtin */
 #if yyjson_has_builtin(__builtin_clzll) || yyjson_gcc_available(3, 4, 0)
-#   define GCC_HAS_CLZLL 1
+#define GCC_HAS_CLZLL 1
 #else
-#   define GCC_HAS_CLZLL 0
+#define GCC_HAS_CLZLL 0
 #endif
 
 #if yyjson_has_builtin(__builtin_ctzll) || yyjson_gcc_available(3, 4, 0)
-#   define GCC_HAS_CTZLL 1
+#define GCC_HAS_CTZLL 1
 #else
-#   define GCC_HAS_CTZLL 0
+#define GCC_HAS_CTZLL 0
 #endif
 
 /* int128 type */
 #if defined(__SIZEOF_INT128__) && (__SIZEOF_INT128__ == 16) && \
     (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER))
-#    define YYJSON_HAS_INT128 1
+#define YYJSON_HAS_INT128 1
 #else
-#    define YYJSON_HAS_INT128 0
+#define YYJSON_HAS_INT128 0
 #endif
 
 /* IEEE 754 floating-point binary representation */
 #if defined(__STDC_IEC_559__) || defined(__STDC_IEC_60559_BFP__)
-#   define YYJSON_HAS_IEEE_754 1
+#define YYJSON_HAS_IEEE_754 1
 #elif (FLT_RADIX == 2) && (DBL_MANT_DIG == 53) && (DBL_DIG == 15) && \
-     (DBL_MIN_EXP == -1021) && (DBL_MAX_EXP == 1024) && \
-     (DBL_MIN_10_EXP == -307) && (DBL_MAX_10_EXP == 308)
-#   define YYJSON_HAS_IEEE_754 1
+    (DBL_MIN_EXP == -1021) && (DBL_MAX_EXP == 1024) &&               \
+    (DBL_MIN_10_EXP == -307) && (DBL_MAX_10_EXP == 308)
+#define YYJSON_HAS_IEEE_754 1
 #else
-#   define YYJSON_HAS_IEEE_754 0
+#define YYJSON_HAS_IEEE_754 0
 #endif
 
 /*
  Correct rounding in double number computations.
- 
+
  On the x86 architecture, some compilers may use x87 FPU instructions for
  floating-point arithmetic. The x87 FPU loads all floating point number as
  80-bit double-extended precision internally, then rounds the result to original
  precision, which may produce inaccurate results. For a more detailed
  explanation, see the paper: https://arxiv.org/abs/cs/0701192
- 
+
  Here are some examples of double precision calculation error:
- 
+
      2877.0 / 1e6   == 0.002877,  but x87 returns 0.0028770000000000002
      43683.0 * 1e21 == 4.3683e25, but x87 returns 4.3683000000000004e25
- 
+
  Here are some examples of compiler flags to generate x87 instructions on x86:
- 
+
      clang -m32 -mno-sse
      gcc/icc -m32 -mfpmath=387
      msvc /arch:SSE or /arch:IA32
- 
+
  If we are sure that there's no similar error described above, we can define the
  YYJSON_DOUBLE_MATH_CORRECT as 1 to enable the fast path calculation. This is
  not an accurate detection, it's just try to avoid the error at compile-time.
  An accurate detection can be done at run-time:
- 
+
      bool is_double_math_correct(void) {
          volatile double r = 43683.0;
          r *= 1e21;
          return r == 4.3683e25;
      }
- 
+
  See also: utils.h in https://github.com/google/double-conversion/
  */
 #if !defined(FLT_EVAL_METHOD) && defined(__FLT_EVAL_METHOD__)
-#    define FLT_EVAL_METHOD __FLT_EVAL_METHOD__
+#define FLT_EVAL_METHOD __FLT_EVAL_METHOD__
 #endif
 
 #if defined(FLT_EVAL_METHOD) && FLT_EVAL_METHOD != 0 && FLT_EVAL_METHOD != 1
-#    define YYJSON_DOUBLE_MATH_CORRECT 0
+#define YYJSON_DOUBLE_MATH_CORRECT 0
 #elif defined(i386) || defined(__i386) || defined(__i386__) || \
-    defined(_X86_) || defined(__X86__) || defined(_M_IX86) || \
+    defined(_X86_) || defined(__X86__) || defined(_M_IX86) ||  \
     defined(__I86__) || defined(__IA32__) || defined(__THW_INTEL)
-#   if (defined(_MSC_VER) && defined(_M_IX86_FP) && _M_IX86_FP == 2) || \
-        (defined(__SSE2_MATH__) && __SSE2_MATH__)
-#       define YYJSON_DOUBLE_MATH_CORRECT 1
-#   else
-#       define YYJSON_DOUBLE_MATH_CORRECT 0
-#   endif
-#elif defined(__mc68000__) || defined(__pnacl__) || defined(__native_client__)
-#   define YYJSON_DOUBLE_MATH_CORRECT 0
+#if (defined(_MSC_VER) && defined(_M_IX86_FP) && _M_IX86_FP == 2) || \
+    (defined(__SSE2_MATH__) && __SSE2_MATH__)
+#define YYJSON_DOUBLE_MATH_CORRECT 1
 #else
-#   define YYJSON_DOUBLE_MATH_CORRECT 1
+#define YYJSON_DOUBLE_MATH_CORRECT 0
+#endif
+#elif defined(__mc68000__) || defined(__pnacl__) || defined(__native_client__)
+#define YYJSON_DOUBLE_MATH_CORRECT 0
+#else
+#define YYJSON_DOUBLE_MATH_CORRECT 1
 #endif
 
 /* endian */
-#if yyjson_has_include(<sys/types.h>)
-#    include <sys/types.h>
+#if yyjson_has_include(<sys / types.h>)
+#include <sys/types.h>
 #endif
 
 #if yyjson_has_include(<endian.h>)
-#    include <endian.h>
-#elif yyjson_has_include(<machine/endian.h>)
-#    include <machine/endian.h>
-#elif yyjson_has_include(<sys/endian.h>)
-#    include <sys/endian.h>
+#include <endian.h>
+#elif yyjson_has_include(<machine / endian.h>)
+#include <machine/endian.h>
+#elif yyjson_has_include(<sys / endian.h>)
+#include <sys/endian.h>
 #endif
 
-#define YYJSON_BIG_ENDIAN       4321
-#define YYJSON_LITTLE_ENDIAN    1234
+#define YYJSON_BIG_ENDIAN 4321
+#define YYJSON_LITTLE_ENDIAN 1234
 
 #if defined(__BYTE_ORDER__) && __BYTE_ORDER__
-#   if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#       define YYJSON_ENDIAN YYJSON_BIG_ENDIAN
-#   elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#       define YYJSON_ENDIAN YYJSON_LITTLE_ENDIAN
-#   endif
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define YYJSON_ENDIAN YYJSON_BIG_ENDIAN
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define YYJSON_ENDIAN YYJSON_LITTLE_ENDIAN
+#endif
 
 #elif defined(__BYTE_ORDER) && __BYTE_ORDER
-#   if __BYTE_ORDER == __BIG_ENDIAN
-#       define YYJSON_ENDIAN YYJSON_BIG_ENDIAN
-#   elif __BYTE_ORDER == __LITTLE_ENDIAN
-#       define YYJSON_ENDIAN YYJSON_LITTLE_ENDIAN
-#   endif
+#if __BYTE_ORDER == __BIG_ENDIAN
+#define YYJSON_ENDIAN YYJSON_BIG_ENDIAN
+#elif __BYTE_ORDER == __LITTLE_ENDIAN
+#define YYJSON_ENDIAN YYJSON_LITTLE_ENDIAN
+#endif
 
 #elif defined(BYTE_ORDER) && BYTE_ORDER
-#   if BYTE_ORDER == BIG_ENDIAN
-#       define YYJSON_ENDIAN YYJSON_BIG_ENDIAN
-#   elif BYTE_ORDER == LITTLE_ENDIAN
-#       define YYJSON_ENDIAN YYJSON_LITTLE_ENDIAN
-#   endif
+#if BYTE_ORDER == BIG_ENDIAN
+#define YYJSON_ENDIAN YYJSON_BIG_ENDIAN
+#elif BYTE_ORDER == LITTLE_ENDIAN
+#define YYJSON_ENDIAN YYJSON_LITTLE_ENDIAN
+#endif
 
-#elif (defined(__LITTLE_ENDIAN__) && __LITTLE_ENDIAN__ == 1) || \
-    defined(__i386) || defined(__i386__) || \
-    defined(_X86_) || defined(__X86__) || \
-    defined(_M_IX86) || defined(__THW_INTEL__) || \
-    defined(__x86_64) || defined(__x86_64__) || \
-    defined(__amd64) || defined(__amd64__) || \
-    defined(_M_AMD64) || defined(_M_X64) || \
-    defined(__ia64) || defined(_IA64) || defined(__IA64__) ||  \
-    defined(__ia64__) || defined(_M_IA64) || defined(__itanium__) || \
+#elif (defined(__LITTLE_ENDIAN__) && __LITTLE_ENDIAN__ == 1) ||             \
+    defined(__i386) || defined(__i386__) ||                                 \
+    defined(_X86_) || defined(__X86__) ||                                   \
+    defined(_M_IX86) || defined(__THW_INTEL__) ||                           \
+    defined(__x86_64) || defined(__x86_64__) ||                             \
+    defined(__amd64) || defined(__amd64__) ||                               \
+    defined(_M_AMD64) || defined(_M_X64) ||                                 \
+    defined(__ia64) || defined(_IA64) || defined(__IA64__) ||               \
+    defined(__ia64__) || defined(_M_IA64) || defined(__itanium__) ||        \
     defined(__ARMEL__) || defined(__THUMBEL__) || defined(__AARCH64EL__) || \
-    defined(__alpha) || defined(__alpha__) || defined(_M_ALPHA) || \
-    defined(__riscv) || defined(__riscv__) || \
-    defined(_MIPSEL) || defined(__MIPSEL) || defined(__MIPSEL__) || \
-    defined(__EMSCRIPTEN__) || defined(__wasm__) || \
+    defined(__alpha) || defined(__alpha__) || defined(_M_ALPHA) ||          \
+    defined(__riscv) || defined(__riscv__) ||                               \
+    defined(_MIPSEL) || defined(__MIPSEL) || defined(__MIPSEL__) ||         \
+    defined(__EMSCRIPTEN__) || defined(__wasm__) ||                         \
     defined(__loongarch__)
-#   define YYJSON_ENDIAN YYJSON_LITTLE_ENDIAN
+#define YYJSON_ENDIAN YYJSON_LITTLE_ENDIAN
 
-#elif (defined(__BIG_ENDIAN__) && __BIG_ENDIAN__ == 1) || \
+#elif (defined(__BIG_ENDIAN__) && __BIG_ENDIAN__ == 1) ||                   \
     defined(__ARMEB__) || defined(__THUMBEB__) || defined(__AARCH64EB__) || \
-    defined(_MIPSEB) || defined(__MIPSEB) || defined(__MIPSEB__) || \
-    defined(_ARCH_PPC) || defined(_ARCH_PPC64) || \
-    defined(__ppc) || defined(__ppc__) || \
-    defined(__sparc) || defined(__sparc__) || defined(__sparc64__) || \
+    defined(_MIPSEB) || defined(__MIPSEB) || defined(__MIPSEB__) ||         \
+    defined(_ARCH_PPC) || defined(_ARCH_PPC64) ||                           \
+    defined(__ppc) || defined(__ppc__) ||                                   \
+    defined(__sparc) || defined(__sparc__) || defined(__sparc64__) ||       \
     defined(__or1k__) || defined(__OR1K__)
-#   define YYJSON_ENDIAN YYJSON_BIG_ENDIAN
+#define YYJSON_ENDIAN YYJSON_BIG_ENDIAN
 
 #else
-#   define YYJSON_ENDIAN 0 /* unknown endian, detect at run-time */
+#define YYJSON_ENDIAN 0 /* unknown endian, detect at run-time */
 #endif
 
 /*
  Unaligned memory access detection.
- 
+
  Some architectures cannot perform unaligned memory access, or unaligned memory
  accesses can have a large performance penalty. Modern compilers can make some
  optimizations for unaligned access. For example: https://godbolt.org/z/Ejo3Pa
- 
+
     typedef struct { char c[2] } vec2;
     void copy_vec2(vec2 *dst, vec2 *src) {
         *dst = *src;
     }
- 
+
  Compiler may generate `load/store` or `move` instruction if target architecture
  supports unaligned access, otherwise it may generate `call memcpy` instruction.
- 
+
  We want to avoid `memcpy` calls, so we should disable unaligned access by
  define `YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS` as 1 on these architectures.
  */
 #ifndef YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-#   if defined(i386) || defined(__i386) || defined(__i386__) || \
-        defined(__i486__) || defined(__i586__) || defined(__i686__) || \
-        defined(_X86_) || defined(__X86__) || defined(_M_IX86) || \
-        defined(__I86__) || defined(__IA32__) || \
-        defined(__THW_INTEL) || defined(__THW_INTEL__) || \
-        defined(__x86_64) || defined(__x86_64__) || \
-        defined(__amd64) || defined(__amd64__) || \
-        defined(_M_AMD64) || defined(_M_X64)
-#       define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 0 /* x86 */
+#if defined(i386) || defined(__i386) || defined(__i386__) ||       \
+    defined(__i486__) || defined(__i586__) || defined(__i686__) || \
+    defined(_X86_) || defined(__X86__) || defined(_M_IX86) ||      \
+    defined(__I86__) || defined(__IA32__) ||                       \
+    defined(__THW_INTEL) || defined(__THW_INTEL__) ||              \
+    defined(__x86_64) || defined(__x86_64__) ||                    \
+    defined(__amd64) || defined(__amd64__) ||                      \
+    defined(_M_AMD64) || defined(_M_X64)
+#define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 0 /* x86 */
 
-#   elif defined(__ia64) || defined(_IA64) || defined(__IA64__) ||  \
-        defined(__ia64__) || defined(_M_IA64) || defined(__itanium__)
-#       define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 1 /* Itanium */
+#elif defined(__ia64) || defined(_IA64) || defined(__IA64__) || \
+    defined(__ia64__) || defined(_M_IA64) || defined(__itanium__)
+#define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 1 /* Itanium */
 
-#   elif defined(__arm64) || defined(__arm64__) || \
-        defined(__AARCH64EL__) || defined(__AARCH64EB__) || \
-        defined(__aarch64__) || defined(_M_ARM64)
-#       define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 0 /* ARM64 */
+#elif defined(__arm64) || defined(__arm64__) ||         \
+    defined(__AARCH64EL__) || defined(__AARCH64EB__) || \
+    defined(__aarch64__) || defined(_M_ARM64)
+#define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 0 /* ARM64 */
 
-#   elif defined(__ARM_ARCH_4__) || defined(__ARM_ARCH_4T__) || \
-        defined(__ARM_ARCH_5TEJ__) || defined(__ARM_ARCH_5TE__) || \
-        defined(__ARM_ARCH_6T2__) || defined(__ARM_ARCH_6KZ__) || \
-        defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6K__)
-#       define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 1 /* ARM */
+#elif defined(__ARM_ARCH_4__) || defined(__ARM_ARCH_4T__) ||   \
+    defined(__ARM_ARCH_5TEJ__) || defined(__ARM_ARCH_5TE__) || \
+    defined(__ARM_ARCH_6T2__) || defined(__ARM_ARCH_6KZ__) ||  \
+    defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6K__)
+#define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 1 /* ARM */
 
-#   elif defined(__ppc64__) || defined(__PPC64__) || \
-        defined(__powerpc64__) || defined(_ARCH_PPC64) || \
-        defined(__ppc) || defined(__ppc__) || defined(__PPC__) || \
-        defined(__powerpc) || defined(__powerpc__) || defined(__POWERPC__) || \
-        defined(_ARCH_PPC) || defined(_M_PPC) || \
-        defined(__PPCGECKO__) || defined(__PPCBROADWAY__) || defined(_XENON)
-#       define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 0 /* PowerPC */
+#elif defined(__ppc64__) || defined(__PPC64__) ||                         \
+    defined(__powerpc64__) || defined(_ARCH_PPC64) ||                     \
+    defined(__ppc) || defined(__ppc__) || defined(__PPC__) ||             \
+    defined(__powerpc) || defined(__powerpc__) || defined(__POWERPC__) || \
+    defined(_ARCH_PPC) || defined(_M_PPC) ||                              \
+    defined(__PPCGECKO__) || defined(__PPCBROADWAY__) || defined(_XENON)
+#define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 0 /* PowerPC */
 
-#   elif defined(__loongarch__)
-#       define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 0 /* loongarch */
+#elif defined(__loongarch__)
+#define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 0 /* loongarch */
 
-#   else
-#       define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 0 /* Unknown */
-#   endif
+#else
+#define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 0 /* Unknown */
+#endif
 
 #endif
 
 /*
  Estimated initial ratio of the JSON data (data_size / value_count).
  For example:
-    
+
     data:        {"id":12345678,"name":"Harry"}
     data_size:   30
     value_count: 5
     ratio:       6
-    
+
  yyjson uses dynamic memory with a growth factor of 1.5 when reading and writing
  JSON, the ratios below are used to determine the initial memory size.
- 
+
  A too large ratio will waste memory, and a too small ratio will cause multiple
  memory growths and degrade performance. Currently, these ratios are generated
  with some commonly used JSON datasets.
@@ -347,10 +341,10 @@ yyjson_api uint32_t yyjson_version(void) {
 #define YYJSON_WRITER_ESTIMATED_MINIFY_RATIO 18
 
 /* The initial and maximum size of the memory pool's chunk in yyjson_mut_doc. */
-#define YYJSON_MUT_DOC_STR_POOL_INIT_SIZE   0x100
-#define YYJSON_MUT_DOC_STR_POOL_MAX_SIZE    0x10000000
-#define YYJSON_MUT_DOC_VAL_POOL_INIT_SIZE   (0x10 * sizeof(yyjson_mut_val))
-#define YYJSON_MUT_DOC_VAL_POOL_MAX_SIZE    (0x1000000 * sizeof(yyjson_mut_val))
+#define YYJSON_MUT_DOC_STR_POOL_INIT_SIZE 0x100
+#define YYJSON_MUT_DOC_STR_POOL_MAX_SIZE 0x10000000
+#define YYJSON_MUT_DOC_VAL_POOL_INIT_SIZE (0x10 * sizeof (yyjson_mut_val))
+#define YYJSON_MUT_DOC_VAL_POOL_MAX_SIZE (0x1000000 * sizeof (yyjson_mut_val))
 
 /* Default value for compile-time options. */
 #ifndef YYJSON_DISABLE_READER
@@ -366,85 +360,109 @@ yyjson_api uint32_t yyjson_version(void) {
 #define YYJSON_DISABLE_NON_STANDARD 0
 #endif
 
-
-
 /*==============================================================================
  * Macros
  *============================================================================*/
 
 /* Macros used for loop unrolling and other purpose. */
-#define repeat2(x)  { x x }
-#define repeat3(x)  { x x x }
-#define repeat4(x)  { x x x x }
-#define repeat8(x)  { x x x x x x x x }
-#define repeat16(x) { x x x x x x x x x x x x x x x x }
+#define repeat2(x) \
+  {                \
+    x x            \
+  }
+#define repeat3(x) \
+  {                \
+    x x x          \
+  }
+#define repeat4(x) \
+  {                \
+    x x x x        \
+  }
+#define repeat8(x)  \
+  {                 \
+    x x x x x x x x \
+  }
+#define repeat16(x)                 \
+  {                                 \
+    x x x x x x x x x x x x x x x x \
+  }
 
-#define repeat2_incr(x)  { x(0) x(1) }
-#define repeat4_incr(x)  { x(0) x(1) x(2) x(3) }
-#define repeat8_incr(x)  { x(0) x(1) x(2) x(3) x(4) x(5) x(6) x(7) }
-#define repeat16_incr(x) { x(0) x(1) x(2) x(3) x(4) x(5) x(6) x(7) \
-                           x(8) x(9) x(10) x(11) x(12) x(13) x(14) x(15) }
-#define repeat_in_1_18(x) { x(1) x(2) x(3) x(4) x(5) x(6) x(7) \
-                            x(8) x(9) x(10) x(11) x(12) x(13) x(14) x(15) \
-                            x(16) x(17) x(18) }
+#define repeat2_incr(x) \
+  {                     \
+    x (0) x (1)         \
+  }
+#define repeat4_incr(x)     \
+  {                         \
+    x (0) x (1) x (2) x (3) \
+  }
+#define repeat8_incr(x)                             \
+  {                                                 \
+    x (0) x (1) x (2) x (3) x (4) x (5) x (6) x (7) \
+  }
+#define repeat16_incr(x)                                      \
+  {                                                           \
+    x (0) x (1) x (2) x (3) x (4) x (5) x (6) x (7)           \
+        x (8) x (9) x (10) x (11) x (12) x (13) x (14) x (15) \
+  }
+#define repeat_in_1_18(x)                                     \
+  {                                                           \
+    x (1) x (2) x (3) x (4) x (5) x (6) x (7)                 \
+        x (8) x (9) x (10) x (11) x (12) x (13) x (14) x (15) \
+            x (16) x (17) x (18)                              \
+  }
 
 /* Macros used to provide branch prediction information for compiler. */
-#undef  likely
-#define likely(x)       yyjson_likely(x)
-#undef  unlikely
-#define unlikely(x)     yyjson_unlikely(x)
+#undef likely
+#define likely(x) yyjson_likely (x)
+#undef unlikely
+#define unlikely(x) yyjson_unlikely (x)
 
 /* Macros used to provide inline information for compiler. */
-#undef  static_inline
-#define static_inline   static yyjson_inline
-#undef  static_noinline
+#undef static_inline
+#define static_inline static yyjson_inline
+#undef static_noinline
 #define static_noinline static yyjson_noinline
 
 /* Macros for min and max. */
-#undef  yyjson_min
+#undef yyjson_min
 #define yyjson_min(x, y) ((x) < (y) ? (x) : (y))
-#undef  yyjson_max
+#undef yyjson_max
 #define yyjson_max(x, y) ((x) > (y) ? (x) : (y))
 
 /* Used to write u64 literal for C89 which doesn't support "ULL" suffix. */
-#undef  U64
+#undef U64
 #define U64(hi, lo) ((((u64)hi##UL) << 32U) + lo##UL)
 
 /* Used to cast away (remove) const qualifier. */
-#define constcast(type) (type)(void *)(size_t)(const void *)
-
-
+#define constcast(type) (type) (void *) (size_t)(const void *)
 
 /*==============================================================================
  * Integer Constants
  *============================================================================*/
 
 /* U64 constant values */
-#undef  U64_MAX
-#define U64_MAX         U64(0xFFFFFFFF, 0xFFFFFFFF)
-#undef  I64_MAX
-#define I64_MAX         U64(0x7FFFFFFF, 0xFFFFFFFF)
-#undef  USIZE_MAX
-#define USIZE_MAX       ((usize)(~(usize)0))
+#undef U64_MAX
+#define U64_MAX U64 (0xFFFFFFFF, 0xFFFFFFFF)
+#undef I64_MAX
+#define I64_MAX U64 (0x7FFFFFFF, 0xFFFFFFFF)
+#undef USIZE_MAX
+#define USIZE_MAX ((usize)(~(usize)0))
 
 /* Maximum number of digits for reading u64 safety. */
-#undef  U64_SAFE_DIG
-#define U64_SAFE_DIG    19
-
-
+#undef U64_SAFE_DIG
+#define U64_SAFE_DIG 19
 
 /*==============================================================================
  * IEEE-754 Double Number Constants
  *============================================================================*/
 
 /* Inf raw value (positive) */
-#define F64_RAW_INF U64(0x7FF00000, 0x00000000)
+#define F64_RAW_INF U64 (0x7FF00000, 0x00000000)
 
 /* NaN raw value (quiet NaN, no payload, no sign) */
 #if defined(__hppa__) || (defined(__mips__) && !defined(__mips_nan2008))
-#define F64_RAW_NAN U64(0x7FF7FFFF, 0xFFFFFFFF)
+#define F64_RAW_NAN U64 (0x7FF7FFFF, 0xFFFFFFFF)
 #else
-#define F64_RAW_NAN U64(0x7FF80000, 0x00000000)
+#define F64_RAW_NAN U64 (0x7FF80000, 0x00000000)
 #endif
 
 /* double number bits */
@@ -460,10 +478,10 @@ yyjson_api uint32_t yyjson_version(void) {
 #define F64_SIG_FULL_BITS 53
 
 /* double number significand bit mask */
-#define F64_SIG_MASK U64(0x000FFFFF, 0xFFFFFFFF)
+#define F64_SIG_MASK U64 (0x000FFFFF, 0xFFFFFFFF)
 
 /* double number exponent bit mask */
-#define F64_EXP_MASK U64(0x7FF00000, 0x00000000)
+#define F64_EXP_MASK U64 (0x7FF00000, 0x00000000)
 
 /* double number exponent bias */
 #define F64_EXP_BIAS 1023
@@ -486,42 +504,59 @@ yyjson_api uint32_t yyjson_version(void) {
 /* minimum binary power of double number */
 #define F64_MIN_BIN_EXP (-1021)
 
-
-
 /*==============================================================================
  * Types
  *============================================================================*/
 
 /** Type define for primitive types. */
-typedef float       f32;
-typedef double      f64;
-typedef int8_t      i8;
-typedef uint8_t     u8;
-typedef int16_t     i16;
-typedef uint16_t    u16;
-typedef int32_t     i32;
-typedef uint32_t    u32;
-typedef int64_t     i64;
-typedef uint64_t    u64;
-typedef size_t      usize;
+typedef float f32;
+typedef double f64;
+typedef int8_t i8;
+typedef uint8_t u8;
+typedef int16_t i16;
+typedef uint16_t u16;
+typedef int32_t i32;
+typedef uint32_t u32;
+typedef int64_t i64;
+typedef uint64_t u64;
+typedef size_t usize;
 
 /** 128-bit integer, used by floating-point number reader and writer. */
 #if YYJSON_HAS_INT128
-__extension__ typedef __int128          i128;
+__extension__ typedef __int128 i128;
 __extension__ typedef unsigned __int128 u128;
 #endif
 
 /** 16/32/64-bit vector */
-typedef struct v16 { char c1, c2; } v16;
-typedef struct v32 { char c1, c2, c3, c4; } v32;
-typedef struct v64 { char c1, c2, c3, c4, c5, c6, c7, c8; } v64;
+typedef struct v16
+{
+  char c1, c2;
+} v16;
+typedef struct v32
+{
+  char c1, c2, c3, c4;
+} v32;
+typedef struct v64
+{
+  char c1, c2, c3, c4, c5, c6, c7, c8;
+} v64;
 
 /** 16/32/64-bit vector union, used for unaligned memory access on modern CPU */
-typedef union v16_uni { v16 v; u16 u; } v16_uni;
-typedef union v32_uni { v32 v; u32 u; } v32_uni;
-typedef union v64_uni { v64 v; u64 u; } v64_uni;
-
-
+typedef union v16_uni
+{
+  v16 v;
+  u16 u;
+} v16_uni;
+typedef union v32_uni
+{
+  v32 v;
+  u32 u;
+} v32_uni;
+typedef union v64_uni
+{
+  v64 v;
+  u64 u;
+} v64_uni;
 
 /*==============================================================================
  * Load/Store Utils
@@ -529,121 +564,143 @@ typedef union v64_uni { v64 v; u64 u; } v64_uni;
 
 #define byte_move_idx(x) ((u8 *)dst)[x] = ((u8 *)src)[x];
 
-static_inline void byte_move_2(void *dst, const void *src) {
+static_inline void
+byte_move_2 (void *dst, const void *src)
+{
 #if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-    repeat2_incr(byte_move_idx)
+  repeat2_incr (byte_move_idx)
 #else
-    memmove(dst, src, 2);
+  memmove (dst, src, 2);
 #endif
 }
 
-static_inline void byte_move_4(void *dst, const void *src) {
+static_inline void
+byte_move_4 (void *dst, const void *src)
+{
 #if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-    repeat4_incr(byte_move_idx)
+  repeat4_incr (byte_move_idx)
 #else
-    memmove(dst, src, 4);
+  memmove (dst, src, 4);
 #endif
 }
 
-static_inline void byte_move_8(void *dst, const void *src) {
+static_inline void
+byte_move_8 (void *dst, const void *src)
+{
 #if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-    repeat8_incr(byte_move_idx)
+  repeat8_incr (byte_move_idx)
 #else
-    memmove(dst, src, 8);
+  memmove (dst, src, 8);
 #endif
 }
 
-static_inline void byte_move_16(void *dst, const void *src) {
+static_inline void
+byte_move_16 (void *dst, const void *src)
+{
 #if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-    repeat16_incr(byte_move_idx)
+  repeat16_incr (byte_move_idx)
 #else
-    memmove(dst, src, 16);
+  memmove (dst, src, 16);
 #endif
 }
 
-static_inline void byte_copy_2(void *dst, const void *src) {
+static_inline void
+byte_copy_2 (void *dst, const void *src)
+{
 #if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-    repeat2_incr(byte_move_idx)
+  repeat2_incr (byte_move_idx)
 #else
-    memcpy(dst, src, 2);
+  memcpy (dst, src, 2);
 #endif
 }
 
-static_inline void byte_copy_4(void *dst, const void *src) {
+static_inline void
+byte_copy_4 (void *dst, const void *src)
+{
 #if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-    repeat4_incr(byte_move_idx)
+  repeat4_incr (byte_move_idx)
 #else
-    memcpy(dst, src, 4);
+  memcpy (dst, src, 4);
 #endif
 }
 
-static_inline void byte_copy_8(void *dst, const void *src) {
+static_inline void
+byte_copy_8 (void *dst, const void *src)
+{
 #if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-    repeat8_incr(byte_move_idx)
+  repeat8_incr (byte_move_idx)
 #else
-    memcpy(dst, src, 8);
+  memcpy (dst, src, 8);
 #endif
 }
 
-static_inline void byte_copy_16(void *dst, const void *src) {
+static_inline void
+byte_copy_16 (void *dst, const void *src)
+{
 #if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-    repeat16_incr(byte_move_idx)
+  repeat16_incr (byte_move_idx)
 #else
-    memcpy(dst, src, 16);
+  memcpy (dst, src, 16);
 #endif
 }
 
-static_inline bool byte_match_2(void *buf, const char *pat) {
+static_inline bool
+byte_match_2 (void *buf, const char *pat)
+{
 #if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-    return
-    ((u8 *)buf)[0] == ((const u8 *)pat)[0] &&
-    ((u8 *)buf)[1] == ((const u8 *)pat)[1];
+  return ((u8 *)buf)[0] == ((const u8 *)pat)[0] &&
+         ((u8 *)buf)[1] == ((const u8 *)pat)[1];
 #else
-    v16_uni u1, u2;
-    u1.v = *(const v16 *)pat;
-    u2.v = *(const v16 *)buf;
-    return u1.u == u2.u;
+  v16_uni u1, u2;
+  u1.v = *(const v16 *)pat;
+  u2.v = *(const v16 *)buf;
+  return u1.u == u2.u;
 #endif
 }
 
-static_inline bool byte_match_4(void *buf, const char *pat) {
+static_inline bool
+byte_match_4 (void *buf, const char *pat)
+{
 #if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-    return
-    ((u8 *)buf)[0] == ((const u8 *)pat)[0] &&
-    ((u8 *)buf)[1] == ((const u8 *)pat)[1] &&
-    ((u8 *)buf)[2] == ((const u8 *)pat)[2] &&
-    ((u8 *)buf)[3] == ((const u8 *)pat)[3];
+  return ((u8 *)buf)[0] == ((const u8 *)pat)[0] &&
+         ((u8 *)buf)[1] == ((const u8 *)pat)[1] &&
+         ((u8 *)buf)[2] == ((const u8 *)pat)[2] &&
+         ((u8 *)buf)[3] == ((const u8 *)pat)[3];
 #else
-    v32_uni u1, u2;
-    u1.v = *(const v32 *)pat;
-    u2.v = *(const v32 *)buf;
-    return u1.u == u2.u;
+  v32_uni u1, u2;
+  u1.v = *(const v32 *)pat;
+  u2.v = *(const v32 *)buf;
+  return u1.u == u2.u;
 #endif
 }
 
-static_inline u16 byte_load_2(const void *src) {
-    v16_uni uni;
-    uni.v = *(const v16 *)src;
-    return uni.u;
+static_inline u16
+byte_load_2 (const void *src)
+{
+  v16_uni uni;
+  uni.v = *(const v16 *)src;
+  return uni.u;
 }
 
-static_inline u32 byte_load_3(const void *src) {
-    v32_uni uni;
-    ((v16_uni *)&uni)->v = *(const v16 *)src;
-    uni.v.c3 = ((const char *)src)[2];
-    uni.v.c4 = 0;
-    return uni.u;
+static_inline u32
+byte_load_3 (const void *src)
+{
+  v32_uni uni;
+  ((v16_uni *)&uni)->v = *(const v16 *)src;
+  uni.v.c3             = ((const char *)src)[2];
+  uni.v.c4             = 0;
+  return uni.u;
 }
 
-static_inline u32 byte_load_4(const void *src) {
-    v32_uni uni;
-    uni.v = *(const v32 *)src;
-    return uni.u;
+static_inline u32
+byte_load_4 (const void *src)
+{
+  v32_uni uni;
+  uni.v = *(const v32 *)src;
+  return uni.u;
 }
 
 #undef byte_move_expr
-
-
 
 /*==============================================================================
  * Number Utils
@@ -655,73 +712,85 @@ static_inline u32 byte_load_4(const void *src) {
  `memcpy` can be used in both C and C++, but it may reduce performance without
  compiler optimization.
  */
-typedef union { u64 u; f64 f; } f64_uni;
+typedef union
+{
+  u64 u;
+  f64 f;
+} f64_uni;
 
 /** Convert raw binary to double. */
-static_inline f64 f64_from_raw(u64 u) {
+static_inline f64
+f64_from_raw (u64 u)
+{
 #ifndef __cplusplus
-    f64_uni uni;
-    uni.u = u;
-    return uni.f;
+  f64_uni uni;
+  uni.u = u;
+  return uni.f;
 #else
-    f64 f;
-    memcpy(&f, &u, 8);
-    return f;
+  f64 f;
+  memcpy (&f, &u, 8);
+  return f;
 #endif
 }
 
 /** Convert double to raw binary. */
-static_inline u64 f64_to_raw(f64 f) {
+static_inline u64
+f64_to_raw (f64 f)
+{
 #ifndef __cplusplus
-    f64_uni uni;
-    uni.f = f;
-    return uni.u;
+  f64_uni uni;
+  uni.f = f;
+  return uni.u;
 #else
-    u64 u;
-    memcpy(&u, &f, 8);
-    return u;
+  u64 u;
+  memcpy (&u, &f, 8);
+  return u;
 #endif
 }
 
 /** Get raw 'infinity' with sign. */
-static_inline u64 f64_raw_get_inf(bool sign) {
+static_inline u64
+f64_raw_get_inf (bool sign)
+{
 #if YYJSON_HAS_IEEE_754
-    return F64_RAW_INF | ((u64)sign << 63);
+  return F64_RAW_INF | ((u64)sign << 63);
 #elif defined(INFINITY)
-    return f64_to_raw(sign ? -INFINITY : INFINITY);
+  return f64_to_raw (sign ? -INFINITY : INFINITY);
 #else
-    return f64_to_raw(sign ? -HUGE_VAL : HUGE_VAL);
+  return f64_to_raw (sign ? -HUGE_VAL : HUGE_VAL);
 #endif
 }
 
 /** Get raw 'nan' with sign. */
-static_inline u64 f64_raw_get_nan(bool sign) {
+static_inline u64
+f64_raw_get_nan (bool sign)
+{
 #if YYJSON_HAS_IEEE_754
-    return F64_RAW_NAN | ((u64)sign << 63);
+  return F64_RAW_NAN | ((u64)sign << 63);
 #elif defined(NAN)
-    return f64_to_raw(sign ? (f64)-NAN : (f64)NAN);
+  return f64_to_raw (sign ? (f64)-NAN : (f64)NAN);
 #else
-    return f64_to_raw((sign ? -0.0 : 0.0) / 0.0);
+  return f64_to_raw ((sign ? -0.0 : 0.0) / 0.0);
 #endif
 }
 
 /**
  Convert normalized u64 (highest bit is 1) to f64.
- 
+
  Some compiler (such as Microsoft Visual C++ 6.0) do not support converting
  number from u64 to f64. This function will first convert u64 to i64 and then
  to f64, with `to nearest` rounding mode.
  */
-static_inline f64 normalized_u64_to_f64(u64 val) {
+static_inline f64
+normalized_u64_to_f64 (u64 val)
+{
 #if YYJSON_U64_TO_F64_NO_IMPL
-    i64 sig = (i64)((val >> 1) | (val & 1));
-    return ((f64)sig) * (f64)2.0;
+  i64 sig = (i64)((val >> 1) | (val & 1));
+  return ((f64)sig) * (f64)2.0;
 #else
-    return (f64)val;
+  return (f64)val;
 #endif
 }
-
-
 
 /*==============================================================================
  * Size Utils
@@ -729,52 +798,68 @@ static_inline f64 normalized_u64_to_f64(u64 val) {
  *============================================================================*/
 
 /** Returns whether the size is overflow after increment. */
-static_inline bool size_add_is_overflow(usize size, usize add) {
-    return size > (size + add);
+static_inline bool
+size_add_is_overflow (usize size, usize add)
+{
+  return size > (size + add);
 }
 
 /** Returns whether the size is power of 2 (size should not be 0). */
-static_inline bool size_is_pow2(usize size) {
-    return (size & (size - 1)) == 0;
+static_inline bool
+size_is_pow2 (usize size)
+{
+  return (size & (size - 1)) == 0;
 }
 
 /** Align size upwards (may overflow). */
-static_inline usize size_align_up(usize size, usize align) {
-    if (size_is_pow2(align)) {
-        return (size + (align - 1)) & ~(align - 1);
-    } else {
-        return size + align - (size + align - 1) % align - 1;
-    }
+static_inline usize
+size_align_up (usize size, usize align)
+{
+  if (size_is_pow2 (align))
+  {
+    return (size + (align - 1)) & ~(align - 1);
+  }
+  else
+  {
+    return size + align - (size + align - 1) % align - 1;
+  }
 }
 
 /** Align size downwards. */
-static_inline usize size_align_down(usize size, usize align) {
-    if (size_is_pow2(align)) {
-        return size & ~(align - 1);
-    } else {
-        return size - (size % align);
-    }
+static_inline usize
+size_align_down (usize size, usize align)
+{
+  if (size_is_pow2 (align))
+  {
+    return size & ~(align - 1);
+  }
+  else
+  {
+    return size - (size % align);
+  }
 }
 
 /** Align address upwards (may overflow). */
-static_inline void *mem_align_up(void *mem, usize align) {
-    usize size;
-    memcpy(&size, &mem, sizeof(usize));
-    size = size_align_up(size, align);
-    memcpy(&mem, &size, sizeof(usize));
-    return mem;
+static_inline void *
+mem_align_up (void *mem, usize align)
+{
+  usize size;
+  memcpy (&size, &mem, sizeof (usize));
+  size = size_align_up (size, align);
+  memcpy (&mem, &size, sizeof (usize));
+  return mem;
 }
 
 /** Align address downwards. */
-static_inline void *mem_align_down(void *mem, usize align) {
-    usize size;
-    memcpy(&size, &mem, sizeof(usize));
-    size = size_align_down(size, align);
-    memcpy(&mem, &size, sizeof(usize));
-    return mem;
+static_inline void *
+mem_align_down (void *mem, usize align)
+{
+  usize size;
+  memcpy (&size, &mem, sizeof (usize));
+  size = size_align_down (size, align);
+  memcpy (&mem, &size, sizeof (usize));
+  return mem;
 }
-
-
 
 /*==============================================================================
  * Bits Utils
@@ -782,70 +867,70 @@ static_inline void *mem_align_down(void *mem, usize align) {
  *============================================================================*/
 
 /** Returns the number of leading 0-bits in value (input should not be 0). */
-static_inline u32 u64_lz_bits(u64 v) {
+static_inline u32
+u64_lz_bits (u64 v)
+{
 #if GCC_HAS_CLZLL
-    return (u32)__builtin_clzll(v);
+  return (u32)__builtin_clzll (v);
 #elif MSC_HAS_BIT_SCAN_64
-    unsigned long r;
-    _BitScanReverse64(&r, v);
-    return (u32)63 - (u32)r;
+  unsigned long r;
+  _BitScanReverse64 (&r, v);
+  return (u32)63 - (u32)r;
 #elif MSC_HAS_BIT_SCAN
-    unsigned long hi, lo;
-    bool hi_set = _BitScanReverse(&hi, (u32)(v >> 32)) != 0;
-    _BitScanReverse(&lo, (u32)v);
-    hi |= 32;
-    return (u32)63 - (u32)(hi_set ? hi : lo);
+  unsigned long hi, lo;
+  bool hi_set = _BitScanReverse (&hi, (u32)(v >> 32)) != 0;
+  _BitScanReverse (&lo, (u32)v);
+  hi |= 32;
+  return (u32)63 - (u32)(hi_set ? hi : lo);
 #else
-    /*
-     branchless, use de Bruijn sequences
-     see: https://www.chessprogramming.org/BitScan
-     */
-    const u8 table[64] = {
-        63, 16, 62,  7, 15, 36, 61,  3,  6, 14, 22, 26, 35, 47, 60,  2,
-         9,  5, 28, 11, 13, 21, 42, 19, 25, 31, 34, 40, 46, 52, 59,  1,
-        17,  8, 37,  4, 23, 27, 48, 10, 29, 12, 43, 20, 32, 41, 53, 18,
-        38, 24, 49, 30, 44, 33, 54, 39, 50, 45, 55, 51, 56, 57, 58,  0
-    };
-    v |= v >> 1;
-    v |= v >> 2;
-    v |= v >> 4;
-    v |= v >> 8;
-    v |= v >> 16;
-    v |= v >> 32;
-    return table[(v * U64(0x03F79D71, 0xB4CB0A89)) >> 58];
+  /*
+   branchless, use de Bruijn sequences
+   see: https://www.chessprogramming.org/BitScan
+   */
+  const u8 table[64] = {
+      63, 16, 62, 7, 15, 36, 61, 3, 6, 14, 22, 26, 35, 47, 60, 2,
+      9, 5, 28, 11, 13, 21, 42, 19, 25, 31, 34, 40, 46, 52, 59, 1,
+      17, 8, 37, 4, 23, 27, 48, 10, 29, 12, 43, 20, 32, 41, 53, 18,
+      38, 24, 49, 30, 44, 33, 54, 39, 50, 45, 55, 51, 56, 57, 58, 0};
+  v |= v >> 1;
+  v |= v >> 2;
+  v |= v >> 4;
+  v |= v >> 8;
+  v |= v >> 16;
+  v |= v >> 32;
+  return table[(v * U64 (0x03F79D71, 0xB4CB0A89)) >> 58];
 #endif
 }
 
 /** Returns the number of trailing 0-bits in value (input should not be 0). */
-static_inline u32 u64_tz_bits(u64 v) {
+static_inline u32
+u64_tz_bits (u64 v)
+{
 #if GCC_HAS_CTZLL
-    return (u32)__builtin_ctzll(v);
+  return (u32)__builtin_ctzll (v);
 #elif MSC_HAS_BIT_SCAN_64
-    unsigned long r;
-    _BitScanForward64(&r, v);
-    return (u32)r;
+  unsigned long r;
+  _BitScanForward64 (&r, v);
+  return (u32)r;
 #elif MSC_HAS_BIT_SCAN
-    unsigned long lo, hi;
-    bool lo_set = _BitScanForward(&lo, (u32)(v)) != 0;
-    _BitScanForward(&hi, (u32)(v >> 32));
-    hi += 32;
-    return lo_set ? lo : hi;
+  unsigned long lo, hi;
+  bool lo_set = _BitScanForward (&lo, (u32)(v)) != 0;
+  _BitScanForward (&hi, (u32)(v >> 32));
+  hi += 32;
+  return lo_set ? lo : hi;
 #else
-    /*
-     branchless, use de Bruijn sequences
-     see: https://www.chessprogramming.org/BitScan
-     */
-    const u8 table[64] = {
-         0,  1,  2, 53,  3,  7, 54, 27,  4, 38, 41,  8, 34, 55, 48, 28,
-        62,  5, 39, 46, 44, 42, 22,  9, 24, 35, 59, 56, 49, 18, 29, 11,
-        63, 52,  6, 26, 37, 40, 33, 47, 61, 45, 43, 21, 23, 58, 17, 10,
-        51, 25, 36, 32, 60, 20, 57, 16, 50, 31, 19, 15, 30, 14, 13, 12
-    };
-    return table[((v & (~v + 1)) * U64(0x022FDD63, 0xCC95386D)) >> 58];
+  /*
+   branchless, use de Bruijn sequences
+   see: https://www.chessprogramming.org/BitScan
+   */
+  const u8 table[64] = {
+      0, 1, 2, 53, 3, 7, 54, 27, 4, 38, 41, 8, 34, 55, 48, 28,
+      62, 5, 39, 46, 44, 42, 22, 9, 24, 35, 59, 56, 49, 18, 29, 11,
+      63, 52, 6, 26, 37, 40, 33, 47, 61, 45, 43, 21, 23, 58, 17, 10,
+      51, 25, 36, 32, 60, 20, 57, 16, 50, 31, 19, 15, 30, 14, 13, 12};
+  return table[((v & (~v + 1)) * U64 (0x022FDD63, 0xCC95386D)) >> 58];
 #endif
 }
-
-
 
 /*==============================================================================
  * 128-bit Integer Utils
@@ -854,45 +939,47 @@ static_inline u32 u64_tz_bits(u64 v) {
 
 /** Multiplies two 64-bit unsigned integers (a * b),
     returns the 128-bit result as 'hi' and 'lo'. */
-static_inline void u128_mul(u64 a, u64 b, u64 *hi, u64 *lo) {
+static_inline void
+u128_mul (u64 a, u64 b, u64 *hi, u64 *lo)
+{
 #if YYJSON_HAS_INT128
-    u128 m = (u128)a * b;
-    *hi = (u64)(m >> 64);
-    *lo = (u64)(m);
+  u128 m = (u128)a * b;
+  *hi    = (u64)(m >> 64);
+  *lo    = (u64)(m);
 #elif MSC_HAS_UMUL128
-    *lo = _umul128(a, b, hi);
+  *lo = _umul128 (a, b, hi);
 #else
-    u32 a0 = (u32)(a), a1 = (u32)(a >> 32);
-    u32 b0 = (u32)(b), b1 = (u32)(b >> 32);
-    u64 p00 = (u64)a0 * b0, p01 = (u64)a0 * b1;
-    u64 p10 = (u64)a1 * b0, p11 = (u64)a1 * b1;
-    u64 m0 = p01 + (p00 >> 32);
-    u32 m00 = (u32)(m0), m01 = (u32)(m0 >> 32);
-    u64 m1 = p10 + m00;
-    u32 m10 = (u32)(m1), m11 = (u32)(m1 >> 32);
-    *hi = p11 + m01 + m11;
-    *lo = ((u64)m10 << 32) | (u32)p00;
+  u32 a0 = (u32)(a), a1 = (u32)(a >> 32);
+  u32 b0 = (u32)(b), b1 = (u32)(b >> 32);
+  u64 p00 = (u64)a0 * b0, p01 = (u64)a0 * b1;
+  u64 p10 = (u64)a1 * b0, p11 = (u64)a1 * b1;
+  u64 m0  = p01 + (p00 >> 32);
+  u32 m00 = (u32)(m0), m01 = (u32)(m0 >> 32);
+  u64 m1  = p10 + m00;
+  u32 m10 = (u32)(m1), m11 = (u32)(m1 >> 32);
+  *hi = p11 + m01 + m11;
+  *lo = ((u64)m10 << 32) | (u32)p00;
 #endif
 }
 
 /** Multiplies two 64-bit unsigned integers and add a value (a * b + c),
     returns the 128-bit result as 'hi' and 'lo'. */
-static_inline void u128_mul_add(u64 a, u64 b, u64 c, u64 *hi, u64 *lo) {
+static_inline void
+u128_mul_add (u64 a, u64 b, u64 c, u64 *hi, u64 *lo)
+{
 #if YYJSON_HAS_INT128
-    u128 m = (u128)a * b + c;
-    *hi = (u64)(m >> 64);
-    *lo = (u64)(m);
+  u128 m = (u128)a * b + c;
+  *hi    = (u64)(m >> 64);
+  *lo    = (u64)(m);
 #else
-    u64 h, l, t;
-    u128_mul(a, b, &h, &l);
-    t = l + c;
-    h += (u64)(((t < l) | (t < c)));
-    *hi = h;
-    *lo = t;
+  u64 h, l, t;
+  u128_mul (a, b, &h, &l);
+  t = l + c;
+  h += (u64)(((t < l) | (t < c)));
+  *hi = h;
+  *lo = t;
 #endif
 }
-
-
 
 /*==============================================================================
  * File Utils
@@ -901,84 +988,99 @@ static_inline void u128_mul_add(u64 a, u64 b, u64 c, u64 *hi, u64 *lo) {
 
 #define YYJSON_FOPEN_EXT
 #if !defined(_MSC_VER) && defined(__GLIBC__) && defined(__GLIBC_PREREQ)
-#   if __GLIBC_PREREQ(2, 7)
-#       undef YYJSON_FOPEN_EXT
-#       define YYJSON_FOPEN_EXT "e" /* glibc extension to enable O_CLOEXEC */
-#   endif
+#if __GLIBC_PREREQ(2, 7)
+#undef YYJSON_FOPEN_EXT
+#define YYJSON_FOPEN_EXT "e" /* glibc extension to enable O_CLOEXEC */
+#endif
 #endif
 
-static_inline FILE *fopen_safe(const char *path, const char *mode) {
+static_inline FILE *
+fopen_safe (const char *path, const char *mode)
+{
 #if YYJSON_MSC_VER >= 1400
-    FILE *file = NULL;
-    if (fopen_s(&file, path, mode) != 0) return NULL;
-    return file;
+  FILE *file = NULL;
+  if (fopen_s (&file, path, mode) != 0)
+    return NULL;
+  return file;
 #else
-    return fopen(path, mode);
+  return fopen (path, mode);
 #endif
 }
 
-static_inline FILE *fopen_readonly(const char *path) {
-    return fopen_safe(path, "rb" YYJSON_FOPEN_EXT);
+static_inline FILE *
+fopen_readonly (const char *path)
+{
+  return fopen_safe (path, "rb" YYJSON_FOPEN_EXT);
 }
 
-static_inline FILE *fopen_writeonly(const char *path) {
-    return fopen_safe(path, "wb" YYJSON_FOPEN_EXT);
+static_inline FILE *
+fopen_writeonly (const char *path)
+{
+  return fopen_safe (path, "wb" YYJSON_FOPEN_EXT);
 }
 
-static_inline usize fread_safe(void *buf, usize size, FILE *file) {
+static_inline usize
+fread_safe (void *buf, usize size, FILE *file)
+{
 #if YYJSON_MSC_VER >= 1400
-    return fread_s(buf, size, 1, size, file);
+  return fread_s (buf, size, 1, size, file);
 #else
-    return fread(buf, 1, size, file);
+  return fread (buf, 1, size, file);
 #endif
 }
-
-
 
 /*==============================================================================
  * Default Memory Allocator
  * This is a simple libc memory allocator wrapper.
  *============================================================================*/
 
-static void *default_malloc(void *ctx, usize size) {
-    return malloc(size);
+static void *
+default_malloc (void *ctx, usize size)
+{
+  return malloc (size);
 }
 
-static void *default_realloc(void *ctx, void *ptr, usize old_size, usize size) {
-    return realloc(ptr, size);
+static void *
+default_realloc (void *ctx, void *ptr, usize old_size, usize size)
+{
+  return realloc (ptr, size);
 }
 
-static void default_free(void *ctx, void *ptr) {
-    free(ptr);
+static void
+default_free (void *ctx, void *ptr)
+{
+  free (ptr);
 }
 
 static const yyjson_alc YYJSON_DEFAULT_ALC = {
     default_malloc,
     default_realloc,
     default_free,
-    NULL
-};
+    NULL};
 
-static void *null_malloc(void *ctx, usize size) {
-    return NULL;
+static void *
+null_malloc (void *ctx, usize size)
+{
+  return NULL;
 }
 
-static void *null_realloc(void *ctx, void *ptr, usize old_size, usize size) {
-    return NULL;
+static void *
+null_realloc (void *ctx, void *ptr, usize old_size, usize size)
+{
+  return NULL;
 }
 
-static void null_free(void *ctx, void *ptr) {
-    return;
+static void
+null_free (void *ctx, void *ptr)
+{
+  return;
 }
 
 static const yyjson_alc YYJSON_NULL_ALC = {
     null_malloc,
     null_realloc,
     null_free,
-    NULL
-};
-
-
+    NULL};
 
 /*==============================================================================
  * Pool Memory Allocator
@@ -988,680 +1090,843 @@ static const yyjson_alc YYJSON_NULL_ALC = {
  *============================================================================*/
 
 /** chunk header */
-typedef struct pool_chunk {
-    usize size; /* chunk memory size (include chunk header) */
-    struct pool_chunk *next;
+typedef struct pool_chunk
+{
+  usize size; /* chunk memory size (include chunk header) */
+  struct pool_chunk *next;
 } pool_chunk;
 
 /** ctx header */
-typedef struct pool_ctx {
-    usize size; /* total memory size (include ctx header) */
-    pool_chunk *free_list;
+typedef struct pool_ctx
+{
+  usize size; /* total memory size (include ctx header) */
+  pool_chunk *free_list;
 } pool_ctx;
 
-static void *pool_malloc(void *ctx_ptr, usize size) {
-    pool_ctx *ctx = (pool_ctx *)ctx_ptr;
-    pool_chunk *next, *prev = NULL, *cur = ctx->free_list;
-    
-    if (unlikely(size == 0 || size >= ctx->size)) return NULL;
-    size = size_align_up(size, sizeof(pool_chunk)) + sizeof(pool_chunk);
-    
-    while (cur) {
-        if (cur->size < size) {
-            /* not enough space, try next chunk */
-            prev = cur;
-            cur = cur->next;
-            continue;
-        }
-        if (cur->size >= size + sizeof(pool_chunk) * 2) {
-            /* too much space, split this chunk */
-            next = (pool_chunk *)(void *)((u8 *)cur + size);
-            next->size = cur->size - size;
-            next->next = cur->next;
-            cur->size = size;
-        } else {
-            /* just enough space, use whole chunk */
-            next = cur->next;
-        }
-        if (prev) prev->next = next;
-        else ctx->free_list = next;
-        return (void *)(cur + 1);
-    }
+static void *
+pool_malloc (void *ctx_ptr, usize size)
+{
+  pool_ctx *ctx = (pool_ctx *)ctx_ptr;
+  pool_chunk *next, *prev = NULL, *cur = ctx->free_list;
+
+  if (unlikely (size == 0 || size >= ctx->size))
     return NULL;
+  size = size_align_up (size, sizeof (pool_chunk)) + sizeof (pool_chunk);
+
+  while (cur)
+  {
+    if (cur->size < size)
+    {
+      /* not enough space, try next chunk */
+      prev = cur;
+      cur  = cur->next;
+      continue;
+    }
+    if (cur->size >= size + sizeof (pool_chunk) * 2)
+    {
+      /* too much space, split this chunk */
+      next       = (pool_chunk *)(void *)((u8 *)cur + size);
+      next->size = cur->size - size;
+      next->next = cur->next;
+      cur->size  = size;
+    }
+    else
+    {
+      /* just enough space, use whole chunk */
+      next = cur->next;
+    }
+    if (prev)
+      prev->next = next;
+    else
+      ctx->free_list = next;
+    return (void *)(cur + 1);
+  }
+  return NULL;
 }
 
-static void pool_free(void *ctx_ptr, void *ptr) {
-    pool_ctx *ctx = (pool_ctx *)ctx_ptr;
-    pool_chunk *cur = ((pool_chunk *)ptr) - 1;
-    pool_chunk *prev = NULL, *next = ctx->free_list;
-    
-    while (next && next < cur) {
-        prev = next;
-        next = next->next;
-    }
-    if (prev) prev->next = cur;
-    else ctx->free_list = cur;
-    cur->next = next;
-    
-    if (next && ((u8 *)cur + cur->size) == (u8 *)next) {
-        /* merge cur to higher chunk */
-        cur->size += next->size;
-        cur->next = next->next;
-    }
-    if (prev && ((u8 *)prev + prev->size) == (u8 *)cur) {
-        /* merge cur to lower chunk */
-        prev->size += cur->size;
-        prev->next = cur->next;
-    }
+static void
+pool_free (void *ctx_ptr, void *ptr)
+{
+  pool_ctx *ctx    = (pool_ctx *)ctx_ptr;
+  pool_chunk *cur  = ((pool_chunk *)ptr) - 1;
+  pool_chunk *prev = NULL, *next = ctx->free_list;
+
+  while (next && next < cur)
+  {
+    prev = next;
+    next = next->next;
+  }
+  if (prev)
+    prev->next = cur;
+  else
+    ctx->free_list = cur;
+  cur->next = next;
+
+  if (next && ((u8 *)cur + cur->size) == (u8 *)next)
+  {
+    /* merge cur to higher chunk */
+    cur->size += next->size;
+    cur->next = next->next;
+  }
+  if (prev && ((u8 *)prev + prev->size) == (u8 *)cur)
+  {
+    /* merge cur to lower chunk */
+    prev->size += cur->size;
+    prev->next = cur->next;
+  }
 }
 
-static void *pool_realloc(void *ctx_ptr, void *ptr,
-                          usize old_size, usize size) {
-    pool_ctx *ctx = (pool_ctx *)ctx_ptr;
-    pool_chunk *cur = ((pool_chunk *)ptr) - 1, *prev, *next, *tmp;
-    usize free_size;
-    void *new_ptr;
-    
-    if (unlikely(size == 0 || size >= ctx->size)) return NULL;
-    size = size_align_up(size, sizeof(pool_chunk)) + sizeof(pool_chunk);
-    
-    /* reduce size */
-    if (unlikely(size <= cur->size)) {
-        free_size = cur->size - size;
-        if (free_size >= sizeof(pool_chunk) * 2) {
-            tmp = (pool_chunk *)(void *)((u8 *)cur + cur->size - free_size);
-            tmp->size = free_size;
-            pool_free(ctx_ptr, (void *)(tmp + 1));
-            cur->size -= free_size;
-        }
-        return ptr;
+static void *
+pool_realloc (void *ctx_ptr, void *ptr,
+              usize old_size, usize size)
+{
+  pool_ctx *ctx   = (pool_ctx *)ctx_ptr;
+  pool_chunk *cur = ((pool_chunk *)ptr) - 1, *prev, *next, *tmp;
+  usize free_size;
+  void *new_ptr;
+
+  if (unlikely (size == 0 || size >= ctx->size))
+    return NULL;
+  size = size_align_up (size, sizeof (pool_chunk)) + sizeof (pool_chunk);
+
+  /* reduce size */
+  if (unlikely (size <= cur->size))
+  {
+    free_size = cur->size - size;
+    if (free_size >= sizeof (pool_chunk) * 2)
+    {
+      tmp       = (pool_chunk *)(void *)((u8 *)cur + cur->size - free_size);
+      tmp->size = free_size;
+      pool_free (ctx_ptr, (void *)(tmp + 1));
+      cur->size -= free_size;
     }
-    
-    /* find next and prev chunk */
-    prev = NULL;
-    next = ctx->free_list;
-    while (next && next < cur) {
-        prev = next;
-        next = next->next;
+    return ptr;
+  }
+
+  /* find next and prev chunk */
+  prev = NULL;
+  next = ctx->free_list;
+  while (next && next < cur)
+  {
+    prev = next;
+    next = next->next;
+  }
+
+  /* merge to higher chunk if they are contiguous */
+  if ((u8 *)cur + cur->size == (u8 *)next &&
+      cur->size + next->size >= size)
+  {
+    free_size = cur->size + next->size - size;
+    if (free_size > sizeof (pool_chunk) * 2)
+    {
+      tmp = (pool_chunk *)(void *)((u8 *)cur + size);
+      if (prev)
+        prev->next = tmp;
+      else
+        ctx->free_list = tmp;
+      tmp->next = next->next;
+      tmp->size = free_size;
+      cur->size = size;
     }
-    
-    /* merge to higher chunk if they are contiguous */
-    if ((u8 *)cur + cur->size == (u8 *)next &&
-        cur->size + next->size >= size) {
-        free_size = cur->size + next->size - size;
-        if (free_size > sizeof(pool_chunk) * 2) {
-            tmp = (pool_chunk *)(void *)((u8 *)cur + size);
-            if (prev) prev->next = tmp;
-            else ctx->free_list = tmp;
-            tmp->next = next->next;
-            tmp->size = free_size;
-            cur->size = size;
-        } else {
-            if (prev) prev->next = next->next;
-            else ctx->free_list = next->next;
-            cur->size += next->size;
-        }
-        return ptr;
+    else
+    {
+      if (prev)
+        prev->next = next->next;
+      else
+        ctx->free_list = next->next;
+      cur->size += next->size;
     }
-    
-    /* fallback to malloc and memcpy */
-    new_ptr = pool_malloc(ctx_ptr, size - sizeof(pool_chunk));
-    if (new_ptr) {
-        memcpy(new_ptr, ptr, cur->size - sizeof(pool_chunk));
-        pool_free(ctx_ptr, ptr);
-    }
-    return new_ptr;
+    return ptr;
+  }
+
+  /* fallback to malloc and memcpy */
+  new_ptr = pool_malloc (ctx_ptr, size - sizeof (pool_chunk));
+  if (new_ptr)
+  {
+    memcpy (new_ptr, ptr, cur->size - sizeof (pool_chunk));
+    pool_free (ctx_ptr, ptr);
+  }
+  return new_ptr;
 }
 
-bool yyjson_alc_pool_init(yyjson_alc *alc, void *buf, usize size) {
-    pool_chunk *chunk;
-    pool_ctx *ctx;
-    
-    if (unlikely(!alc)) return false;
-    *alc = YYJSON_NULL_ALC;
-    if (size < sizeof(pool_ctx) * 4) return false;
-    ctx = (pool_ctx *)mem_align_up(buf, sizeof(pool_ctx));
-    if (unlikely(!ctx)) return false;
-    size -= (usize)((u8 *)ctx - (u8 *)buf);
-    size = size_align_down(size, sizeof(pool_ctx));
-    
-    chunk = (pool_chunk *)(ctx + 1);
-    chunk->size = size - sizeof(pool_ctx);
-    chunk->next = NULL;
-    ctx->size = size;
-    ctx->free_list = chunk;
-    
-    alc->malloc = pool_malloc;
-    alc->realloc = pool_realloc;
-    alc->free = pool_free;
-    alc->ctx = (void *)ctx;
-    return true;
+bool
+yyjson_alc_pool_init (yyjson_alc *alc, void *buf, usize size)
+{
+  pool_chunk *chunk;
+  pool_ctx *ctx;
+
+  if (unlikely (!alc))
+    return false;
+  *alc = YYJSON_NULL_ALC;
+  if (size < sizeof (pool_ctx) * 4)
+    return false;
+  ctx = (pool_ctx *)mem_align_up (buf, sizeof (pool_ctx));
+  if (unlikely (!ctx))
+    return false;
+  size -= (usize)((u8 *)ctx - (u8 *)buf);
+  size = size_align_down (size, sizeof (pool_ctx));
+
+  chunk          = (pool_chunk *)(ctx + 1);
+  chunk->size    = size - sizeof (pool_ctx);
+  chunk->next    = NULL;
+  ctx->size      = size;
+  ctx->free_list = chunk;
+
+  alc->malloc  = pool_malloc;
+  alc->realloc = pool_realloc;
+  alc->free    = pool_free;
+  alc->ctx     = (void *)ctx;
+  return true;
 }
-
-
 
 /*==============================================================================
  * JSON document and value
  *============================================================================*/
 
-static_inline void unsafe_yyjson_str_pool_release(yyjson_str_pool *pool,
-                                                  yyjson_alc *alc) {
-    yyjson_str_chunk *chunk = pool->chunks, *next;
-    while (chunk) {
-        next = chunk->next;
-        alc->free(alc->ctx, chunk);
-        chunk = next;
-    }
+static_inline void
+unsafe_yyjson_str_pool_release (yyjson_str_pool *pool,
+                                yyjson_alc *alc)
+{
+  yyjson_str_chunk *chunk = pool->chunks, *next;
+  while (chunk)
+  {
+    next = chunk->next;
+    alc->free (alc->ctx, chunk);
+    chunk = next;
+  }
 }
 
-static_inline void unsafe_yyjson_val_pool_release(yyjson_val_pool *pool,
-                                                  yyjson_alc *alc) {
-    yyjson_val_chunk *chunk = pool->chunks, *next;
-    while (chunk) {
-        next = chunk->next;
-        alc->free(alc->ctx, chunk);
-        chunk = next;
-    }
+static_inline void
+unsafe_yyjson_val_pool_release (yyjson_val_pool *pool,
+                                yyjson_alc *alc)
+{
+  yyjson_val_chunk *chunk = pool->chunks, *next;
+  while (chunk)
+  {
+    next = chunk->next;
+    alc->free (alc->ctx, chunk);
+    chunk = next;
+  }
 }
 
-bool unsafe_yyjson_str_pool_grow(yyjson_str_pool *pool,
-                                 const yyjson_alc *alc, usize len) {
-    yyjson_str_chunk *chunk;
-    usize size, max_len;
-    
-    /* create a new chunk */
-    max_len = USIZE_MAX - sizeof(yyjson_str_chunk);
-    if (unlikely(len > max_len)) return false;
-    size = len + sizeof(yyjson_str_chunk);
-    size = yyjson_max(pool->chunk_size, size);
-    chunk = (yyjson_str_chunk *)alc->malloc(alc->ctx, size);
-    if (unlikely(!chunk)) return false;
-    
-    /* insert the new chunk as the head of the linked list */
-    chunk->next = pool->chunks;
-    chunk->chunk_size = size;
-    pool->chunks = chunk;
-    pool->cur = (char *)chunk + sizeof(yyjson_str_chunk);
-    pool->end = (char *)chunk + size;
-    
-    /* the next chunk is twice the size of the current one */
-    size = yyjson_min(pool->chunk_size * 2, pool->chunk_size_max);
-    if (size < pool->chunk_size) size = pool->chunk_size_max; /* overflow */
-    pool->chunk_size = size;
-    return true;
+bool
+unsafe_yyjson_str_pool_grow (yyjson_str_pool *pool,
+                             const yyjson_alc *alc, usize len)
+{
+  yyjson_str_chunk *chunk;
+  usize size, max_len;
+
+  /* create a new chunk */
+  max_len = USIZE_MAX - sizeof (yyjson_str_chunk);
+  if (unlikely (len > max_len))
+    return false;
+  size  = len + sizeof (yyjson_str_chunk);
+  size  = yyjson_max (pool->chunk_size, size);
+  chunk = (yyjson_str_chunk *)alc->malloc (alc->ctx, size);
+  if (unlikely (!chunk))
+    return false;
+
+  /* insert the new chunk as the head of the linked list */
+  chunk->next       = pool->chunks;
+  chunk->chunk_size = size;
+  pool->chunks      = chunk;
+  pool->cur         = (char *)chunk + sizeof (yyjson_str_chunk);
+  pool->end         = (char *)chunk + size;
+
+  /* the next chunk is twice the size of the current one */
+  size = yyjson_min (pool->chunk_size * 2, pool->chunk_size_max);
+  if (size < pool->chunk_size)
+    size = pool->chunk_size_max; /* overflow */
+  pool->chunk_size = size;
+  return true;
 }
 
-bool unsafe_yyjson_val_pool_grow(yyjson_val_pool *pool,
-                                 const yyjson_alc *alc, usize count) {
-    yyjson_val_chunk *chunk;
-    usize size, max_count;
-    
-    /* create a new chunk */
-    max_count = USIZE_MAX / sizeof(yyjson_mut_val) - 1;
-    if (unlikely(count > max_count)) return false;
-    size = (count + 1) * sizeof(yyjson_mut_val);
-    size = yyjson_max(pool->chunk_size, size);
-    chunk = (yyjson_val_chunk *)alc->malloc(alc->ctx, size);
-    if (unlikely(!chunk)) return false;
-    
-    /* insert the new chunk as the head of the linked list */
-    chunk->next = pool->chunks;
-    chunk->chunk_size = size;
-    pool->chunks = chunk;
-    pool->cur = (yyjson_mut_val *)(void *)((u8 *)chunk) + 1;
-    pool->end = (yyjson_mut_val *)(void *)((u8 *)chunk + size);
-    
-    /* the next chunk is twice the size of the current one */
-    size = yyjson_min(pool->chunk_size * 2, pool->chunk_size_max);
-    if (size < pool->chunk_size) size = pool->chunk_size_max; /* overflow */
-    pool->chunk_size = size;
-    return true;
+bool
+unsafe_yyjson_val_pool_grow (yyjson_val_pool *pool,
+                             const yyjson_alc *alc, usize count)
+{
+  yyjson_val_chunk *chunk;
+  usize size, max_count;
+
+  /* create a new chunk */
+  max_count = USIZE_MAX / sizeof (yyjson_mut_val) - 1;
+  if (unlikely (count > max_count))
+    return false;
+  size  = (count + 1) * sizeof (yyjson_mut_val);
+  size  = yyjson_max (pool->chunk_size, size);
+  chunk = (yyjson_val_chunk *)alc->malloc (alc->ctx, size);
+  if (unlikely (!chunk))
+    return false;
+
+  /* insert the new chunk as the head of the linked list */
+  chunk->next       = pool->chunks;
+  chunk->chunk_size = size;
+  pool->chunks      = chunk;
+  pool->cur         = (yyjson_mut_val *)(void *)((u8 *)chunk) + 1;
+  pool->end         = (yyjson_mut_val *)(void *)((u8 *)chunk + size);
+
+  /* the next chunk is twice the size of the current one */
+  size = yyjson_min (pool->chunk_size * 2, pool->chunk_size_max);
+  if (size < pool->chunk_size)
+    size = pool->chunk_size_max; /* overflow */
+  pool->chunk_size = size;
+  return true;
 }
 
-bool yyjson_mut_doc_set_str_pool_size(yyjson_mut_doc *doc, size_t len) {
-    usize max_size = USIZE_MAX - sizeof(yyjson_str_chunk);
-    if (!doc || !len || len > max_size) return false;
-    doc->str_pool.chunk_size = len + sizeof(yyjson_str_chunk);
-    return true;
+bool
+yyjson_mut_doc_set_str_pool_size (yyjson_mut_doc *doc, size_t len)
+{
+  usize max_size = USIZE_MAX - sizeof (yyjson_str_chunk);
+  if (!doc || !len || len > max_size)
+    return false;
+  doc->str_pool.chunk_size = len + sizeof (yyjson_str_chunk);
+  return true;
 }
 
-bool yyjson_mut_doc_set_val_pool_size(yyjson_mut_doc *doc, size_t count) {
-    usize max_count = USIZE_MAX / sizeof(yyjson_mut_val) - 1;
-    if (!doc || !count || count > max_count) return false;
-    doc->val_pool.chunk_size = (count + 1) * sizeof(yyjson_mut_val);
-    return true;
+bool
+yyjson_mut_doc_set_val_pool_size (yyjson_mut_doc *doc, size_t count)
+{
+  usize max_count = USIZE_MAX / sizeof (yyjson_mut_val) - 1;
+  if (!doc || !count || count > max_count)
+    return false;
+  doc->val_pool.chunk_size = (count + 1) * sizeof (yyjson_mut_val);
+  return true;
 }
 
-void yyjson_mut_doc_free(yyjson_mut_doc *doc) {
-    if (doc) {
-        yyjson_alc alc = doc->alc;
-        unsafe_yyjson_str_pool_release(&doc->str_pool, &alc);
-        unsafe_yyjson_val_pool_release(&doc->val_pool, &alc);
-        alc.free(alc.ctx, doc);
-    }
+void
+yyjson_mut_doc_free (yyjson_mut_doc *doc)
+{
+  if (doc)
+  {
+    yyjson_alc alc = doc->alc;
+    unsafe_yyjson_str_pool_release (&doc->str_pool, &alc);
+    unsafe_yyjson_val_pool_release (&doc->val_pool, &alc);
+    alc.free (alc.ctx, doc);
+  }
 }
 
-yyjson_mut_doc *yyjson_mut_doc_new(const yyjson_alc *alc) {
-    yyjson_mut_doc *doc;
-    if (!alc) alc = &YYJSON_DEFAULT_ALC;
-    doc = (yyjson_mut_doc *)alc->malloc(alc->ctx, sizeof(yyjson_mut_doc));
-    if (!doc) return NULL;
-    memset(doc, 0, sizeof(yyjson_mut_doc));
-    
-    doc->alc = *alc;
-    doc->str_pool.chunk_size = YYJSON_MUT_DOC_STR_POOL_INIT_SIZE;
-    doc->str_pool.chunk_size_max = YYJSON_MUT_DOC_STR_POOL_MAX_SIZE;
-    doc->val_pool.chunk_size = YYJSON_MUT_DOC_VAL_POOL_INIT_SIZE;
-    doc->val_pool.chunk_size_max = YYJSON_MUT_DOC_VAL_POOL_MAX_SIZE;
-    return doc;
-}
-
-yyjson_api yyjson_mut_doc *yyjson_doc_mut_copy(yyjson_doc *doc,
-                                               const yyjson_alc *alc) {
-    yyjson_mut_doc *m_doc;
-    yyjson_mut_val *m_val;
-    
-    if (!doc || !doc->root) return NULL;
-    m_doc = yyjson_mut_doc_new(alc);
-    if (!m_doc) return NULL;
-    m_val = yyjson_val_mut_copy(m_doc, doc->root);
-    if (!m_val) {
-        yyjson_mut_doc_free(m_doc);
-        return NULL;
-    }
-    yyjson_mut_doc_set_root(m_doc, m_val);
-    return m_doc;
-}
-
-yyjson_api yyjson_mut_doc *yyjson_mut_doc_mut_copy(yyjson_mut_doc *doc,
-                                                   const yyjson_alc *alc) {
-    yyjson_mut_doc *m_doc;
-    yyjson_mut_val *m_val;
-    
-    if (!doc || !doc->root) return NULL;
-    m_doc = yyjson_mut_doc_new(alc);
-    if (!m_doc) return NULL;
-    m_val = yyjson_mut_val_mut_copy(m_doc, doc->root);
-    if (!m_val) {
-        yyjson_mut_doc_free(m_doc);
-        return NULL;
-    }
-    yyjson_mut_doc_set_root(m_doc, m_val);
-    return m_doc;
-}
-
-yyjson_api yyjson_mut_val *yyjson_val_mut_copy(yyjson_mut_doc *m_doc,
-                                               yyjson_val *i_vals) {
-    /*
-     The immutable object or array stores all sub-values in a contiguous memory,
-     We copy them to another contiguous memory as mutable values,
-     then reconnect the mutable values with the original relationship.
-     */
-    
-    usize i_vals_len;
-    yyjson_mut_val *m_vals, *m_val;
-    yyjson_val *i_val, *i_end;
-    
-    if (!m_doc || !i_vals) return NULL;
-    i_end = unsafe_yyjson_get_next(i_vals);
-    i_vals_len = (usize)(unsafe_yyjson_get_next(i_vals) - i_vals);
-    m_vals = unsafe_yyjson_mut_val(m_doc, i_vals_len);
-    if (!m_vals) return NULL;
-    i_val = i_vals;
-    m_val = m_vals;
-    
-    for (; i_val < i_end; i_val++, m_val++) {
-        yyjson_type type = unsafe_yyjson_get_type(i_val);
-        m_val->tag = i_val->tag;
-        m_val->uni.u64 = i_val->uni.u64;
-        if (type == YYJSON_TYPE_STR || type == YYJSON_TYPE_RAW) {
-            const char *str = i_val->uni.str;
-            usize str_len = unsafe_yyjson_get_len(i_val);
-            m_val->uni.str = unsafe_yyjson_mut_strncpy(m_doc, str, str_len);
-            if (!m_val->uni.str) return NULL;
-        } else if (type == YYJSON_TYPE_ARR) {
-            usize len = unsafe_yyjson_get_len(i_val);
-            if (len > 0) {
-                yyjson_val *ii_val = i_val + 1, *ii_next;
-                yyjson_mut_val *mm_val = m_val + 1, *mm_ctn = m_val, *mm_next;
-                while (len-- > 1) {
-                    ii_next = unsafe_yyjson_get_next(ii_val);
-                    mm_next = mm_val + (ii_next - ii_val);
-                    mm_val->next = mm_next;
-                    ii_val = ii_next;
-                    mm_val = mm_next;
-                }
-                mm_val->next = mm_ctn + 1;
-                mm_ctn->uni.ptr = mm_val;
-            }
-        } else if (type == YYJSON_TYPE_OBJ) {
-            usize len = unsafe_yyjson_get_len(i_val);
-            if (len > 0) {
-                yyjson_val *ii_key = i_val + 1, *ii_nextkey;
-                yyjson_mut_val *mm_key = m_val + 1, *mm_ctn = m_val;
-                yyjson_mut_val *mm_nextkey;
-                while (len-- > 1) {
-                    ii_nextkey = unsafe_yyjson_get_next(ii_key + 1);
-                    mm_nextkey = mm_key + (ii_nextkey - ii_key);
-                    mm_key->next = mm_key + 1;
-                    mm_key->next->next = mm_nextkey;
-                    ii_key = ii_nextkey;
-                    mm_key = mm_nextkey;
-                }
-                mm_key->next = mm_key + 1;
-                mm_key->next->next = mm_ctn + 1;
-                mm_ctn->uni.ptr = mm_key;
-            }
-        }
-    }
-    
-    return m_vals;
-}
-
-static yyjson_mut_val *unsafe_yyjson_mut_val_mut_copy(yyjson_mut_doc *m_doc,
-                                                      yyjson_mut_val *m_vals) {
-    /*
-     The mutable object or array stores all sub-values in a circular linked
-     list, so we can traverse them in the same loop. The traversal starts from
-     the last item, continues with the first item in a list, and ends with the
-     second to last item, which needs to be linked to the last item to close the
-     circle.
-     */
-    
-    yyjson_mut_val *m_val = unsafe_yyjson_mut_val(m_doc, 1);
-    if (unlikely(!m_val)) return NULL;
-    m_val->tag = m_vals->tag;
-    
-    switch (unsafe_yyjson_get_type(m_vals)) {
-        case YYJSON_TYPE_OBJ:
-        case YYJSON_TYPE_ARR:
-            if (unsafe_yyjson_get_len(m_vals) > 0) {
-                yyjson_mut_val *last = (yyjson_mut_val *)m_vals->uni.ptr;
-                yyjson_mut_val *next = last->next, *prev;
-                prev = unsafe_yyjson_mut_val_mut_copy(m_doc, last);
-                if (!prev) return NULL;
-                m_val->uni.ptr = (void *)prev;
-                while (next != last) {
-                    prev->next = unsafe_yyjson_mut_val_mut_copy(m_doc, next);
-                    if (!prev->next) return NULL;
-                    prev = prev->next;
-                    next = next->next;
-                }
-                prev->next = (yyjson_mut_val *)m_val->uni.ptr;
-            }
-            break;
-        
-        case YYJSON_TYPE_RAW:
-        case YYJSON_TYPE_STR: {
-            const char *str = m_vals->uni.str;
-            usize str_len = unsafe_yyjson_get_len(m_vals);
-            m_val->uni.str = unsafe_yyjson_mut_strncpy(m_doc, str, str_len);
-            if (!m_val->uni.str) return NULL;
-            break;
-        }
-        
-        default:
-            m_val->uni = m_vals->uni;
-            break;
-    }
-    
-    return m_val;
-}
-
-yyjson_api yyjson_mut_val *yyjson_mut_val_mut_copy(yyjson_mut_doc *doc,
-                                                   yyjson_mut_val *val) {
-    if (doc && val) return unsafe_yyjson_mut_val_mut_copy(doc, val);
+yyjson_mut_doc *
+yyjson_mut_doc_new (const yyjson_alc *alc)
+{
+  yyjson_mut_doc *doc;
+  if (!alc)
+    alc = &YYJSON_DEFAULT_ALC;
+  doc = (yyjson_mut_doc *)alc->malloc (alc->ctx, sizeof (yyjson_mut_doc));
+  if (!doc)
     return NULL;
+  memset (doc, 0, sizeof (yyjson_mut_doc));
+
+  doc->alc                     = *alc;
+  doc->str_pool.chunk_size     = YYJSON_MUT_DOC_STR_POOL_INIT_SIZE;
+  doc->str_pool.chunk_size_max = YYJSON_MUT_DOC_STR_POOL_MAX_SIZE;
+  doc->val_pool.chunk_size     = YYJSON_MUT_DOC_VAL_POOL_INIT_SIZE;
+  doc->val_pool.chunk_size_max = YYJSON_MUT_DOC_VAL_POOL_MAX_SIZE;
+  return doc;
+}
+
+yyjson_api yyjson_mut_doc *
+yyjson_doc_mut_copy (yyjson_doc *doc,
+                     const yyjson_alc *alc)
+{
+  yyjson_mut_doc *m_doc;
+  yyjson_mut_val *m_val;
+
+  if (!doc || !doc->root)
+    return NULL;
+  m_doc = yyjson_mut_doc_new (alc);
+  if (!m_doc)
+    return NULL;
+  m_val = yyjson_val_mut_copy (m_doc, doc->root);
+  if (!m_val)
+  {
+    yyjson_mut_doc_free (m_doc);
+    return NULL;
+  }
+  yyjson_mut_doc_set_root (m_doc, m_val);
+  return m_doc;
+}
+
+yyjson_api yyjson_mut_doc *
+yyjson_mut_doc_mut_copy (yyjson_mut_doc *doc,
+                         const yyjson_alc *alc)
+{
+  yyjson_mut_doc *m_doc;
+  yyjson_mut_val *m_val;
+
+  if (!doc || !doc->root)
+    return NULL;
+  m_doc = yyjson_mut_doc_new (alc);
+  if (!m_doc)
+    return NULL;
+  m_val = yyjson_mut_val_mut_copy (m_doc, doc->root);
+  if (!m_val)
+  {
+    yyjson_mut_doc_free (m_doc);
+    return NULL;
+  }
+  yyjson_mut_doc_set_root (m_doc, m_val);
+  return m_doc;
+}
+
+yyjson_api yyjson_mut_val *
+yyjson_val_mut_copy (yyjson_mut_doc *m_doc,
+                     yyjson_val *i_vals)
+{
+  /*
+   The immutable object or array stores all sub-values in a contiguous memory,
+   We copy them to another contiguous memory as mutable values,
+   then reconnect the mutable values with the original relationship.
+   */
+
+  usize i_vals_len;
+  yyjson_mut_val *m_vals, *m_val;
+  yyjson_val *i_val, *i_end;
+
+  if (!m_doc || !i_vals)
+    return NULL;
+  i_end      = unsafe_yyjson_get_next (i_vals);
+  i_vals_len = (usize)(unsafe_yyjson_get_next (i_vals) - i_vals);
+  m_vals     = unsafe_yyjson_mut_val (m_doc, i_vals_len);
+  if (!m_vals)
+    return NULL;
+  i_val = i_vals;
+  m_val = m_vals;
+
+  for (; i_val < i_end; i_val++, m_val++)
+  {
+    yyjson_type type = unsafe_yyjson_get_type (i_val);
+    m_val->tag       = i_val->tag;
+    m_val->uni.u64   = i_val->uni.u64;
+    if (type == YYJSON_TYPE_STR || type == YYJSON_TYPE_RAW)
+    {
+      const char *str = i_val->uni.str;
+      usize str_len   = unsafe_yyjson_get_len (i_val);
+      m_val->uni.str  = unsafe_yyjson_mut_strncpy (m_doc, str, str_len);
+      if (!m_val->uni.str)
+        return NULL;
+    }
+    else if (type == YYJSON_TYPE_ARR)
+    {
+      usize len = unsafe_yyjson_get_len (i_val);
+      if (len > 0)
+      {
+        yyjson_val *ii_val     = i_val + 1, *ii_next;
+        yyjson_mut_val *mm_val = m_val + 1, *mm_ctn = m_val, *mm_next;
+        while (len-- > 1)
+        {
+          ii_next      = unsafe_yyjson_get_next (ii_val);
+          mm_next      = mm_val + (ii_next - ii_val);
+          mm_val->next = mm_next;
+          ii_val       = ii_next;
+          mm_val       = mm_next;
+        }
+        mm_val->next    = mm_ctn + 1;
+        mm_ctn->uni.ptr = mm_val;
+      }
+    }
+    else if (type == YYJSON_TYPE_OBJ)
+    {
+      usize len = unsafe_yyjson_get_len (i_val);
+      if (len > 0)
+      {
+        yyjson_val *ii_key     = i_val + 1, *ii_nextkey;
+        yyjson_mut_val *mm_key = m_val + 1, *mm_ctn = m_val;
+        yyjson_mut_val *mm_nextkey;
+        while (len-- > 1)
+        {
+          ii_nextkey         = unsafe_yyjson_get_next (ii_key + 1);
+          mm_nextkey         = mm_key + (ii_nextkey - ii_key);
+          mm_key->next       = mm_key + 1;
+          mm_key->next->next = mm_nextkey;
+          ii_key             = ii_nextkey;
+          mm_key             = mm_nextkey;
+        }
+        mm_key->next       = mm_key + 1;
+        mm_key->next->next = mm_ctn + 1;
+        mm_ctn->uni.ptr    = mm_key;
+      }
+    }
+  }
+
+  return m_vals;
+}
+
+static yyjson_mut_val *
+unsafe_yyjson_mut_val_mut_copy (yyjson_mut_doc *m_doc,
+                                yyjson_mut_val *m_vals)
+{
+  /*
+   The mutable object or array stores all sub-values in a circular linked
+   list, so we can traverse them in the same loop. The traversal starts from
+   the last item, continues with the first item in a list, and ends with the
+   second to last item, which needs to be linked to the last item to close the
+   circle.
+   */
+
+  yyjson_mut_val *m_val = unsafe_yyjson_mut_val (m_doc, 1);
+  if (unlikely (!m_val))
+    return NULL;
+  m_val->tag = m_vals->tag;
+
+  switch (unsafe_yyjson_get_type (m_vals))
+  {
+  case YYJSON_TYPE_OBJ:
+  case YYJSON_TYPE_ARR:
+    if (unsafe_yyjson_get_len (m_vals) > 0)
+    {
+      yyjson_mut_val *last = (yyjson_mut_val *)m_vals->uni.ptr;
+      yyjson_mut_val *next = last->next, *prev;
+      prev                 = unsafe_yyjson_mut_val_mut_copy (m_doc, last);
+      if (!prev)
+        return NULL;
+      m_val->uni.ptr = (void *)prev;
+      while (next != last)
+      {
+        prev->next = unsafe_yyjson_mut_val_mut_copy (m_doc, next);
+        if (!prev->next)
+          return NULL;
+        prev = prev->next;
+        next = next->next;
+      }
+      prev->next = (yyjson_mut_val *)m_val->uni.ptr;
+    }
+    break;
+
+  case YYJSON_TYPE_RAW:
+  case YYJSON_TYPE_STR:
+  {
+    const char *str = m_vals->uni.str;
+    usize str_len   = unsafe_yyjson_get_len (m_vals);
+    m_val->uni.str  = unsafe_yyjson_mut_strncpy (m_doc, str, str_len);
+    if (!m_val->uni.str)
+      return NULL;
+    break;
+  }
+
+  default:
+    m_val->uni = m_vals->uni;
+    break;
+  }
+
+  return m_val;
+}
+
+yyjson_api yyjson_mut_val *
+yyjson_mut_val_mut_copy (yyjson_mut_doc *doc,
+                         yyjson_mut_val *val)
+{
+  if (doc && val)
+    return unsafe_yyjson_mut_val_mut_copy (doc, val);
+  return NULL;
 }
 
 /* Count the number of values and the total length of the strings. */
-static void yyjson_mut_stat(yyjson_mut_val *val,
-                            usize *val_sum, usize *str_sum) {
-    yyjson_type type = unsafe_yyjson_get_type(val);
-    *val_sum += 1;
-    if (type == YYJSON_TYPE_ARR || type == YYJSON_TYPE_OBJ) {
-        yyjson_mut_val *child = (yyjson_mut_val *)val->uni.ptr;
-        usize len = unsafe_yyjson_get_len(val), i;
-        len <<= (u8)(type == YYJSON_TYPE_OBJ);
-        *val_sum += len;
-        for (i = 0; i < len; i++) {
-            yyjson_type stype = unsafe_yyjson_get_type(child);
-            if (stype == YYJSON_TYPE_STR || stype == YYJSON_TYPE_RAW) {
-                *str_sum += unsafe_yyjson_get_len(child) + 1;
-            } else if (stype == YYJSON_TYPE_ARR || stype == YYJSON_TYPE_OBJ) {
-                yyjson_mut_stat(child, val_sum, str_sum);
-                *val_sum -= 1;
-            }
-            child = child->next;
-        }
-    } else if (type == YYJSON_TYPE_STR || type == YYJSON_TYPE_RAW) {
-        *str_sum += unsafe_yyjson_get_len(val) + 1;
+static void
+yyjson_mut_stat (yyjson_mut_val *val,
+                 usize *val_sum, usize *str_sum)
+{
+  yyjson_type type = unsafe_yyjson_get_type (val);
+  *val_sum += 1;
+  if (type == YYJSON_TYPE_ARR || type == YYJSON_TYPE_OBJ)
+  {
+    yyjson_mut_val *child = (yyjson_mut_val *)val->uni.ptr;
+    usize len             = unsafe_yyjson_get_len (val), i;
+    len <<= (u8)(type == YYJSON_TYPE_OBJ);
+    *val_sum += len;
+    for (i = 0; i < len; i++)
+    {
+      yyjson_type stype = unsafe_yyjson_get_type (child);
+      if (stype == YYJSON_TYPE_STR || stype == YYJSON_TYPE_RAW)
+      {
+        *str_sum += unsafe_yyjson_get_len (child) + 1;
+      }
+      else if (stype == YYJSON_TYPE_ARR || stype == YYJSON_TYPE_OBJ)
+      {
+        yyjson_mut_stat (child, val_sum, str_sum);
+        *val_sum -= 1;
+      }
+      child = child->next;
     }
+  }
+  else if (type == YYJSON_TYPE_STR || type == YYJSON_TYPE_RAW)
+  {
+    *str_sum += unsafe_yyjson_get_len (val) + 1;
+  }
 }
 
 /* Copy mutable values to immutable value pool. */
-static usize yyjson_imut_copy(yyjson_val **val_ptr, char **buf_ptr,
-                              yyjson_mut_val *mval) {
-    yyjson_val *val = *val_ptr;
-    yyjson_type type = unsafe_yyjson_get_type(mval);
-    if (type == YYJSON_TYPE_ARR || type == YYJSON_TYPE_OBJ) {
-        yyjson_mut_val *child = (yyjson_mut_val *)mval->uni.ptr;
-        usize len = unsafe_yyjson_get_len(mval), i;
-        usize val_sum = 1;
-        if (type == YYJSON_TYPE_OBJ) {
-            if (len) child = child->next->next;
-            len <<= 1;
-        } else {
-            if (len) child = child->next;
-        }
-        *val_ptr = val + 1;
-        for (i = 0; i < len; i++) {
-            val_sum += yyjson_imut_copy(val_ptr, buf_ptr, child);
-            child = child->next;
-        }
-        val->tag = mval->tag;
-        val->uni.ofs = val_sum * sizeof(yyjson_val);
-        return val_sum;
-    } else if (type == YYJSON_TYPE_STR || type == YYJSON_TYPE_RAW) {
-        char *buf = *buf_ptr;
-        usize len = unsafe_yyjson_get_len(mval);
-        memcpy((void *)buf, (const void *)mval->uni.str, len);
-        buf[len] = '\0';
-        val->tag = mval->tag;
-        val->uni.str = buf;
-        *val_ptr = val + 1;
-        *buf_ptr = buf + len + 1;
-        return 1;
-    } else {
-        val->tag = mval->tag;
-        val->uni = mval->uni;
-        *val_ptr = val + 1;
-        return 1;
+static usize
+yyjson_imut_copy (yyjson_val **val_ptr, char **buf_ptr,
+                  yyjson_mut_val *mval)
+{
+  yyjson_val *val  = *val_ptr;
+  yyjson_type type = unsafe_yyjson_get_type (mval);
+  if (type == YYJSON_TYPE_ARR || type == YYJSON_TYPE_OBJ)
+  {
+    yyjson_mut_val *child = (yyjson_mut_val *)mval->uni.ptr;
+    usize len             = unsafe_yyjson_get_len (mval), i;
+    usize val_sum         = 1;
+    if (type == YYJSON_TYPE_OBJ)
+    {
+      if (len)
+        child = child->next->next;
+      len <<= 1;
     }
-}
-
-yyjson_api yyjson_doc *yyjson_mut_doc_imut_copy(yyjson_mut_doc *mdoc,
-                                                const yyjson_alc *alc) {
-    if (!mdoc) return NULL;
-    return yyjson_mut_val_imut_copy(mdoc->root, alc);
-}
-
-yyjson_api yyjson_doc *yyjson_mut_val_imut_copy(yyjson_mut_val *mval,
-                                                const yyjson_alc *alc) {
-    usize val_num = 0, str_sum = 0, hdr_size, buf_size;
-    yyjson_doc *doc = NULL;
-    yyjson_val *val_hdr = NULL;
-    
-    /* This value should be NULL here. Setting a non-null value suppresses
-       warning from the clang analyzer. */
-    char *str_hdr = (char *)(void *)&str_sum;
-    if (!mval) return NULL;
-    if (!alc) alc = &YYJSON_DEFAULT_ALC;
-    
-    /* traverse the input value to get pool size */
-    yyjson_mut_stat(mval, &val_num, &str_sum);
-    
-    /* create doc and val pool */
-    hdr_size = size_align_up(sizeof(yyjson_doc), sizeof(yyjson_val));
-    buf_size = hdr_size + val_num * sizeof(yyjson_val);
-    doc = (yyjson_doc *)alc->malloc(alc->ctx, buf_size);
-    if (!doc) return NULL;
-    memset(doc, 0, sizeof(yyjson_doc));
-    val_hdr = (yyjson_val *)(void *)((char *)(void *)doc + hdr_size);
-    doc->root = val_hdr;
-    doc->alc = *alc;
-    
-    /* create str pool */
-    if (str_sum > 0) {
-        str_hdr = (char *)alc->malloc(alc->ctx, str_sum);
-        doc->str_pool = str_hdr;
-        if (!str_hdr) {
-            alc->free(alc->ctx, (void *)doc);
-            return NULL;
-        }
+    else
+    {
+      if (len)
+        child = child->next;
     }
-    
-    /* copy vals and strs */
-    doc->val_read = yyjson_imut_copy(&val_hdr, &str_hdr, mval);
-    doc->dat_read = str_sum + 1;
-    return doc;
+    *val_ptr = val + 1;
+    for (i = 0; i < len; i++)
+    {
+      val_sum += yyjson_imut_copy (val_ptr, buf_ptr, child);
+      child = child->next;
+    }
+    val->tag     = mval->tag;
+    val->uni.ofs = val_sum * sizeof (yyjson_val);
+    return val_sum;
+  }
+  else if (type == YYJSON_TYPE_STR || type == YYJSON_TYPE_RAW)
+  {
+    char *buf = *buf_ptr;
+    usize len = unsafe_yyjson_get_len (mval);
+    memcpy ((void *)buf, (const void *)mval->uni.str, len);
+    buf[len]     = '\0';
+    val->tag     = mval->tag;
+    val->uni.str = buf;
+    *val_ptr     = val + 1;
+    *buf_ptr     = buf + len + 1;
+    return 1;
+  }
+  else
+  {
+    val->tag = mval->tag;
+    val->uni = mval->uni;
+    *val_ptr = val + 1;
+    return 1;
+  }
 }
 
-static_inline bool unsafe_yyjson_num_equals(void *lhs, void *rhs) {
-    yyjson_val_uni *luni = &((yyjson_val *)lhs)->uni;
-    yyjson_val_uni *runi = &((yyjson_val *)rhs)->uni;
-    yyjson_subtype lt = unsafe_yyjson_get_subtype(lhs);
-    yyjson_subtype rt = unsafe_yyjson_get_subtype(rhs);
-    if (lt == rt)
-        return luni->u64 == runi->u64;
-    if (lt == YYJSON_SUBTYPE_SINT && rt == YYJSON_SUBTYPE_UINT)
-        return luni->i64 >= 0 && luni->u64 == runi->u64;
-    if (lt == YYJSON_SUBTYPE_UINT && rt == YYJSON_SUBTYPE_SINT)
-        return runi->i64 >= 0 && luni->u64 == runi->u64;
+yyjson_api yyjson_doc *
+yyjson_mut_doc_imut_copy (yyjson_mut_doc *mdoc,
+                          const yyjson_alc *alc)
+{
+  if (!mdoc)
+    return NULL;
+  return yyjson_mut_val_imut_copy (mdoc->root, alc);
+}
+
+yyjson_api yyjson_doc *
+yyjson_mut_val_imut_copy (yyjson_mut_val *mval,
+                          const yyjson_alc *alc)
+{
+  usize val_num = 0, str_sum = 0, hdr_size, buf_size;
+  yyjson_doc *doc     = NULL;
+  yyjson_val *val_hdr = NULL;
+
+  /* This value should be NULL here. Setting a non-null value suppresses
+     warning from the clang analyzer. */
+  char *str_hdr = (char *)(void *)&str_sum;
+  if (!mval)
+    return NULL;
+  if (!alc)
+    alc = &YYJSON_DEFAULT_ALC;
+
+  /* traverse the input value to get pool size */
+  yyjson_mut_stat (mval, &val_num, &str_sum);
+
+  /* create doc and val pool */
+  hdr_size = size_align_up (sizeof (yyjson_doc), sizeof (yyjson_val));
+  buf_size = hdr_size + val_num * sizeof (yyjson_val);
+  doc      = (yyjson_doc *)alc->malloc (alc->ctx, buf_size);
+  if (!doc)
+    return NULL;
+  memset (doc, 0, sizeof (yyjson_doc));
+  val_hdr   = (yyjson_val *)(void *)((char *)(void *)doc + hdr_size);
+  doc->root = val_hdr;
+  doc->alc  = *alc;
+
+  /* create str pool */
+  if (str_sum > 0)
+  {
+    str_hdr       = (char *)alc->malloc (alc->ctx, str_sum);
+    doc->str_pool = str_hdr;
+    if (!str_hdr)
+    {
+      alc->free (alc->ctx, (void *)doc);
+      return NULL;
+    }
+  }
+
+  /* copy vals and strs */
+  doc->val_read = yyjson_imut_copy (&val_hdr, &str_hdr, mval);
+  doc->dat_read = str_sum + 1;
+  return doc;
+}
+
+static_inline bool
+unsafe_yyjson_num_equals (void *lhs, void *rhs)
+{
+  yyjson_val_uni *luni = &((yyjson_val *)lhs)->uni;
+  yyjson_val_uni *runi = &((yyjson_val *)rhs)->uni;
+  yyjson_subtype lt    = unsafe_yyjson_get_subtype (lhs);
+  yyjson_subtype rt    = unsafe_yyjson_get_subtype (rhs);
+  if (lt == rt)
+    return luni->u64 == runi->u64;
+  if (lt == YYJSON_SUBTYPE_SINT && rt == YYJSON_SUBTYPE_UINT)
+    return luni->i64 >= 0 && luni->u64 == runi->u64;
+  if (lt == YYJSON_SUBTYPE_UINT && rt == YYJSON_SUBTYPE_SINT)
+    return runi->i64 >= 0 && luni->u64 == runi->u64;
+  return false;
+}
+
+static_inline bool
+unsafe_yyjson_str_equals (void *lhs, void *rhs)
+{
+  usize len = unsafe_yyjson_get_len (lhs);
+  if (len != unsafe_yyjson_get_len (rhs))
     return false;
+  return 0 == len ||
+         0 == memcmp (unsafe_yyjson_get_str (lhs),
+                      unsafe_yyjson_get_str (rhs), len);
 }
 
-static_inline bool unsafe_yyjson_str_equals(void *lhs, void *rhs) {
-    usize len = unsafe_yyjson_get_len(lhs);
-    if (len != unsafe_yyjson_get_len(rhs)) return false;
-    return 0 == len ||
-           0 == memcmp(unsafe_yyjson_get_str(lhs),
-                       unsafe_yyjson_get_str(rhs), len);
-}
+yyjson_api bool
+unsafe_yyjson_equals (yyjson_val *lhs, yyjson_val *rhs)
+{
+  yyjson_type type = unsafe_yyjson_get_type (lhs);
+  if (type != unsafe_yyjson_get_type (rhs))
+    return false;
 
-yyjson_api bool unsafe_yyjson_equals(yyjson_val *lhs, yyjson_val *rhs) {
-    yyjson_type type = unsafe_yyjson_get_type(lhs);
-    if (type != unsafe_yyjson_get_type(rhs)) return false;
-    
-    switch (type) {
-        case YYJSON_TYPE_OBJ: {
-            usize len = unsafe_yyjson_get_len(lhs);
-            if (len != unsafe_yyjson_get_len(rhs)) return false;
-            if (len > 0) {
-                yyjson_obj_iter iter;
-                yyjson_obj_iter_init(rhs, &iter);
-                lhs = unsafe_yyjson_get_first(lhs);
-                while (len-- > 0) {
-                    rhs = yyjson_obj_iter_getn(&iter, lhs->uni.str,
-                                               unsafe_yyjson_get_len(lhs));
-                    if (!rhs || !unsafe_yyjson_equals(lhs + 1, rhs))
-                        return false;
-                    lhs = unsafe_yyjson_get_next(lhs + 1);
-                }
-            }
-            /* yyjson allows duplicate keys, so the check may be inaccurate */
-            return true;
-        }
-        
-        case YYJSON_TYPE_ARR: {
-            usize len = unsafe_yyjson_get_len(lhs);
-            if (len != unsafe_yyjson_get_len(rhs)) return false;
-            if (len > 0) {
-                lhs = unsafe_yyjson_get_first(lhs);
-                rhs = unsafe_yyjson_get_first(rhs);
-                while (len-- > 0) {
-                    if (!unsafe_yyjson_equals(lhs, rhs))
-                        return false;
-                    lhs = unsafe_yyjson_get_next(lhs);
-                    rhs = unsafe_yyjson_get_next(rhs);
-                }
-            }
-            return true;
-        }
-        
-        case YYJSON_TYPE_NUM:
-            return unsafe_yyjson_num_equals(lhs, rhs);
-        
-        case YYJSON_TYPE_RAW:
-        case YYJSON_TYPE_STR:
-            return unsafe_yyjson_str_equals(lhs, rhs);
-        
-        case YYJSON_TYPE_NULL:
-        case YYJSON_TYPE_BOOL:
-            return lhs->tag == rhs->tag;
-        
-        default:
-            return false;
+  switch (type)
+  {
+  case YYJSON_TYPE_OBJ:
+  {
+    usize len = unsafe_yyjson_get_len (lhs);
+    if (len != unsafe_yyjson_get_len (rhs))
+      return false;
+    if (len > 0)
+    {
+      yyjson_obj_iter iter;
+      yyjson_obj_iter_init (rhs, &iter);
+      lhs = unsafe_yyjson_get_first (lhs);
+      while (len-- > 0)
+      {
+        rhs = yyjson_obj_iter_getn (&iter, lhs->uni.str,
+                                    unsafe_yyjson_get_len (lhs));
+        if (!rhs || !unsafe_yyjson_equals (lhs + 1, rhs))
+          return false;
+        lhs = unsafe_yyjson_get_next (lhs + 1);
+      }
     }
-}
+    /* yyjson allows duplicate keys, so the check may be inaccurate */
+    return true;
+  }
 
-bool unsafe_yyjson_mut_equals(yyjson_mut_val *lhs, yyjson_mut_val *rhs) {
-    yyjson_type type = unsafe_yyjson_get_type(lhs);
-    if (type != unsafe_yyjson_get_type(rhs)) return false;
-    
-    switch (type) {
-        case YYJSON_TYPE_OBJ: {
-            usize len = unsafe_yyjson_get_len(lhs);
-            if (len != unsafe_yyjson_get_len(rhs)) return false;
-            if (len > 0) {
-                yyjson_mut_obj_iter iter;
-                yyjson_mut_obj_iter_init(rhs, &iter);
-                lhs = (yyjson_mut_val *)lhs->uni.ptr;
-                while (len-- > 0) {
-                    rhs = yyjson_mut_obj_iter_getn(&iter, lhs->uni.str,
-                                                   unsafe_yyjson_get_len(lhs));
-                    if (!rhs || !unsafe_yyjson_mut_equals(lhs->next, rhs))
-                        return false;
-                    lhs = lhs->next->next;
-                }
-            }
-            /* yyjson allows duplicate keys, so the check may be inaccurate */
-            return true;
-        }
-        
-        case YYJSON_TYPE_ARR: {
-            usize len = unsafe_yyjson_get_len(lhs);
-            if (len != unsafe_yyjson_get_len(rhs)) return false;
-            if (len > 0) {
-                lhs = (yyjson_mut_val *)lhs->uni.ptr;
-                rhs = (yyjson_mut_val *)rhs->uni.ptr;
-                while (len-- > 0) {
-                    if (!unsafe_yyjson_mut_equals(lhs, rhs))
-                        return false;
-                    lhs = lhs->next;
-                    rhs = rhs->next;
-                }
-            }
-            return true;
-        }
-        
-        case YYJSON_TYPE_NUM:
-            return unsafe_yyjson_num_equals(lhs, rhs);
-        
-        case YYJSON_TYPE_RAW:
-        case YYJSON_TYPE_STR:
-            return unsafe_yyjson_str_equals(lhs, rhs);
-        
-        case YYJSON_TYPE_NULL:
-        case YYJSON_TYPE_BOOL:
-            return lhs->tag == rhs->tag;
-        
-        default:
-            return false;
+  case YYJSON_TYPE_ARR:
+  {
+    usize len = unsafe_yyjson_get_len (lhs);
+    if (len != unsafe_yyjson_get_len (rhs))
+      return false;
+    if (len > 0)
+    {
+      lhs = unsafe_yyjson_get_first (lhs);
+      rhs = unsafe_yyjson_get_first (rhs);
+      while (len-- > 0)
+      {
+        if (!unsafe_yyjson_equals (lhs, rhs))
+          return false;
+        lhs = unsafe_yyjson_get_next (lhs);
+        rhs = unsafe_yyjson_get_next (rhs);
+      }
     }
+    return true;
+  }
+
+  case YYJSON_TYPE_NUM:
+    return unsafe_yyjson_num_equals (lhs, rhs);
+
+  case YYJSON_TYPE_RAW:
+  case YYJSON_TYPE_STR:
+    return unsafe_yyjson_str_equals (lhs, rhs);
+
+  case YYJSON_TYPE_NULL:
+  case YYJSON_TYPE_BOOL:
+    return lhs->tag == rhs->tag;
+
+  default:
+    return false;
+  }
 }
 
+bool
+unsafe_yyjson_mut_equals (yyjson_mut_val *lhs, yyjson_mut_val *rhs)
+{
+  yyjson_type type = unsafe_yyjson_get_type (lhs);
+  if (type != unsafe_yyjson_get_type (rhs))
+    return false;
 
+  switch (type)
+  {
+  case YYJSON_TYPE_OBJ:
+  {
+    usize len = unsafe_yyjson_get_len (lhs);
+    if (len != unsafe_yyjson_get_len (rhs))
+      return false;
+    if (len > 0)
+    {
+      yyjson_mut_obj_iter iter;
+      yyjson_mut_obj_iter_init (rhs, &iter);
+      lhs = (yyjson_mut_val *)lhs->uni.ptr;
+      while (len-- > 0)
+      {
+        rhs = yyjson_mut_obj_iter_getn (&iter, lhs->uni.str,
+                                        unsafe_yyjson_get_len (lhs));
+        if (!rhs || !unsafe_yyjson_mut_equals (lhs->next, rhs))
+          return false;
+        lhs = lhs->next->next;
+      }
+    }
+    /* yyjson allows duplicate keys, so the check may be inaccurate */
+    return true;
+  }
+
+  case YYJSON_TYPE_ARR:
+  {
+    usize len = unsafe_yyjson_get_len (lhs);
+    if (len != unsafe_yyjson_get_len (rhs))
+      return false;
+    if (len > 0)
+    {
+      lhs = (yyjson_mut_val *)lhs->uni.ptr;
+      rhs = (yyjson_mut_val *)rhs->uni.ptr;
+      while (len-- > 0)
+      {
+        if (!unsafe_yyjson_mut_equals (lhs, rhs))
+          return false;
+        lhs = lhs->next;
+        rhs = rhs->next;
+      }
+    }
+    return true;
+  }
+
+  case YYJSON_TYPE_NUM:
+    return unsafe_yyjson_num_equals (lhs, rhs);
+
+  case YYJSON_TYPE_RAW:
+  case YYJSON_TYPE_STR:
+    return unsafe_yyjson_str_equals (lhs, rhs);
+
+  case YYJSON_TYPE_NULL:
+  case YYJSON_TYPE_BOOL:
+    return lhs->tag == rhs->tag;
+
+  default:
+    return false;
+  }
+}
 
 /*==============================================================================
  * JSON Pointer
@@ -1675,36 +1940,42 @@ bool unsafe_yyjson_mut_equals(yyjson_mut_val *lhs, yyjson_mut_val *rhs) {
  @param mut Whether `arr` is mutable.
  @return The matched value, or NULL if not matched.
  */
-static_inline void *pointer_read_arr(const char **ptr,
-                                     const char *end,
-                                     void *arr,
-                                     bool mut) {
-    const char *hdr = *ptr;
-    const char *cur = hdr;
-    yyjson_val *i_arr = (yyjson_val *)arr;
-    yyjson_mut_val *m_arr = (yyjson_mut_val *)arr;
-    u64 idx = 0;
-    u8 add;
-    
-    /* start with 0 */
-    if (cur < end && *cur == '0') {
-        *ptr = cur + 1;
-        return mut
-            ? (void *)yyjson_mut_arr_get_first(m_arr)
-            : (void *)yyjson_arr_get_first(i_arr);
-    }
-    
-    /* read whole number */
-    if (cur + U64_SAFE_DIG < end) end = cur + U64_SAFE_DIG;
-    while (cur < end && (add = (u8)((u8)*cur - (u8)'0')) <= 9) {
-        cur++;
-        idx = idx * 10 + add;
-    }
-    if (cur == hdr || idx >= (u64)USIZE_MAX) return NULL;
-    *ptr = cur;
+static_inline void *
+pointer_read_arr (const char **ptr,
+                  const char *end,
+                  void *arr,
+                  bool mut)
+{
+  const char *hdr       = *ptr;
+  const char *cur       = hdr;
+  yyjson_val *i_arr     = (yyjson_val *)arr;
+  yyjson_mut_val *m_arr = (yyjson_mut_val *)arr;
+  u64 idx               = 0;
+  u8 add;
+
+  /* start with 0 */
+  if (cur < end && *cur == '0')
+  {
+    *ptr = cur + 1;
     return mut
-        ? (void *)yyjson_mut_arr_get(m_arr, (usize)idx)
-        : (void *)yyjson_arr_get(i_arr, (usize)idx);
+               ? (void *)yyjson_mut_arr_get_first (m_arr)
+               : (void *)yyjson_arr_get_first (i_arr);
+  }
+
+  /* read whole number */
+  if (cur + U64_SAFE_DIG < end)
+    end = cur + U64_SAFE_DIG;
+  while (cur < end && (add = (u8)((u8)*cur - (u8)'0')) <= 9)
+  {
+    cur++;
+    idx = idx * 10 + add;
+  }
+  if (cur == hdr || idx >= (u64)USIZE_MAX)
+    return NULL;
+  *ptr = cur;
+  return mut
+             ? (void *)yyjson_mut_arr_get (m_arr, (usize)idx)
+             : (void *)yyjson_arr_get (i_arr, (usize)idx);
 }
 
 /**
@@ -1715,237 +1986,297 @@ static_inline void *pointer_read_arr(const char **ptr,
  @param mut `obj` is mutable.
  @return The matched value, or NULL if not matched.
  */
-static_inline void *pointer_read_obj(const char **ptr,
-                                     const char *end,
-                                     void *obj,
-                                     bool mut) {
+static_inline void *
+pointer_read_obj (const char **ptr,
+                  const char *end,
+                  void *obj,
+                  bool mut)
+{
 #define BUF_SIZE 512
 #define is_escaped(cur) ((cur) < end && (*(cur) == '0' || *(cur) == '1'))
 #define is_unescaped(cur) ((cur) < end && *(cur) != '/' && *(cur) != '~')
 #define is_completed(cur) ((cur) == end || *(cur) == '/')
-    
-    const char *hdr = *ptr;
-    const char *cur = hdr;
-    yyjson_val *i_obj = (yyjson_val *)obj;
-    yyjson_mut_val *m_obj = (yyjson_mut_val *)obj;
-    yyjson_obj_iter i_iter;
-    yyjson_mut_obj_iter m_iter;
-    void *key;
-    
-    /* skip unescaped characters */
-    while (is_unescaped(cur)) cur++;
-    if (likely(is_completed(cur))) {
-        usize len = (usize)(cur - hdr);
-        *ptr = cur;
+
+  const char *hdr       = *ptr;
+  const char *cur       = hdr;
+  yyjson_val *i_obj     = (yyjson_val *)obj;
+  yyjson_mut_val *m_obj = (yyjson_mut_val *)obj;
+  yyjson_obj_iter i_iter;
+  yyjson_mut_obj_iter m_iter;
+  void *key;
+
+  /* skip unescaped characters */
+  while (is_unescaped (cur))
+    cur++;
+  if (likely (is_completed (cur)))
+  {
+    usize len = (usize)(cur - hdr);
+    *ptr      = cur;
+    return mut
+               ? (void *)yyjson_mut_obj_getn (m_obj, hdr, len)
+               : (void *)yyjson_obj_getn (i_obj, hdr, len);
+  }
+
+  /* copy escaped characters to buffer */
+  if (likely (end - hdr <= BUF_SIZE))
+  {
+    char buf[BUF_SIZE];
+    char *dst = buf + (usize)(cur - hdr);
+    memcpy (buf, hdr, (usize)(cur - hdr));
+    while (true)
+    {
+      if (is_unescaped (cur))
+      {
+        *dst++ = *cur++;
+      }
+      else if (is_completed (cur))
+      {
+        usize len = (usize)(dst - buf);
+        *ptr      = cur;
         return mut
-            ? (void *)yyjson_mut_obj_getn(m_obj, hdr, len)
-            : (void *)yyjson_obj_getn(i_obj, hdr, len);
+                   ? (void *)yyjson_mut_obj_getn (m_obj, buf, len)
+                   : (void *)yyjson_obj_getn (i_obj, buf, len);
+      }
+      else
+      {
+        cur++; /* skip '~' */
+        if (unlikely (!is_escaped (cur)))
+          return NULL;
+        *dst++ = (char)(*cur++ == '0' ? '~' : '/');
+      }
     }
-    
-    /* copy escaped characters to buffer */
-    if (likely(end - hdr <= BUF_SIZE)) {
-        char buf[BUF_SIZE];
-        char *dst = buf + (usize)(cur - hdr);
-        memcpy(buf, hdr, (usize)(cur - hdr));
-        while (true) {
-            if (is_unescaped(cur)) {
-                *dst++ = *cur++;
-            } else if (is_completed(cur)) {
-                usize len = (usize)(dst - buf);
-                *ptr = cur;
-                return mut
-                    ? (void *)yyjson_mut_obj_getn(m_obj, buf, len)
-                    : (void *)yyjson_obj_getn(i_obj, buf, len);
-            } else {
-                cur++; /* skip '~' */
-                if (unlikely(!is_escaped(cur))) return NULL;
-                *dst++ = (char)(*cur++ == '0' ? '~' : '/');
-            }
-        }
+  }
+
+  /* compare byte by byte */
+  cur = hdr;
+  if (!mut)
+    yyjson_obj_iter_init (i_obj, &i_iter);
+  else
+    yyjson_mut_obj_iter_init (m_obj, &m_iter);
+  while ((key = mut ? (void *)yyjson_mut_obj_iter_next (&m_iter)
+                    : (void *)yyjson_obj_iter_next (&i_iter)))
+  {
+    const char *k_str = unsafe_yyjson_get_str (key);
+    const char *k_end = k_str + unsafe_yyjson_get_len (key);
+    while (k_str < k_end)
+    {
+      if (is_unescaped (cur) && *k_str == *cur)
+      {
+        k_str += 1;
+        cur += 1;
+      }
+      else if (cur < end && *cur == '~' && is_escaped (cur + 1) &&
+               *k_str == (*(cur + 1) == '0' ? '~' : '/'))
+      {
+        k_str += 1;
+        cur += 2;
+      }
+      else
+      {
+        break;
+      }
     }
-    
-    /* compare byte by byte */
-    cur = hdr;
-    if (!mut) yyjson_obj_iter_init(i_obj, &i_iter);
-    else yyjson_mut_obj_iter_init(m_obj, &m_iter);
-    while ((key = mut ? (void *)yyjson_mut_obj_iter_next(&m_iter)
-                      : (void *)yyjson_obj_iter_next(&i_iter))) {
-        const char *k_str = unsafe_yyjson_get_str(key);
-        const char *k_end = k_str + unsafe_yyjson_get_len(key);
-        while (k_str < k_end) {
-            if (is_unescaped(cur) && *k_str == *cur) {
-                k_str += 1;
-                cur += 1;
-            } else if (cur < end && *cur == '~' && is_escaped(cur + 1) &&
-                       *k_str == (*(cur + 1) == '0' ? '~' : '/')) {
-                k_str += 1;
-                cur += 2;
-            } else {
-                break;
-            }
-        }
-        if (k_str == k_end && is_completed(cur)) {
-            *ptr = cur;
-            return mut
-                ? (void *)yyjson_mut_obj_iter_get_val((yyjson_mut_val *)key)
-                : (void *)yyjson_obj_iter_get_val((yyjson_val *)key);
-        }
+    if (k_str == k_end && is_completed (cur))
+    {
+      *ptr = cur;
+      return mut
+                 ? (void *)yyjson_mut_obj_iter_get_val ((yyjson_mut_val *)key)
+                 : (void *)yyjson_obj_iter_get_val ((yyjson_val *)key);
     }
-    return NULL;
-    
+  }
+  return NULL;
+
 #undef BUF_SIZE
 #undef is_escaped
 #undef is_unescaped
 #undef is_completed
 }
 
-yyjson_api yyjson_val *unsafe_yyjson_get_pointer(yyjson_val *val,
-                                                 const char *ptr,
-                                                 usize len) {
-    const char *end = ptr + len;
-    ptr++; /* skip '/' */
-    while (true) {
-        if (yyjson_is_obj(val)) {
-            val = (yyjson_val *)pointer_read_obj(&ptr, end, val, false);
-        } else if (yyjson_is_arr(val)) {
-            val = (yyjson_val *)pointer_read_arr(&ptr, end, val, false);
-        } else {
-            val = NULL;
-        }
-        if (!val || ptr == end) return val;
-        if (*ptr++ != '/') return NULL;
+yyjson_api yyjson_val *
+unsafe_yyjson_get_pointer (yyjson_val *val,
+                           const char *ptr,
+                           usize len)
+{
+  const char *end = ptr + len;
+  ptr++; /* skip '/' */
+  while (true)
+  {
+    if (yyjson_is_obj (val))
+    {
+      val = (yyjson_val *)pointer_read_obj (&ptr, end, val, false);
     }
+    else if (yyjson_is_arr (val))
+    {
+      val = (yyjson_val *)pointer_read_arr (&ptr, end, val, false);
+    }
+    else
+    {
+      val = NULL;
+    }
+    if (!val || ptr == end)
+      return val;
+    if (*ptr++ != '/')
+      return NULL;
+  }
 }
 
-yyjson_api yyjson_mut_val *unsafe_yyjson_mut_get_pointer(yyjson_mut_val *val,
-                                                         const char *ptr,
-                                                         usize len) {
-    const char *end = ptr + len;
-    ptr++; /* skip '/' */
-    while (true) {
-        if (yyjson_mut_is_obj(val)) {
-            val = (yyjson_mut_val *)pointer_read_obj(&ptr, end, val, true);
-        } else if (yyjson_mut_is_arr(val)) {
-            val = (yyjson_mut_val *)pointer_read_arr(&ptr, end, val, true);
-        } else {
-            val = NULL;
-        }
-        if (!val || ptr == end) return val;
-        if (*ptr++ != '/') return NULL;
+yyjson_api yyjson_mut_val *
+unsafe_yyjson_mut_get_pointer (yyjson_mut_val *val,
+                               const char *ptr,
+                               usize len)
+{
+  const char *end = ptr + len;
+  ptr++; /* skip '/' */
+  while (true)
+  {
+    if (yyjson_mut_is_obj (val))
+    {
+      val = (yyjson_mut_val *)pointer_read_obj (&ptr, end, val, true);
     }
+    else if (yyjson_mut_is_arr (val))
+    {
+      val = (yyjson_mut_val *)pointer_read_arr (&ptr, end, val, true);
+    }
+    else
+    {
+      val = NULL;
+    }
+    if (!val || ptr == end)
+      return val;
+    if (*ptr++ != '/')
+      return NULL;
+  }
 }
-
-
 
 /*==============================================================================
  * JSON Merge-Patch
  *============================================================================*/
 
-yyjson_api yyjson_mut_val *yyjson_merge_patch(yyjson_mut_doc *doc,
-                                              yyjson_val *orig,
-                                              yyjson_val *patch) {
-    usize idx, max;
-    yyjson_val *key, *orig_val, *patch_val, local_orig;
-    yyjson_mut_val *builder, *mut_key, *mut_val, *merged_val;
-    
-    if (unlikely(!yyjson_is_obj(patch))) {
-        return yyjson_val_mut_copy(doc, patch);
-    }
-    
-    builder = yyjson_mut_obj(doc);
-    if (unlikely(!builder)) return NULL;
-    
-    if (!yyjson_is_obj(orig)) {
-        orig = &local_orig;
-        orig->tag = builder->tag;
-        orig->uni = builder->uni;
-    }
-    
-    /* If orig is contributing, copy any items not modified by the patch */
-    if (orig != &local_orig)
-    {
-        yyjson_obj_foreach(orig, idx, max, key, orig_val) {
-            patch_val = yyjson_obj_getn(patch,
-                                        unsafe_yyjson_get_str(key),
-                                        unsafe_yyjson_get_len(key));
-            if (!patch_val) {
-                mut_key = yyjson_val_mut_copy(doc, key);
-                mut_val = yyjson_val_mut_copy(doc, orig_val);
-                if (!yyjson_mut_obj_add(builder, mut_key, mut_val)) return NULL;
-            }
-        }
-    }
+yyjson_api yyjson_mut_val *
+yyjson_merge_patch (yyjson_mut_doc *doc,
+                    yyjson_val *orig,
+                    yyjson_val *patch)
+{
+  usize idx, max;
+  yyjson_val *key, *orig_val, *patch_val, local_orig;
+  yyjson_mut_val *builder, *mut_key, *mut_val, *merged_val;
 
-    /* Merge items modified by the patch. */
-    yyjson_obj_foreach(patch, idx, max, key, patch_val) {
-        /* null indicates the field is removed. */
-        if (unsafe_yyjson_is_null(patch_val)) {
-            continue;
-        }
-        mut_key = yyjson_val_mut_copy(doc, key);
-        orig_val = yyjson_obj_getn(orig,
-                                   unsafe_yyjson_get_str(key),
-                                   unsafe_yyjson_get_len(key));
-        merged_val = yyjson_merge_patch(doc, orig_val, patch_val);
-        if (!yyjson_mut_obj_add(builder, mut_key, merged_val)) return NULL;
+  if (unlikely (!yyjson_is_obj (patch)))
+  {
+    return yyjson_val_mut_copy (doc, patch);
+  }
+
+  builder = yyjson_mut_obj (doc);
+  if (unlikely (!builder))
+    return NULL;
+
+  if (!yyjson_is_obj (orig))
+  {
+    orig      = &local_orig;
+    orig->tag = builder->tag;
+    orig->uni = builder->uni;
+  }
+
+  /* If orig is contributing, copy any items not modified by the patch */
+  if (orig != &local_orig)
+  {
+    yyjson_obj_foreach (orig, idx, max, key, orig_val)
+    {
+      patch_val = yyjson_obj_getn (patch,
+                                   unsafe_yyjson_get_str (key),
+                                   unsafe_yyjson_get_len (key));
+      if (!patch_val)
+      {
+        mut_key = yyjson_val_mut_copy (doc, key);
+        mut_val = yyjson_val_mut_copy (doc, orig_val);
+        if (!yyjson_mut_obj_add (builder, mut_key, mut_val))
+          return NULL;
+      }
     }
-    
-    return builder;
+  }
+
+  /* Merge items modified by the patch. */
+  yyjson_obj_foreach (patch, idx, max, key, patch_val)
+  {
+    /* null indicates the field is removed. */
+    if (unsafe_yyjson_is_null (patch_val))
+    {
+      continue;
+    }
+    mut_key    = yyjson_val_mut_copy (doc, key);
+    orig_val   = yyjson_obj_getn (orig,
+                                  unsafe_yyjson_get_str (key),
+                                  unsafe_yyjson_get_len (key));
+    merged_val = yyjson_merge_patch (doc, orig_val, patch_val);
+    if (!yyjson_mut_obj_add (builder, mut_key, merged_val))
+      return NULL;
+  }
+
+  return builder;
 }
 
-yyjson_api yyjson_mut_val *yyjson_mut_merge_patch(yyjson_mut_doc *doc,
-                                                  yyjson_mut_val *orig,
-                                                  yyjson_mut_val *patch) {
-    usize idx, max;
-    yyjson_mut_val *key, *orig_val, *patch_val, local_orig;
-    yyjson_mut_val *builder, *mut_key, *mut_val, *merged_val;
-    
-    if (unlikely(!yyjson_mut_is_obj(patch))) {
-        return yyjson_mut_val_mut_copy(doc, patch);
-    }
-    
-    builder = yyjson_mut_obj(doc);
-    if (unlikely(!builder)) return NULL;
-    
-    if (!yyjson_mut_is_obj(orig)) {
-        orig = &local_orig;
-        orig->tag = builder->tag;
-        orig->uni = builder->uni;
-    }
-    
-    /* If orig is contributing, copy any items not modified by the patch */
-    if (orig != &local_orig)
+yyjson_api yyjson_mut_val *
+yyjson_mut_merge_patch (yyjson_mut_doc *doc,
+                        yyjson_mut_val *orig,
+                        yyjson_mut_val *patch)
+{
+  usize idx, max;
+  yyjson_mut_val *key, *orig_val, *patch_val, local_orig;
+  yyjson_mut_val *builder, *mut_key, *mut_val, *merged_val;
+
+  if (unlikely (!yyjson_mut_is_obj (patch)))
+  {
+    return yyjson_mut_val_mut_copy (doc, patch);
+  }
+
+  builder = yyjson_mut_obj (doc);
+  if (unlikely (!builder))
+    return NULL;
+
+  if (!yyjson_mut_is_obj (orig))
+  {
+    orig      = &local_orig;
+    orig->tag = builder->tag;
+    orig->uni = builder->uni;
+  }
+
+  /* If orig is contributing, copy any items not modified by the patch */
+  if (orig != &local_orig)
+  {
+    yyjson_mut_obj_foreach (orig, idx, max, key, orig_val)
     {
-        yyjson_mut_obj_foreach(orig, idx, max, key, orig_val) {
-            patch_val = yyjson_mut_obj_getn(patch,
-                                            unsafe_yyjson_get_str(key),
-                                            unsafe_yyjson_get_len(key));
-            if (!patch_val) {
-                mut_key = yyjson_mut_val_mut_copy(doc, key);
-                mut_val = yyjson_mut_val_mut_copy(doc, orig_val);
-                if (!yyjson_mut_obj_add(builder, mut_key, mut_val)) return NULL;
-            }
-        }
+      patch_val = yyjson_mut_obj_getn (patch,
+                                       unsafe_yyjson_get_str (key),
+                                       unsafe_yyjson_get_len (key));
+      if (!patch_val)
+      {
+        mut_key = yyjson_mut_val_mut_copy (doc, key);
+        mut_val = yyjson_mut_val_mut_copy (doc, orig_val);
+        if (!yyjson_mut_obj_add (builder, mut_key, mut_val))
+          return NULL;
+      }
     }
+  }
 
-    /* Merge items modified by the patch. */
-    yyjson_mut_obj_foreach(patch, idx, max, key, patch_val) {
-        /* null indicates the field is removed. */
-        if (unsafe_yyjson_is_null(patch_val)) {
-            continue;
-        }
-        mut_key = yyjson_mut_val_mut_copy(doc, key);
-        orig_val = yyjson_mut_obj_getn(orig,
-                                       unsafe_yyjson_get_str(key),
-                                       unsafe_yyjson_get_len(key));
-        merged_val = yyjson_mut_merge_patch(doc, orig_val, patch_val);
-        if (!yyjson_mut_obj_add(builder, mut_key, merged_val)) return NULL;
+  /* Merge items modified by the patch. */
+  yyjson_mut_obj_foreach (patch, idx, max, key, patch_val)
+  {
+    /* null indicates the field is removed. */
+    if (unsafe_yyjson_is_null (patch_val))
+    {
+      continue;
     }
-    
-    return builder;
+    mut_key    = yyjson_mut_val_mut_copy (doc, key);
+    orig_val   = yyjson_mut_obj_getn (orig,
+                                      unsafe_yyjson_get_str (key),
+                                      unsafe_yyjson_get_len (key));
+    merged_val = yyjson_mut_merge_patch (doc, orig_val, patch_val);
+    if (!yyjson_mut_obj_add (builder, mut_key, merged_val))
+      return NULL;
+  }
+
+  return builder;
 }
-
-
 
 /*==============================================================================
  * Power10 Lookup Table
@@ -1971,674 +2302,674 @@ yyjson_api yyjson_mut_val *yyjson_mut_merge_patch(yyjson_mut_doc *doc,
     This lookup table is used by both the double number reader and writer.
     (generate with misc/make_tables.c) */
 static const u64 pow10_sig_table[] = {
-    U64(0xBF29DCAB, 0xA82FDEAE), U64(0x7432EE87, 0x3880FC33), /* ~= 10^-343 */
-    U64(0xEEF453D6, 0x923BD65A), U64(0x113FAA29, 0x06A13B3F), /* ~= 10^-342 */
-    U64(0x9558B466, 0x1B6565F8), U64(0x4AC7CA59, 0xA424C507), /* ~= 10^-341 */
-    U64(0xBAAEE17F, 0xA23EBF76), U64(0x5D79BCF0, 0x0D2DF649), /* ~= 10^-340 */
-    U64(0xE95A99DF, 0x8ACE6F53), U64(0xF4D82C2C, 0x107973DC), /* ~= 10^-339 */
-    U64(0x91D8A02B, 0xB6C10594), U64(0x79071B9B, 0x8A4BE869), /* ~= 10^-338 */
-    U64(0xB64EC836, 0xA47146F9), U64(0x9748E282, 0x6CDEE284), /* ~= 10^-337 */
-    U64(0xE3E27A44, 0x4D8D98B7), U64(0xFD1B1B23, 0x08169B25), /* ~= 10^-336 */
-    U64(0x8E6D8C6A, 0xB0787F72), U64(0xFE30F0F5, 0xE50E20F7), /* ~= 10^-335 */
-    U64(0xB208EF85, 0x5C969F4F), U64(0xBDBD2D33, 0x5E51A935), /* ~= 10^-334 */
-    U64(0xDE8B2B66, 0xB3BC4723), U64(0xAD2C7880, 0x35E61382), /* ~= 10^-333 */
-    U64(0x8B16FB20, 0x3055AC76), U64(0x4C3BCB50, 0x21AFCC31), /* ~= 10^-332 */
-    U64(0xADDCB9E8, 0x3C6B1793), U64(0xDF4ABE24, 0x2A1BBF3D), /* ~= 10^-331 */
-    U64(0xD953E862, 0x4B85DD78), U64(0xD71D6DAD, 0x34A2AF0D), /* ~= 10^-330 */
-    U64(0x87D4713D, 0x6F33AA6B), U64(0x8672648C, 0x40E5AD68), /* ~= 10^-329 */
-    U64(0xA9C98D8C, 0xCB009506), U64(0x680EFDAF, 0x511F18C2), /* ~= 10^-328 */
-    U64(0xD43BF0EF, 0xFDC0BA48), U64(0x0212BD1B, 0x2566DEF2), /* ~= 10^-327 */
-    U64(0x84A57695, 0xFE98746D), U64(0x014BB630, 0xF7604B57), /* ~= 10^-326 */
-    U64(0xA5CED43B, 0x7E3E9188), U64(0x419EA3BD, 0x35385E2D), /* ~= 10^-325 */
-    U64(0xCF42894A, 0x5DCE35EA), U64(0x52064CAC, 0x828675B9), /* ~= 10^-324 */
-    U64(0x818995CE, 0x7AA0E1B2), U64(0x7343EFEB, 0xD1940993), /* ~= 10^-323 */
-    U64(0xA1EBFB42, 0x19491A1F), U64(0x1014EBE6, 0xC5F90BF8), /* ~= 10^-322 */
-    U64(0xCA66FA12, 0x9F9B60A6), U64(0xD41A26E0, 0x77774EF6), /* ~= 10^-321 */
-    U64(0xFD00B897, 0x478238D0), U64(0x8920B098, 0x955522B4), /* ~= 10^-320 */
-    U64(0x9E20735E, 0x8CB16382), U64(0x55B46E5F, 0x5D5535B0), /* ~= 10^-319 */
-    U64(0xC5A89036, 0x2FDDBC62), U64(0xEB2189F7, 0x34AA831D), /* ~= 10^-318 */
-    U64(0xF712B443, 0xBBD52B7B), U64(0xA5E9EC75, 0x01D523E4), /* ~= 10^-317 */
-    U64(0x9A6BB0AA, 0x55653B2D), U64(0x47B233C9, 0x2125366E), /* ~= 10^-316 */
-    U64(0xC1069CD4, 0xEABE89F8), U64(0x999EC0BB, 0x696E840A), /* ~= 10^-315 */
-    U64(0xF148440A, 0x256E2C76), U64(0xC00670EA, 0x43CA250D), /* ~= 10^-314 */
-    U64(0x96CD2A86, 0x5764DBCA), U64(0x38040692, 0x6A5E5728), /* ~= 10^-313 */
-    U64(0xBC807527, 0xED3E12BC), U64(0xC6050837, 0x04F5ECF2), /* ~= 10^-312 */
-    U64(0xEBA09271, 0xE88D976B), U64(0xF7864A44, 0xC633682E), /* ~= 10^-311 */
-    U64(0x93445B87, 0x31587EA3), U64(0x7AB3EE6A, 0xFBE0211D), /* ~= 10^-310 */
-    U64(0xB8157268, 0xFDAE9E4C), U64(0x5960EA05, 0xBAD82964), /* ~= 10^-309 */
-    U64(0xE61ACF03, 0x3D1A45DF), U64(0x6FB92487, 0x298E33BD), /* ~= 10^-308 */
-    U64(0x8FD0C162, 0x06306BAB), U64(0xA5D3B6D4, 0x79F8E056), /* ~= 10^-307 */
-    U64(0xB3C4F1BA, 0x87BC8696), U64(0x8F48A489, 0x9877186C), /* ~= 10^-306 */
-    U64(0xE0B62E29, 0x29ABA83C), U64(0x331ACDAB, 0xFE94DE87), /* ~= 10^-305 */
-    U64(0x8C71DCD9, 0xBA0B4925), U64(0x9FF0C08B, 0x7F1D0B14), /* ~= 10^-304 */
-    U64(0xAF8E5410, 0x288E1B6F), U64(0x07ECF0AE, 0x5EE44DD9), /* ~= 10^-303 */
-    U64(0xDB71E914, 0x32B1A24A), U64(0xC9E82CD9, 0xF69D6150), /* ~= 10^-302 */
-    U64(0x892731AC, 0x9FAF056E), U64(0xBE311C08, 0x3A225CD2), /* ~= 10^-301 */
-    U64(0xAB70FE17, 0xC79AC6CA), U64(0x6DBD630A, 0x48AAF406), /* ~= 10^-300 */
-    U64(0xD64D3D9D, 0xB981787D), U64(0x092CBBCC, 0xDAD5B108), /* ~= 10^-299 */
-    U64(0x85F04682, 0x93F0EB4E), U64(0x25BBF560, 0x08C58EA5), /* ~= 10^-298 */
-    U64(0xA76C5823, 0x38ED2621), U64(0xAF2AF2B8, 0x0AF6F24E), /* ~= 10^-297 */
-    U64(0xD1476E2C, 0x07286FAA), U64(0x1AF5AF66, 0x0DB4AEE1), /* ~= 10^-296 */
-    U64(0x82CCA4DB, 0x847945CA), U64(0x50D98D9F, 0xC890ED4D), /* ~= 10^-295 */
-    U64(0xA37FCE12, 0x6597973C), U64(0xE50FF107, 0xBAB528A0), /* ~= 10^-294 */
-    U64(0xCC5FC196, 0xFEFD7D0C), U64(0x1E53ED49, 0xA96272C8), /* ~= 10^-293 */
-    U64(0xFF77B1FC, 0xBEBCDC4F), U64(0x25E8E89C, 0x13BB0F7A), /* ~= 10^-292 */
-    U64(0x9FAACF3D, 0xF73609B1), U64(0x77B19161, 0x8C54E9AC), /* ~= 10^-291 */
-    U64(0xC795830D, 0x75038C1D), U64(0xD59DF5B9, 0xEF6A2417), /* ~= 10^-290 */
-    U64(0xF97AE3D0, 0xD2446F25), U64(0x4B057328, 0x6B44AD1D), /* ~= 10^-289 */
-    U64(0x9BECCE62, 0x836AC577), U64(0x4EE367F9, 0x430AEC32), /* ~= 10^-288 */
-    U64(0xC2E801FB, 0x244576D5), U64(0x229C41F7, 0x93CDA73F), /* ~= 10^-287 */
-    U64(0xF3A20279, 0xED56D48A), U64(0x6B435275, 0x78C1110F), /* ~= 10^-286 */
-    U64(0x9845418C, 0x345644D6), U64(0x830A1389, 0x6B78AAA9), /* ~= 10^-285 */
-    U64(0xBE5691EF, 0x416BD60C), U64(0x23CC986B, 0xC656D553), /* ~= 10^-284 */
-    U64(0xEDEC366B, 0x11C6CB8F), U64(0x2CBFBE86, 0xB7EC8AA8), /* ~= 10^-283 */
-    U64(0x94B3A202, 0xEB1C3F39), U64(0x7BF7D714, 0x32F3D6A9), /* ~= 10^-282 */
-    U64(0xB9E08A83, 0xA5E34F07), U64(0xDAF5CCD9, 0x3FB0CC53), /* ~= 10^-281 */
-    U64(0xE858AD24, 0x8F5C22C9), U64(0xD1B3400F, 0x8F9CFF68), /* ~= 10^-280 */
-    U64(0x91376C36, 0xD99995BE), U64(0x23100809, 0xB9C21FA1), /* ~= 10^-279 */
-    U64(0xB5854744, 0x8FFFFB2D), U64(0xABD40A0C, 0x2832A78A), /* ~= 10^-278 */
-    U64(0xE2E69915, 0xB3FFF9F9), U64(0x16C90C8F, 0x323F516C), /* ~= 10^-277 */
-    U64(0x8DD01FAD, 0x907FFC3B), U64(0xAE3DA7D9, 0x7F6792E3), /* ~= 10^-276 */
-    U64(0xB1442798, 0xF49FFB4A), U64(0x99CD11CF, 0xDF41779C), /* ~= 10^-275 */
-    U64(0xDD95317F, 0x31C7FA1D), U64(0x40405643, 0xD711D583), /* ~= 10^-274 */
-    U64(0x8A7D3EEF, 0x7F1CFC52), U64(0x482835EA, 0x666B2572), /* ~= 10^-273 */
-    U64(0xAD1C8EAB, 0x5EE43B66), U64(0xDA324365, 0x0005EECF), /* ~= 10^-272 */
-    U64(0xD863B256, 0x369D4A40), U64(0x90BED43E, 0x40076A82), /* ~= 10^-271 */
-    U64(0x873E4F75, 0xE2224E68), U64(0x5A7744A6, 0xE804A291), /* ~= 10^-270 */
-    U64(0xA90DE353, 0x5AAAE202), U64(0x711515D0, 0xA205CB36), /* ~= 10^-269 */
-    U64(0xD3515C28, 0x31559A83), U64(0x0D5A5B44, 0xCA873E03), /* ~= 10^-268 */
-    U64(0x8412D999, 0x1ED58091), U64(0xE858790A, 0xFE9486C2), /* ~= 10^-267 */
-    U64(0xA5178FFF, 0x668AE0B6), U64(0x626E974D, 0xBE39A872), /* ~= 10^-266 */
-    U64(0xCE5D73FF, 0x402D98E3), U64(0xFB0A3D21, 0x2DC8128F), /* ~= 10^-265 */
-    U64(0x80FA687F, 0x881C7F8E), U64(0x7CE66634, 0xBC9D0B99), /* ~= 10^-264 */
-    U64(0xA139029F, 0x6A239F72), U64(0x1C1FFFC1, 0xEBC44E80), /* ~= 10^-263 */
-    U64(0xC9874347, 0x44AC874E), U64(0xA327FFB2, 0x66B56220), /* ~= 10^-262 */
-    U64(0xFBE91419, 0x15D7A922), U64(0x4BF1FF9F, 0x0062BAA8), /* ~= 10^-261 */
-    U64(0x9D71AC8F, 0xADA6C9B5), U64(0x6F773FC3, 0x603DB4A9), /* ~= 10^-260 */
-    U64(0xC4CE17B3, 0x99107C22), U64(0xCB550FB4, 0x384D21D3), /* ~= 10^-259 */
-    U64(0xF6019DA0, 0x7F549B2B), U64(0x7E2A53A1, 0x46606A48), /* ~= 10^-258 */
-    U64(0x99C10284, 0x4F94E0FB), U64(0x2EDA7444, 0xCBFC426D), /* ~= 10^-257 */
-    U64(0xC0314325, 0x637A1939), U64(0xFA911155, 0xFEFB5308), /* ~= 10^-256 */
-    U64(0xF03D93EE, 0xBC589F88), U64(0x793555AB, 0x7EBA27CA), /* ~= 10^-255 */
-    U64(0x96267C75, 0x35B763B5), U64(0x4BC1558B, 0x2F3458DE), /* ~= 10^-254 */
-    U64(0xBBB01B92, 0x83253CA2), U64(0x9EB1AAED, 0xFB016F16), /* ~= 10^-253 */
-    U64(0xEA9C2277, 0x23EE8BCB), U64(0x465E15A9, 0x79C1CADC), /* ~= 10^-252 */
-    U64(0x92A1958A, 0x7675175F), U64(0x0BFACD89, 0xEC191EC9), /* ~= 10^-251 */
-    U64(0xB749FAED, 0x14125D36), U64(0xCEF980EC, 0x671F667B), /* ~= 10^-250 */
-    U64(0xE51C79A8, 0x5916F484), U64(0x82B7E127, 0x80E7401A), /* ~= 10^-249 */
-    U64(0x8F31CC09, 0x37AE58D2), U64(0xD1B2ECB8, 0xB0908810), /* ~= 10^-248 */
-    U64(0xB2FE3F0B, 0x8599EF07), U64(0x861FA7E6, 0xDCB4AA15), /* ~= 10^-247 */
-    U64(0xDFBDCECE, 0x67006AC9), U64(0x67A791E0, 0x93E1D49A), /* ~= 10^-246 */
-    U64(0x8BD6A141, 0x006042BD), U64(0xE0C8BB2C, 0x5C6D24E0), /* ~= 10^-245 */
-    U64(0xAECC4991, 0x4078536D), U64(0x58FAE9F7, 0x73886E18), /* ~= 10^-244 */
-    U64(0xDA7F5BF5, 0x90966848), U64(0xAF39A475, 0x506A899E), /* ~= 10^-243 */
-    U64(0x888F9979, 0x7A5E012D), U64(0x6D8406C9, 0x52429603), /* ~= 10^-242 */
-    U64(0xAAB37FD7, 0xD8F58178), U64(0xC8E5087B, 0xA6D33B83), /* ~= 10^-241 */
-    U64(0xD5605FCD, 0xCF32E1D6), U64(0xFB1E4A9A, 0x90880A64), /* ~= 10^-240 */
-    U64(0x855C3BE0, 0xA17FCD26), U64(0x5CF2EEA0, 0x9A55067F), /* ~= 10^-239 */
-    U64(0xA6B34AD8, 0xC9DFC06F), U64(0xF42FAA48, 0xC0EA481E), /* ~= 10^-238 */
-    U64(0xD0601D8E, 0xFC57B08B), U64(0xF13B94DA, 0xF124DA26), /* ~= 10^-237 */
-    U64(0x823C1279, 0x5DB6CE57), U64(0x76C53D08, 0xD6B70858), /* ~= 10^-236 */
-    U64(0xA2CB1717, 0xB52481ED), U64(0x54768C4B, 0x0C64CA6E), /* ~= 10^-235 */
-    U64(0xCB7DDCDD, 0xA26DA268), U64(0xA9942F5D, 0xCF7DFD09), /* ~= 10^-234 */
-    U64(0xFE5D5415, 0x0B090B02), U64(0xD3F93B35, 0x435D7C4C), /* ~= 10^-233 */
-    U64(0x9EFA548D, 0x26E5A6E1), U64(0xC47BC501, 0x4A1A6DAF), /* ~= 10^-232 */
-    U64(0xC6B8E9B0, 0x709F109A), U64(0x359AB641, 0x9CA1091B), /* ~= 10^-231 */
-    U64(0xF867241C, 0x8CC6D4C0), U64(0xC30163D2, 0x03C94B62), /* ~= 10^-230 */
-    U64(0x9B407691, 0xD7FC44F8), U64(0x79E0DE63, 0x425DCF1D), /* ~= 10^-229 */
-    U64(0xC2109436, 0x4DFB5636), U64(0x985915FC, 0x12F542E4), /* ~= 10^-228 */
-    U64(0xF294B943, 0xE17A2BC4), U64(0x3E6F5B7B, 0x17B2939D), /* ~= 10^-227 */
-    U64(0x979CF3CA, 0x6CEC5B5A), U64(0xA705992C, 0xEECF9C42), /* ~= 10^-226 */
-    U64(0xBD8430BD, 0x08277231), U64(0x50C6FF78, 0x2A838353), /* ~= 10^-225 */
-    U64(0xECE53CEC, 0x4A314EBD), U64(0xA4F8BF56, 0x35246428), /* ~= 10^-224 */
-    U64(0x940F4613, 0xAE5ED136), U64(0x871B7795, 0xE136BE99), /* ~= 10^-223 */
-    U64(0xB9131798, 0x99F68584), U64(0x28E2557B, 0x59846E3F), /* ~= 10^-222 */
-    U64(0xE757DD7E, 0xC07426E5), U64(0x331AEADA, 0x2FE589CF), /* ~= 10^-221 */
-    U64(0x9096EA6F, 0x3848984F), U64(0x3FF0D2C8, 0x5DEF7621), /* ~= 10^-220 */
-    U64(0xB4BCA50B, 0x065ABE63), U64(0x0FED077A, 0x756B53A9), /* ~= 10^-219 */
-    U64(0xE1EBCE4D, 0xC7F16DFB), U64(0xD3E84959, 0x12C62894), /* ~= 10^-218 */
-    U64(0x8D3360F0, 0x9CF6E4BD), U64(0x64712DD7, 0xABBBD95C), /* ~= 10^-217 */
-    U64(0xB080392C, 0xC4349DEC), U64(0xBD8D794D, 0x96AACFB3), /* ~= 10^-216 */
-    U64(0xDCA04777, 0xF541C567), U64(0xECF0D7A0, 0xFC5583A0), /* ~= 10^-215 */
-    U64(0x89E42CAA, 0xF9491B60), U64(0xF41686C4, 0x9DB57244), /* ~= 10^-214 */
-    U64(0xAC5D37D5, 0xB79B6239), U64(0x311C2875, 0xC522CED5), /* ~= 10^-213 */
-    U64(0xD77485CB, 0x25823AC7), U64(0x7D633293, 0x366B828B), /* ~= 10^-212 */
-    U64(0x86A8D39E, 0xF77164BC), U64(0xAE5DFF9C, 0x02033197), /* ~= 10^-211 */
-    U64(0xA8530886, 0xB54DBDEB), U64(0xD9F57F83, 0x0283FDFC), /* ~= 10^-210 */
-    U64(0xD267CAA8, 0x62A12D66), U64(0xD072DF63, 0xC324FD7B), /* ~= 10^-209 */
-    U64(0x8380DEA9, 0x3DA4BC60), U64(0x4247CB9E, 0x59F71E6D), /* ~= 10^-208 */
-    U64(0xA4611653, 0x8D0DEB78), U64(0x52D9BE85, 0xF074E608), /* ~= 10^-207 */
-    U64(0xCD795BE8, 0x70516656), U64(0x67902E27, 0x6C921F8B), /* ~= 10^-206 */
-    U64(0x806BD971, 0x4632DFF6), U64(0x00BA1CD8, 0xA3DB53B6), /* ~= 10^-205 */
-    U64(0xA086CFCD, 0x97BF97F3), U64(0x80E8A40E, 0xCCD228A4), /* ~= 10^-204 */
-    U64(0xC8A883C0, 0xFDAF7DF0), U64(0x6122CD12, 0x8006B2CD), /* ~= 10^-203 */
-    U64(0xFAD2A4B1, 0x3D1B5D6C), U64(0x796B8057, 0x20085F81), /* ~= 10^-202 */
-    U64(0x9CC3A6EE, 0xC6311A63), U64(0xCBE33036, 0x74053BB0), /* ~= 10^-201 */
-    U64(0xC3F490AA, 0x77BD60FC), U64(0xBEDBFC44, 0x11068A9C), /* ~= 10^-200 */
-    U64(0xF4F1B4D5, 0x15ACB93B), U64(0xEE92FB55, 0x15482D44), /* ~= 10^-199 */
-    U64(0x99171105, 0x2D8BF3C5), U64(0x751BDD15, 0x2D4D1C4A), /* ~= 10^-198 */
-    U64(0xBF5CD546, 0x78EEF0B6), U64(0xD262D45A, 0x78A0635D), /* ~= 10^-197 */
-    U64(0xEF340A98, 0x172AACE4), U64(0x86FB8971, 0x16C87C34), /* ~= 10^-196 */
-    U64(0x9580869F, 0x0E7AAC0E), U64(0xD45D35E6, 0xAE3D4DA0), /* ~= 10^-195 */
-    U64(0xBAE0A846, 0xD2195712), U64(0x89748360, 0x59CCA109), /* ~= 10^-194 */
-    U64(0xE998D258, 0x869FACD7), U64(0x2BD1A438, 0x703FC94B), /* ~= 10^-193 */
-    U64(0x91FF8377, 0x5423CC06), U64(0x7B6306A3, 0x4627DDCF), /* ~= 10^-192 */
-    U64(0xB67F6455, 0x292CBF08), U64(0x1A3BC84C, 0x17B1D542), /* ~= 10^-191 */
-    U64(0xE41F3D6A, 0x7377EECA), U64(0x20CABA5F, 0x1D9E4A93), /* ~= 10^-190 */
-    U64(0x8E938662, 0x882AF53E), U64(0x547EB47B, 0x7282EE9C), /* ~= 10^-189 */
-    U64(0xB23867FB, 0x2A35B28D), U64(0xE99E619A, 0x4F23AA43), /* ~= 10^-188 */
-    U64(0xDEC681F9, 0xF4C31F31), U64(0x6405FA00, 0xE2EC94D4), /* ~= 10^-187 */
-    U64(0x8B3C113C, 0x38F9F37E), U64(0xDE83BC40, 0x8DD3DD04), /* ~= 10^-186 */
-    U64(0xAE0B158B, 0x4738705E), U64(0x9624AB50, 0xB148D445), /* ~= 10^-185 */
-    U64(0xD98DDAEE, 0x19068C76), U64(0x3BADD624, 0xDD9B0957), /* ~= 10^-184 */
-    U64(0x87F8A8D4, 0xCFA417C9), U64(0xE54CA5D7, 0x0A80E5D6), /* ~= 10^-183 */
-    U64(0xA9F6D30A, 0x038D1DBC), U64(0x5E9FCF4C, 0xCD211F4C), /* ~= 10^-182 */
-    U64(0xD47487CC, 0x8470652B), U64(0x7647C320, 0x0069671F), /* ~= 10^-181 */
-    U64(0x84C8D4DF, 0xD2C63F3B), U64(0x29ECD9F4, 0x0041E073), /* ~= 10^-180 */
-    U64(0xA5FB0A17, 0xC777CF09), U64(0xF4681071, 0x00525890), /* ~= 10^-179 */
-    U64(0xCF79CC9D, 0xB955C2CC), U64(0x7182148D, 0x4066EEB4), /* ~= 10^-178 */
-    U64(0x81AC1FE2, 0x93D599BF), U64(0xC6F14CD8, 0x48405530), /* ~= 10^-177 */
-    U64(0xA21727DB, 0x38CB002F), U64(0xB8ADA00E, 0x5A506A7C), /* ~= 10^-176 */
-    U64(0xCA9CF1D2, 0x06FDC03B), U64(0xA6D90811, 0xF0E4851C), /* ~= 10^-175 */
-    U64(0xFD442E46, 0x88BD304A), U64(0x908F4A16, 0x6D1DA663), /* ~= 10^-174 */
-    U64(0x9E4A9CEC, 0x15763E2E), U64(0x9A598E4E, 0x043287FE), /* ~= 10^-173 */
-    U64(0xC5DD4427, 0x1AD3CDBA), U64(0x40EFF1E1, 0x853F29FD), /* ~= 10^-172 */
-    U64(0xF7549530, 0xE188C128), U64(0xD12BEE59, 0xE68EF47C), /* ~= 10^-171 */
-    U64(0x9A94DD3E, 0x8CF578B9), U64(0x82BB74F8, 0x301958CE), /* ~= 10^-170 */
-    U64(0xC13A148E, 0x3032D6E7), U64(0xE36A5236, 0x3C1FAF01), /* ~= 10^-169 */
-    U64(0xF18899B1, 0xBC3F8CA1), U64(0xDC44E6C3, 0xCB279AC1), /* ~= 10^-168 */
-    U64(0x96F5600F, 0x15A7B7E5), U64(0x29AB103A, 0x5EF8C0B9), /* ~= 10^-167 */
-    U64(0xBCB2B812, 0xDB11A5DE), U64(0x7415D448, 0xF6B6F0E7), /* ~= 10^-166 */
-    U64(0xEBDF6617, 0x91D60F56), U64(0x111B495B, 0x3464AD21), /* ~= 10^-165 */
-    U64(0x936B9FCE, 0xBB25C995), U64(0xCAB10DD9, 0x00BEEC34), /* ~= 10^-164 */
-    U64(0xB84687C2, 0x69EF3BFB), U64(0x3D5D514F, 0x40EEA742), /* ~= 10^-163 */
-    U64(0xE65829B3, 0x046B0AFA), U64(0x0CB4A5A3, 0x112A5112), /* ~= 10^-162 */
-    U64(0x8FF71A0F, 0xE2C2E6DC), U64(0x47F0E785, 0xEABA72AB), /* ~= 10^-161 */
-    U64(0xB3F4E093, 0xDB73A093), U64(0x59ED2167, 0x65690F56), /* ~= 10^-160 */
-    U64(0xE0F218B8, 0xD25088B8), U64(0x306869C1, 0x3EC3532C), /* ~= 10^-159 */
-    U64(0x8C974F73, 0x83725573), U64(0x1E414218, 0xC73A13FB), /* ~= 10^-158 */
-    U64(0xAFBD2350, 0x644EEACF), U64(0xE5D1929E, 0xF90898FA), /* ~= 10^-157 */
-    U64(0xDBAC6C24, 0x7D62A583), U64(0xDF45F746, 0xB74ABF39), /* ~= 10^-156 */
-    U64(0x894BC396, 0xCE5DA772), U64(0x6B8BBA8C, 0x328EB783), /* ~= 10^-155 */
-    U64(0xAB9EB47C, 0x81F5114F), U64(0x066EA92F, 0x3F326564), /* ~= 10^-154 */
-    U64(0xD686619B, 0xA27255A2), U64(0xC80A537B, 0x0EFEFEBD), /* ~= 10^-153 */
-    U64(0x8613FD01, 0x45877585), U64(0xBD06742C, 0xE95F5F36), /* ~= 10^-152 */
-    U64(0xA798FC41, 0x96E952E7), U64(0x2C481138, 0x23B73704), /* ~= 10^-151 */
-    U64(0xD17F3B51, 0xFCA3A7A0), U64(0xF75A1586, 0x2CA504C5), /* ~= 10^-150 */
-    U64(0x82EF8513, 0x3DE648C4), U64(0x9A984D73, 0xDBE722FB), /* ~= 10^-149 */
-    U64(0xA3AB6658, 0x0D5FDAF5), U64(0xC13E60D0, 0xD2E0EBBA), /* ~= 10^-148 */
-    U64(0xCC963FEE, 0x10B7D1B3), U64(0x318DF905, 0x079926A8), /* ~= 10^-147 */
-    U64(0xFFBBCFE9, 0x94E5C61F), U64(0xFDF17746, 0x497F7052), /* ~= 10^-146 */
-    U64(0x9FD561F1, 0xFD0F9BD3), U64(0xFEB6EA8B, 0xEDEFA633), /* ~= 10^-145 */
-    U64(0xC7CABA6E, 0x7C5382C8), U64(0xFE64A52E, 0xE96B8FC0), /* ~= 10^-144 */
-    U64(0xF9BD690A, 0x1B68637B), U64(0x3DFDCE7A, 0xA3C673B0), /* ~= 10^-143 */
-    U64(0x9C1661A6, 0x51213E2D), U64(0x06BEA10C, 0xA65C084E), /* ~= 10^-142 */
-    U64(0xC31BFA0F, 0xE5698DB8), U64(0x486E494F, 0xCFF30A62), /* ~= 10^-141 */
-    U64(0xF3E2F893, 0xDEC3F126), U64(0x5A89DBA3, 0xC3EFCCFA), /* ~= 10^-140 */
-    U64(0x986DDB5C, 0x6B3A76B7), U64(0xF8962946, 0x5A75E01C), /* ~= 10^-139 */
-    U64(0xBE895233, 0x86091465), U64(0xF6BBB397, 0xF1135823), /* ~= 10^-138 */
-    U64(0xEE2BA6C0, 0x678B597F), U64(0x746AA07D, 0xED582E2C), /* ~= 10^-137 */
-    U64(0x94DB4838, 0x40B717EF), U64(0xA8C2A44E, 0xB4571CDC), /* ~= 10^-136 */
-    U64(0xBA121A46, 0x50E4DDEB), U64(0x92F34D62, 0x616CE413), /* ~= 10^-135 */
-    U64(0xE896A0D7, 0xE51E1566), U64(0x77B020BA, 0xF9C81D17), /* ~= 10^-134 */
-    U64(0x915E2486, 0xEF32CD60), U64(0x0ACE1474, 0xDC1D122E), /* ~= 10^-133 */
-    U64(0xB5B5ADA8, 0xAAFF80B8), U64(0x0D819992, 0x132456BA), /* ~= 10^-132 */
-    U64(0xE3231912, 0xD5BF60E6), U64(0x10E1FFF6, 0x97ED6C69), /* ~= 10^-131 */
-    U64(0x8DF5EFAB, 0xC5979C8F), U64(0xCA8D3FFA, 0x1EF463C1), /* ~= 10^-130 */
-    U64(0xB1736B96, 0xB6FD83B3), U64(0xBD308FF8, 0xA6B17CB2), /* ~= 10^-129 */
-    U64(0xDDD0467C, 0x64BCE4A0), U64(0xAC7CB3F6, 0xD05DDBDE), /* ~= 10^-128 */
-    U64(0x8AA22C0D, 0xBEF60EE4), U64(0x6BCDF07A, 0x423AA96B), /* ~= 10^-127 */
-    U64(0xAD4AB711, 0x2EB3929D), U64(0x86C16C98, 0xD2C953C6), /* ~= 10^-126 */
-    U64(0xD89D64D5, 0x7A607744), U64(0xE871C7BF, 0x077BA8B7), /* ~= 10^-125 */
-    U64(0x87625F05, 0x6C7C4A8B), U64(0x11471CD7, 0x64AD4972), /* ~= 10^-124 */
-    U64(0xA93AF6C6, 0xC79B5D2D), U64(0xD598E40D, 0x3DD89BCF), /* ~= 10^-123 */
-    U64(0xD389B478, 0x79823479), U64(0x4AFF1D10, 0x8D4EC2C3), /* ~= 10^-122 */
-    U64(0x843610CB, 0x4BF160CB), U64(0xCEDF722A, 0x585139BA), /* ~= 10^-121 */
-    U64(0xA54394FE, 0x1EEDB8FE), U64(0xC2974EB4, 0xEE658828), /* ~= 10^-120 */
-    U64(0xCE947A3D, 0xA6A9273E), U64(0x733D2262, 0x29FEEA32), /* ~= 10^-119 */
-    U64(0x811CCC66, 0x8829B887), U64(0x0806357D, 0x5A3F525F), /* ~= 10^-118 */
-    U64(0xA163FF80, 0x2A3426A8), U64(0xCA07C2DC, 0xB0CF26F7), /* ~= 10^-117 */
-    U64(0xC9BCFF60, 0x34C13052), U64(0xFC89B393, 0xDD02F0B5), /* ~= 10^-116 */
-    U64(0xFC2C3F38, 0x41F17C67), U64(0xBBAC2078, 0xD443ACE2), /* ~= 10^-115 */
-    U64(0x9D9BA783, 0x2936EDC0), U64(0xD54B944B, 0x84AA4C0D), /* ~= 10^-114 */
-    U64(0xC5029163, 0xF384A931), U64(0x0A9E795E, 0x65D4DF11), /* ~= 10^-113 */
-    U64(0xF64335BC, 0xF065D37D), U64(0x4D4617B5, 0xFF4A16D5), /* ~= 10^-112 */
-    U64(0x99EA0196, 0x163FA42E), U64(0x504BCED1, 0xBF8E4E45), /* ~= 10^-111 */
-    U64(0xC06481FB, 0x9BCF8D39), U64(0xE45EC286, 0x2F71E1D6), /* ~= 10^-110 */
-    U64(0xF07DA27A, 0x82C37088), U64(0x5D767327, 0xBB4E5A4C), /* ~= 10^-109 */
-    U64(0x964E858C, 0x91BA2655), U64(0x3A6A07F8, 0xD510F86F), /* ~= 10^-108 */
-    U64(0xBBE226EF, 0xB628AFEA), U64(0x890489F7, 0x0A55368B), /* ~= 10^-107 */
-    U64(0xEADAB0AB, 0xA3B2DBE5), U64(0x2B45AC74, 0xCCEA842E), /* ~= 10^-106 */
-    U64(0x92C8AE6B, 0x464FC96F), U64(0x3B0B8BC9, 0x0012929D), /* ~= 10^-105 */
-    U64(0xB77ADA06, 0x17E3BBCB), U64(0x09CE6EBB, 0x40173744), /* ~= 10^-104 */
-    U64(0xE5599087, 0x9DDCAABD), U64(0xCC420A6A, 0x101D0515), /* ~= 10^-103 */
-    U64(0x8F57FA54, 0xC2A9EAB6), U64(0x9FA94682, 0x4A12232D), /* ~= 10^-102 */
-    U64(0xB32DF8E9, 0xF3546564), U64(0x47939822, 0xDC96ABF9), /* ~= 10^-101 */
-    U64(0xDFF97724, 0x70297EBD), U64(0x59787E2B, 0x93BC56F7), /* ~= 10^-100 */
-    U64(0x8BFBEA76, 0xC619EF36), U64(0x57EB4EDB, 0x3C55B65A), /* ~= 10^-99 */
-    U64(0xAEFAE514, 0x77A06B03), U64(0xEDE62292, 0x0B6B23F1), /* ~= 10^-98 */
-    U64(0xDAB99E59, 0x958885C4), U64(0xE95FAB36, 0x8E45ECED), /* ~= 10^-97 */
-    U64(0x88B402F7, 0xFD75539B), U64(0x11DBCB02, 0x18EBB414), /* ~= 10^-96 */
-    U64(0xAAE103B5, 0xFCD2A881), U64(0xD652BDC2, 0x9F26A119), /* ~= 10^-95 */
-    U64(0xD59944A3, 0x7C0752A2), U64(0x4BE76D33, 0x46F0495F), /* ~= 10^-94 */
-    U64(0x857FCAE6, 0x2D8493A5), U64(0x6F70A440, 0x0C562DDB), /* ~= 10^-93 */
-    U64(0xA6DFBD9F, 0xB8E5B88E), U64(0xCB4CCD50, 0x0F6BB952), /* ~= 10^-92 */
-    U64(0xD097AD07, 0xA71F26B2), U64(0x7E2000A4, 0x1346A7A7), /* ~= 10^-91 */
-    U64(0x825ECC24, 0xC873782F), U64(0x8ED40066, 0x8C0C28C8), /* ~= 10^-90 */
-    U64(0xA2F67F2D, 0xFA90563B), U64(0x72890080, 0x2F0F32FA), /* ~= 10^-89 */
-    U64(0xCBB41EF9, 0x79346BCA), U64(0x4F2B40A0, 0x3AD2FFB9), /* ~= 10^-88 */
-    U64(0xFEA126B7, 0xD78186BC), U64(0xE2F610C8, 0x4987BFA8), /* ~= 10^-87 */
-    U64(0x9F24B832, 0xE6B0F436), U64(0x0DD9CA7D, 0x2DF4D7C9), /* ~= 10^-86 */
-    U64(0xC6EDE63F, 0xA05D3143), U64(0x91503D1C, 0x79720DBB), /* ~= 10^-85 */
-    U64(0xF8A95FCF, 0x88747D94), U64(0x75A44C63, 0x97CE912A), /* ~= 10^-84 */
-    U64(0x9B69DBE1, 0xB548CE7C), U64(0xC986AFBE, 0x3EE11ABA), /* ~= 10^-83 */
-    U64(0xC24452DA, 0x229B021B), U64(0xFBE85BAD, 0xCE996168), /* ~= 10^-82 */
-    U64(0xF2D56790, 0xAB41C2A2), U64(0xFAE27299, 0x423FB9C3), /* ~= 10^-81 */
-    U64(0x97C560BA, 0x6B0919A5), U64(0xDCCD879F, 0xC967D41A), /* ~= 10^-80 */
-    U64(0xBDB6B8E9, 0x05CB600F), U64(0x5400E987, 0xBBC1C920), /* ~= 10^-79 */
-    U64(0xED246723, 0x473E3813), U64(0x290123E9, 0xAAB23B68), /* ~= 10^-78 */
-    U64(0x9436C076, 0x0C86E30B), U64(0xF9A0B672, 0x0AAF6521), /* ~= 10^-77 */
-    U64(0xB9447093, 0x8FA89BCE), U64(0xF808E40E, 0x8D5B3E69), /* ~= 10^-76 */
-    U64(0xE7958CB8, 0x7392C2C2), U64(0xB60B1D12, 0x30B20E04), /* ~= 10^-75 */
-    U64(0x90BD77F3, 0x483BB9B9), U64(0xB1C6F22B, 0x5E6F48C2), /* ~= 10^-74 */
-    U64(0xB4ECD5F0, 0x1A4AA828), U64(0x1E38AEB6, 0x360B1AF3), /* ~= 10^-73 */
-    U64(0xE2280B6C, 0x20DD5232), U64(0x25C6DA63, 0xC38DE1B0), /* ~= 10^-72 */
-    U64(0x8D590723, 0x948A535F), U64(0x579C487E, 0x5A38AD0E), /* ~= 10^-71 */
-    U64(0xB0AF48EC, 0x79ACE837), U64(0x2D835A9D, 0xF0C6D851), /* ~= 10^-70 */
-    U64(0xDCDB1B27, 0x98182244), U64(0xF8E43145, 0x6CF88E65), /* ~= 10^-69 */
-    U64(0x8A08F0F8, 0xBF0F156B), U64(0x1B8E9ECB, 0x641B58FF), /* ~= 10^-68 */
-    U64(0xAC8B2D36, 0xEED2DAC5), U64(0xE272467E, 0x3D222F3F), /* ~= 10^-67 */
-    U64(0xD7ADF884, 0xAA879177), U64(0x5B0ED81D, 0xCC6ABB0F), /* ~= 10^-66 */
-    U64(0x86CCBB52, 0xEA94BAEA), U64(0x98E94712, 0x9FC2B4E9), /* ~= 10^-65 */
-    U64(0xA87FEA27, 0xA539E9A5), U64(0x3F2398D7, 0x47B36224), /* ~= 10^-64 */
-    U64(0xD29FE4B1, 0x8E88640E), U64(0x8EEC7F0D, 0x19A03AAD), /* ~= 10^-63 */
-    U64(0x83A3EEEE, 0xF9153E89), U64(0x1953CF68, 0x300424AC), /* ~= 10^-62 */
-    U64(0xA48CEAAA, 0xB75A8E2B), U64(0x5FA8C342, 0x3C052DD7), /* ~= 10^-61 */
-    U64(0xCDB02555, 0x653131B6), U64(0x3792F412, 0xCB06794D), /* ~= 10^-60 */
-    U64(0x808E1755, 0x5F3EBF11), U64(0xE2BBD88B, 0xBEE40BD0), /* ~= 10^-59 */
-    U64(0xA0B19D2A, 0xB70E6ED6), U64(0x5B6ACEAE, 0xAE9D0EC4), /* ~= 10^-58 */
-    U64(0xC8DE0475, 0x64D20A8B), U64(0xF245825A, 0x5A445275), /* ~= 10^-57 */
-    U64(0xFB158592, 0xBE068D2E), U64(0xEED6E2F0, 0xF0D56712), /* ~= 10^-56 */
-    U64(0x9CED737B, 0xB6C4183D), U64(0x55464DD6, 0x9685606B), /* ~= 10^-55 */
-    U64(0xC428D05A, 0xA4751E4C), U64(0xAA97E14C, 0x3C26B886), /* ~= 10^-54 */
-    U64(0xF5330471, 0x4D9265DF), U64(0xD53DD99F, 0x4B3066A8), /* ~= 10^-53 */
-    U64(0x993FE2C6, 0xD07B7FAB), U64(0xE546A803, 0x8EFE4029), /* ~= 10^-52 */
-    U64(0xBF8FDB78, 0x849A5F96), U64(0xDE985204, 0x72BDD033), /* ~= 10^-51 */
-    U64(0xEF73D256, 0xA5C0F77C), U64(0x963E6685, 0x8F6D4440), /* ~= 10^-50 */
-    U64(0x95A86376, 0x27989AAD), U64(0xDDE70013, 0x79A44AA8), /* ~= 10^-49 */
-    U64(0xBB127C53, 0xB17EC159), U64(0x5560C018, 0x580D5D52), /* ~= 10^-48 */
-    U64(0xE9D71B68, 0x9DDE71AF), U64(0xAAB8F01E, 0x6E10B4A6), /* ~= 10^-47 */
-    U64(0x92267121, 0x62AB070D), U64(0xCAB39613, 0x04CA70E8), /* ~= 10^-46 */
-    U64(0xB6B00D69, 0xBB55C8D1), U64(0x3D607B97, 0xC5FD0D22), /* ~= 10^-45 */
-    U64(0xE45C10C4, 0x2A2B3B05), U64(0x8CB89A7D, 0xB77C506A), /* ~= 10^-44 */
-    U64(0x8EB98A7A, 0x9A5B04E3), U64(0x77F3608E, 0x92ADB242), /* ~= 10^-43 */
-    U64(0xB267ED19, 0x40F1C61C), U64(0x55F038B2, 0x37591ED3), /* ~= 10^-42 */
-    U64(0xDF01E85F, 0x912E37A3), U64(0x6B6C46DE, 0xC52F6688), /* ~= 10^-41 */
-    U64(0x8B61313B, 0xBABCE2C6), U64(0x2323AC4B, 0x3B3DA015), /* ~= 10^-40 */
-    U64(0xAE397D8A, 0xA96C1B77), U64(0xABEC975E, 0x0A0D081A), /* ~= 10^-39 */
-    U64(0xD9C7DCED, 0x53C72255), U64(0x96E7BD35, 0x8C904A21), /* ~= 10^-38 */
-    U64(0x881CEA14, 0x545C7575), U64(0x7E50D641, 0x77DA2E54), /* ~= 10^-37 */
-    U64(0xAA242499, 0x697392D2), U64(0xDDE50BD1, 0xD5D0B9E9), /* ~= 10^-36 */
-    U64(0xD4AD2DBF, 0xC3D07787), U64(0x955E4EC6, 0x4B44E864), /* ~= 10^-35 */
-    U64(0x84EC3C97, 0xDA624AB4), U64(0xBD5AF13B, 0xEF0B113E), /* ~= 10^-34 */
-    U64(0xA6274BBD, 0xD0FADD61), U64(0xECB1AD8A, 0xEACDD58E), /* ~= 10^-33 */
-    U64(0xCFB11EAD, 0x453994BA), U64(0x67DE18ED, 0xA5814AF2), /* ~= 10^-32 */
-    U64(0x81CEB32C, 0x4B43FCF4), U64(0x80EACF94, 0x8770CED7), /* ~= 10^-31 */
-    U64(0xA2425FF7, 0x5E14FC31), U64(0xA1258379, 0xA94D028D), /* ~= 10^-30 */
-    U64(0xCAD2F7F5, 0x359A3B3E), U64(0x096EE458, 0x13A04330), /* ~= 10^-29 */
-    U64(0xFD87B5F2, 0x8300CA0D), U64(0x8BCA9D6E, 0x188853FC), /* ~= 10^-28 */
-    U64(0x9E74D1B7, 0x91E07E48), U64(0x775EA264, 0xCF55347D), /* ~= 10^-27 */
-    U64(0xC6120625, 0x76589DDA), U64(0x95364AFE, 0x032A819D), /* ~= 10^-26 */
-    U64(0xF79687AE, 0xD3EEC551), U64(0x3A83DDBD, 0x83F52204), /* ~= 10^-25 */
-    U64(0x9ABE14CD, 0x44753B52), U64(0xC4926A96, 0x72793542), /* ~= 10^-24 */
-    U64(0xC16D9A00, 0x95928A27), U64(0x75B7053C, 0x0F178293), /* ~= 10^-23 */
-    U64(0xF1C90080, 0xBAF72CB1), U64(0x5324C68B, 0x12DD6338), /* ~= 10^-22 */
-    U64(0x971DA050, 0x74DA7BEE), U64(0xD3F6FC16, 0xEBCA5E03), /* ~= 10^-21 */
-    U64(0xBCE50864, 0x92111AEA), U64(0x88F4BB1C, 0xA6BCF584), /* ~= 10^-20 */
-    U64(0xEC1E4A7D, 0xB69561A5), U64(0x2B31E9E3, 0xD06C32E5), /* ~= 10^-19 */
-    U64(0x9392EE8E, 0x921D5D07), U64(0x3AFF322E, 0x62439FCF), /* ~= 10^-18 */
-    U64(0xB877AA32, 0x36A4B449), U64(0x09BEFEB9, 0xFAD487C2), /* ~= 10^-17 */
-    U64(0xE69594BE, 0xC44DE15B), U64(0x4C2EBE68, 0x7989A9B3), /* ~= 10^-16 */
-    U64(0x901D7CF7, 0x3AB0ACD9), U64(0x0F9D3701, 0x4BF60A10), /* ~= 10^-15 */
-    U64(0xB424DC35, 0x095CD80F), U64(0x538484C1, 0x9EF38C94), /* ~= 10^-14 */
-    U64(0xE12E1342, 0x4BB40E13), U64(0x2865A5F2, 0x06B06FB9), /* ~= 10^-13 */
-    U64(0x8CBCCC09, 0x6F5088CB), U64(0xF93F87B7, 0x442E45D3), /* ~= 10^-12 */
-    U64(0xAFEBFF0B, 0xCB24AAFE), U64(0xF78F69A5, 0x1539D748), /* ~= 10^-11 */
-    U64(0xDBE6FECE, 0xBDEDD5BE), U64(0xB573440E, 0x5A884D1B), /* ~= 10^-10 */
-    U64(0x89705F41, 0x36B4A597), U64(0x31680A88, 0xF8953030), /* ~= 10^-9 */
-    U64(0xABCC7711, 0x8461CEFC), U64(0xFDC20D2B, 0x36BA7C3D), /* ~= 10^-8 */
-    U64(0xD6BF94D5, 0xE57A42BC), U64(0x3D329076, 0x04691B4C), /* ~= 10^-7 */
-    U64(0x8637BD05, 0xAF6C69B5), U64(0xA63F9A49, 0xC2C1B10F), /* ~= 10^-6 */
-    U64(0xA7C5AC47, 0x1B478423), U64(0x0FCF80DC, 0x33721D53), /* ~= 10^-5 */
-    U64(0xD1B71758, 0xE219652B), U64(0xD3C36113, 0x404EA4A8), /* ~= 10^-4 */
-    U64(0x83126E97, 0x8D4FDF3B), U64(0x645A1CAC, 0x083126E9), /* ~= 10^-3 */
-    U64(0xA3D70A3D, 0x70A3D70A), U64(0x3D70A3D7, 0x0A3D70A3), /* ~= 10^-2 */
-    U64(0xCCCCCCCC, 0xCCCCCCCC), U64(0xCCCCCCCC, 0xCCCCCCCC), /* ~= 10^-1 */
-    U64(0x80000000, 0x00000000), U64(0x00000000, 0x00000000), /* == 10^0 */
-    U64(0xA0000000, 0x00000000), U64(0x00000000, 0x00000000), /* == 10^1 */
-    U64(0xC8000000, 0x00000000), U64(0x00000000, 0x00000000), /* == 10^2 */
-    U64(0xFA000000, 0x00000000), U64(0x00000000, 0x00000000), /* == 10^3 */
-    U64(0x9C400000, 0x00000000), U64(0x00000000, 0x00000000), /* == 10^4 */
-    U64(0xC3500000, 0x00000000), U64(0x00000000, 0x00000000), /* == 10^5 */
-    U64(0xF4240000, 0x00000000), U64(0x00000000, 0x00000000), /* == 10^6 */
-    U64(0x98968000, 0x00000000), U64(0x00000000, 0x00000000), /* == 10^7 */
-    U64(0xBEBC2000, 0x00000000), U64(0x00000000, 0x00000000), /* == 10^8 */
-    U64(0xEE6B2800, 0x00000000), U64(0x00000000, 0x00000000), /* == 10^9 */
-    U64(0x9502F900, 0x00000000), U64(0x00000000, 0x00000000), /* == 10^10 */
-    U64(0xBA43B740, 0x00000000), U64(0x00000000, 0x00000000), /* == 10^11 */
-    U64(0xE8D4A510, 0x00000000), U64(0x00000000, 0x00000000), /* == 10^12 */
-    U64(0x9184E72A, 0x00000000), U64(0x00000000, 0x00000000), /* == 10^13 */
-    U64(0xB5E620F4, 0x80000000), U64(0x00000000, 0x00000000), /* == 10^14 */
-    U64(0xE35FA931, 0xA0000000), U64(0x00000000, 0x00000000), /* == 10^15 */
-    U64(0x8E1BC9BF, 0x04000000), U64(0x00000000, 0x00000000), /* == 10^16 */
-    U64(0xB1A2BC2E, 0xC5000000), U64(0x00000000, 0x00000000), /* == 10^17 */
-    U64(0xDE0B6B3A, 0x76400000), U64(0x00000000, 0x00000000), /* == 10^18 */
-    U64(0x8AC72304, 0x89E80000), U64(0x00000000, 0x00000000), /* == 10^19 */
-    U64(0xAD78EBC5, 0xAC620000), U64(0x00000000, 0x00000000), /* == 10^20 */
-    U64(0xD8D726B7, 0x177A8000), U64(0x00000000, 0x00000000), /* == 10^21 */
-    U64(0x87867832, 0x6EAC9000), U64(0x00000000, 0x00000000), /* == 10^22 */
-    U64(0xA968163F, 0x0A57B400), U64(0x00000000, 0x00000000), /* == 10^23 */
-    U64(0xD3C21BCE, 0xCCEDA100), U64(0x00000000, 0x00000000), /* == 10^24 */
-    U64(0x84595161, 0x401484A0), U64(0x00000000, 0x00000000), /* == 10^25 */
-    U64(0xA56FA5B9, 0x9019A5C8), U64(0x00000000, 0x00000000), /* == 10^26 */
-    U64(0xCECB8F27, 0xF4200F3A), U64(0x00000000, 0x00000000), /* == 10^27 */
-    U64(0x813F3978, 0xF8940984), U64(0x40000000, 0x00000000), /* == 10^28 */
-    U64(0xA18F07D7, 0x36B90BE5), U64(0x50000000, 0x00000000), /* == 10^29 */
-    U64(0xC9F2C9CD, 0x04674EDE), U64(0xA4000000, 0x00000000), /* == 10^30 */
-    U64(0xFC6F7C40, 0x45812296), U64(0x4D000000, 0x00000000), /* == 10^31 */
-    U64(0x9DC5ADA8, 0x2B70B59D), U64(0xF0200000, 0x00000000), /* == 10^32 */
-    U64(0xC5371912, 0x364CE305), U64(0x6C280000, 0x00000000), /* == 10^33 */
-    U64(0xF684DF56, 0xC3E01BC6), U64(0xC7320000, 0x00000000), /* == 10^34 */
-    U64(0x9A130B96, 0x3A6C115C), U64(0x3C7F4000, 0x00000000), /* == 10^35 */
-    U64(0xC097CE7B, 0xC90715B3), U64(0x4B9F1000, 0x00000000), /* == 10^36 */
-    U64(0xF0BDC21A, 0xBB48DB20), U64(0x1E86D400, 0x00000000), /* == 10^37 */
-    U64(0x96769950, 0xB50D88F4), U64(0x13144480, 0x00000000), /* == 10^38 */
-    U64(0xBC143FA4, 0xE250EB31), U64(0x17D955A0, 0x00000000), /* == 10^39 */
-    U64(0xEB194F8E, 0x1AE525FD), U64(0x5DCFAB08, 0x00000000), /* == 10^40 */
-    U64(0x92EFD1B8, 0xD0CF37BE), U64(0x5AA1CAE5, 0x00000000), /* == 10^41 */
-    U64(0xB7ABC627, 0x050305AD), U64(0xF14A3D9E, 0x40000000), /* == 10^42 */
-    U64(0xE596B7B0, 0xC643C719), U64(0x6D9CCD05, 0xD0000000), /* == 10^43 */
-    U64(0x8F7E32CE, 0x7BEA5C6F), U64(0xE4820023, 0xA2000000), /* == 10^44 */
-    U64(0xB35DBF82, 0x1AE4F38B), U64(0xDDA2802C, 0x8A800000), /* == 10^45 */
-    U64(0xE0352F62, 0xA19E306E), U64(0xD50B2037, 0xAD200000), /* == 10^46 */
-    U64(0x8C213D9D, 0xA502DE45), U64(0x4526F422, 0xCC340000), /* == 10^47 */
-    U64(0xAF298D05, 0x0E4395D6), U64(0x9670B12B, 0x7F410000), /* == 10^48 */
-    U64(0xDAF3F046, 0x51D47B4C), U64(0x3C0CDD76, 0x5F114000), /* == 10^49 */
-    U64(0x88D8762B, 0xF324CD0F), U64(0xA5880A69, 0xFB6AC800), /* == 10^50 */
-    U64(0xAB0E93B6, 0xEFEE0053), U64(0x8EEA0D04, 0x7A457A00), /* == 10^51 */
-    U64(0xD5D238A4, 0xABE98068), U64(0x72A49045, 0x98D6D880), /* == 10^52 */
-    U64(0x85A36366, 0xEB71F041), U64(0x47A6DA2B, 0x7F864750), /* == 10^53 */
-    U64(0xA70C3C40, 0xA64E6C51), U64(0x999090B6, 0x5F67D924), /* == 10^54 */
-    U64(0xD0CF4B50, 0xCFE20765), U64(0xFFF4B4E3, 0xF741CF6D), /* == 10^55 */
-    U64(0x82818F12, 0x81ED449F), U64(0xBFF8F10E, 0x7A8921A4), /* ~= 10^56 */
-    U64(0xA321F2D7, 0x226895C7), U64(0xAFF72D52, 0x192B6A0D), /* ~= 10^57 */
-    U64(0xCBEA6F8C, 0xEB02BB39), U64(0x9BF4F8A6, 0x9F764490), /* ~= 10^58 */
-    U64(0xFEE50B70, 0x25C36A08), U64(0x02F236D0, 0x4753D5B4), /* ~= 10^59 */
-    U64(0x9F4F2726, 0x179A2245), U64(0x01D76242, 0x2C946590), /* ~= 10^60 */
-    U64(0xC722F0EF, 0x9D80AAD6), U64(0x424D3AD2, 0xB7B97EF5), /* ~= 10^61 */
-    U64(0xF8EBAD2B, 0x84E0D58B), U64(0xD2E08987, 0x65A7DEB2), /* ~= 10^62 */
-    U64(0x9B934C3B, 0x330C8577), U64(0x63CC55F4, 0x9F88EB2F), /* ~= 10^63 */
-    U64(0xC2781F49, 0xFFCFA6D5), U64(0x3CBF6B71, 0xC76B25FB), /* ~= 10^64 */
-    U64(0xF316271C, 0x7FC3908A), U64(0x8BEF464E, 0x3945EF7A), /* ~= 10^65 */
-    U64(0x97EDD871, 0xCFDA3A56), U64(0x97758BF0, 0xE3CBB5AC), /* ~= 10^66 */
-    U64(0xBDE94E8E, 0x43D0C8EC), U64(0x3D52EEED, 0x1CBEA317), /* ~= 10^67 */
-    U64(0xED63A231, 0xD4C4FB27), U64(0x4CA7AAA8, 0x63EE4BDD), /* ~= 10^68 */
-    U64(0x945E455F, 0x24FB1CF8), U64(0x8FE8CAA9, 0x3E74EF6A), /* ~= 10^69 */
-    U64(0xB975D6B6, 0xEE39E436), U64(0xB3E2FD53, 0x8E122B44), /* ~= 10^70 */
-    U64(0xE7D34C64, 0xA9C85D44), U64(0x60DBBCA8, 0x7196B616), /* ~= 10^71 */
-    U64(0x90E40FBE, 0xEA1D3A4A), U64(0xBC8955E9, 0x46FE31CD), /* ~= 10^72 */
-    U64(0xB51D13AE, 0xA4A488DD), U64(0x6BABAB63, 0x98BDBE41), /* ~= 10^73 */
-    U64(0xE264589A, 0x4DCDAB14), U64(0xC696963C, 0x7EED2DD1), /* ~= 10^74 */
-    U64(0x8D7EB760, 0x70A08AEC), U64(0xFC1E1DE5, 0xCF543CA2), /* ~= 10^75 */
-    U64(0xB0DE6538, 0x8CC8ADA8), U64(0x3B25A55F, 0x43294BCB), /* ~= 10^76 */
-    U64(0xDD15FE86, 0xAFFAD912), U64(0x49EF0EB7, 0x13F39EBE), /* ~= 10^77 */
-    U64(0x8A2DBF14, 0x2DFCC7AB), U64(0x6E356932, 0x6C784337), /* ~= 10^78 */
-    U64(0xACB92ED9, 0x397BF996), U64(0x49C2C37F, 0x07965404), /* ~= 10^79 */
-    U64(0xD7E77A8F, 0x87DAF7FB), U64(0xDC33745E, 0xC97BE906), /* ~= 10^80 */
-    U64(0x86F0AC99, 0xB4E8DAFD), U64(0x69A028BB, 0x3DED71A3), /* ~= 10^81 */
-    U64(0xA8ACD7C0, 0x222311BC), U64(0xC40832EA, 0x0D68CE0C), /* ~= 10^82 */
-    U64(0xD2D80DB0, 0x2AABD62B), U64(0xF50A3FA4, 0x90C30190), /* ~= 10^83 */
-    U64(0x83C7088E, 0x1AAB65DB), U64(0x792667C6, 0xDA79E0FA), /* ~= 10^84 */
-    U64(0xA4B8CAB1, 0xA1563F52), U64(0x577001B8, 0x91185938), /* ~= 10^85 */
-    U64(0xCDE6FD5E, 0x09ABCF26), U64(0xED4C0226, 0xB55E6F86), /* ~= 10^86 */
-    U64(0x80B05E5A, 0xC60B6178), U64(0x544F8158, 0x315B05B4), /* ~= 10^87 */
-    U64(0xA0DC75F1, 0x778E39D6), U64(0x696361AE, 0x3DB1C721), /* ~= 10^88 */
-    U64(0xC913936D, 0xD571C84C), U64(0x03BC3A19, 0xCD1E38E9), /* ~= 10^89 */
-    U64(0xFB587849, 0x4ACE3A5F), U64(0x04AB48A0, 0x4065C723), /* ~= 10^90 */
-    U64(0x9D174B2D, 0xCEC0E47B), U64(0x62EB0D64, 0x283F9C76), /* ~= 10^91 */
-    U64(0xC45D1DF9, 0x42711D9A), U64(0x3BA5D0BD, 0x324F8394), /* ~= 10^92 */
-    U64(0xF5746577, 0x930D6500), U64(0xCA8F44EC, 0x7EE36479), /* ~= 10^93 */
-    U64(0x9968BF6A, 0xBBE85F20), U64(0x7E998B13, 0xCF4E1ECB), /* ~= 10^94 */
-    U64(0xBFC2EF45, 0x6AE276E8), U64(0x9E3FEDD8, 0xC321A67E), /* ~= 10^95 */
-    U64(0xEFB3AB16, 0xC59B14A2), U64(0xC5CFE94E, 0xF3EA101E), /* ~= 10^96 */
-    U64(0x95D04AEE, 0x3B80ECE5), U64(0xBBA1F1D1, 0x58724A12), /* ~= 10^97 */
-    U64(0xBB445DA9, 0xCA61281F), U64(0x2A8A6E45, 0xAE8EDC97), /* ~= 10^98 */
-    U64(0xEA157514, 0x3CF97226), U64(0xF52D09D7, 0x1A3293BD), /* ~= 10^99 */
-    U64(0x924D692C, 0xA61BE758), U64(0x593C2626, 0x705F9C56), /* ~= 10^100 */
-    U64(0xB6E0C377, 0xCFA2E12E), U64(0x6F8B2FB0, 0x0C77836C), /* ~= 10^101 */
-    U64(0xE498F455, 0xC38B997A), U64(0x0B6DFB9C, 0x0F956447), /* ~= 10^102 */
-    U64(0x8EDF98B5, 0x9A373FEC), U64(0x4724BD41, 0x89BD5EAC), /* ~= 10^103 */
-    U64(0xB2977EE3, 0x00C50FE7), U64(0x58EDEC91, 0xEC2CB657), /* ~= 10^104 */
-    U64(0xDF3D5E9B, 0xC0F653E1), U64(0x2F2967B6, 0x6737E3ED), /* ~= 10^105 */
-    U64(0x8B865B21, 0x5899F46C), U64(0xBD79E0D2, 0x0082EE74), /* ~= 10^106 */
-    U64(0xAE67F1E9, 0xAEC07187), U64(0xECD85906, 0x80A3AA11), /* ~= 10^107 */
-    U64(0xDA01EE64, 0x1A708DE9), U64(0xE80E6F48, 0x20CC9495), /* ~= 10^108 */
-    U64(0x884134FE, 0x908658B2), U64(0x3109058D, 0x147FDCDD), /* ~= 10^109 */
-    U64(0xAA51823E, 0x34A7EEDE), U64(0xBD4B46F0, 0x599FD415), /* ~= 10^110 */
-    U64(0xD4E5E2CD, 0xC1D1EA96), U64(0x6C9E18AC, 0x7007C91A), /* ~= 10^111 */
-    U64(0x850FADC0, 0x9923329E), U64(0x03E2CF6B, 0xC604DDB0), /* ~= 10^112 */
-    U64(0xA6539930, 0xBF6BFF45), U64(0x84DB8346, 0xB786151C), /* ~= 10^113 */
-    U64(0xCFE87F7C, 0xEF46FF16), U64(0xE6126418, 0x65679A63), /* ~= 10^114 */
-    U64(0x81F14FAE, 0x158C5F6E), U64(0x4FCB7E8F, 0x3F60C07E), /* ~= 10^115 */
-    U64(0xA26DA399, 0x9AEF7749), U64(0xE3BE5E33, 0x0F38F09D), /* ~= 10^116 */
-    U64(0xCB090C80, 0x01AB551C), U64(0x5CADF5BF, 0xD3072CC5), /* ~= 10^117 */
-    U64(0xFDCB4FA0, 0x02162A63), U64(0x73D9732F, 0xC7C8F7F6), /* ~= 10^118 */
-    U64(0x9E9F11C4, 0x014DDA7E), U64(0x2867E7FD, 0xDCDD9AFA), /* ~= 10^119 */
-    U64(0xC646D635, 0x01A1511D), U64(0xB281E1FD, 0x541501B8), /* ~= 10^120 */
-    U64(0xF7D88BC2, 0x4209A565), U64(0x1F225A7C, 0xA91A4226), /* ~= 10^121 */
-    U64(0x9AE75759, 0x6946075F), U64(0x3375788D, 0xE9B06958), /* ~= 10^122 */
-    U64(0xC1A12D2F, 0xC3978937), U64(0x0052D6B1, 0x641C83AE), /* ~= 10^123 */
-    U64(0xF209787B, 0xB47D6B84), U64(0xC0678C5D, 0xBD23A49A), /* ~= 10^124 */
-    U64(0x9745EB4D, 0x50CE6332), U64(0xF840B7BA, 0x963646E0), /* ~= 10^125 */
-    U64(0xBD176620, 0xA501FBFF), U64(0xB650E5A9, 0x3BC3D898), /* ~= 10^126 */
-    U64(0xEC5D3FA8, 0xCE427AFF), U64(0xA3E51F13, 0x8AB4CEBE), /* ~= 10^127 */
-    U64(0x93BA47C9, 0x80E98CDF), U64(0xC66F336C, 0x36B10137), /* ~= 10^128 */
-    U64(0xB8A8D9BB, 0xE123F017), U64(0xB80B0047, 0x445D4184), /* ~= 10^129 */
-    U64(0xE6D3102A, 0xD96CEC1D), U64(0xA60DC059, 0x157491E5), /* ~= 10^130 */
-    U64(0x9043EA1A, 0xC7E41392), U64(0x87C89837, 0xAD68DB2F), /* ~= 10^131 */
-    U64(0xB454E4A1, 0x79DD1877), U64(0x29BABE45, 0x98C311FB), /* ~= 10^132 */
-    U64(0xE16A1DC9, 0xD8545E94), U64(0xF4296DD6, 0xFEF3D67A), /* ~= 10^133 */
-    U64(0x8CE2529E, 0x2734BB1D), U64(0x1899E4A6, 0x5F58660C), /* ~= 10^134 */
-    U64(0xB01AE745, 0xB101E9E4), U64(0x5EC05DCF, 0xF72E7F8F), /* ~= 10^135 */
-    U64(0xDC21A117, 0x1D42645D), U64(0x76707543, 0xF4FA1F73), /* ~= 10^136 */
-    U64(0x899504AE, 0x72497EBA), U64(0x6A06494A, 0x791C53A8), /* ~= 10^137 */
-    U64(0xABFA45DA, 0x0EDBDE69), U64(0x0487DB9D, 0x17636892), /* ~= 10^138 */
-    U64(0xD6F8D750, 0x9292D603), U64(0x45A9D284, 0x5D3C42B6), /* ~= 10^139 */
-    U64(0x865B8692, 0x5B9BC5C2), U64(0x0B8A2392, 0xBA45A9B2), /* ~= 10^140 */
-    U64(0xA7F26836, 0xF282B732), U64(0x8E6CAC77, 0x68D7141E), /* ~= 10^141 */
-    U64(0xD1EF0244, 0xAF2364FF), U64(0x3207D795, 0x430CD926), /* ~= 10^142 */
-    U64(0x8335616A, 0xED761F1F), U64(0x7F44E6BD, 0x49E807B8), /* ~= 10^143 */
-    U64(0xA402B9C5, 0xA8D3A6E7), U64(0x5F16206C, 0x9C6209A6), /* ~= 10^144 */
-    U64(0xCD036837, 0x130890A1), U64(0x36DBA887, 0xC37A8C0F), /* ~= 10^145 */
-    U64(0x80222122, 0x6BE55A64), U64(0xC2494954, 0xDA2C9789), /* ~= 10^146 */
-    U64(0xA02AA96B, 0x06DEB0FD), U64(0xF2DB9BAA, 0x10B7BD6C), /* ~= 10^147 */
-    U64(0xC83553C5, 0xC8965D3D), U64(0x6F928294, 0x94E5ACC7), /* ~= 10^148 */
-    U64(0xFA42A8B7, 0x3ABBF48C), U64(0xCB772339, 0xBA1F17F9), /* ~= 10^149 */
-    U64(0x9C69A972, 0x84B578D7), U64(0xFF2A7604, 0x14536EFB), /* ~= 10^150 */
-    U64(0xC38413CF, 0x25E2D70D), U64(0xFEF51385, 0x19684ABA), /* ~= 10^151 */
-    U64(0xF46518C2, 0xEF5B8CD1), U64(0x7EB25866, 0x5FC25D69), /* ~= 10^152 */
-    U64(0x98BF2F79, 0xD5993802), U64(0xEF2F773F, 0xFBD97A61), /* ~= 10^153 */
-    U64(0xBEEEFB58, 0x4AFF8603), U64(0xAAFB550F, 0xFACFD8FA), /* ~= 10^154 */
-    U64(0xEEAABA2E, 0x5DBF6784), U64(0x95BA2A53, 0xF983CF38), /* ~= 10^155 */
-    U64(0x952AB45C, 0xFA97A0B2), U64(0xDD945A74, 0x7BF26183), /* ~= 10^156 */
-    U64(0xBA756174, 0x393D88DF), U64(0x94F97111, 0x9AEEF9E4), /* ~= 10^157 */
-    U64(0xE912B9D1, 0x478CEB17), U64(0x7A37CD56, 0x01AAB85D), /* ~= 10^158 */
-    U64(0x91ABB422, 0xCCB812EE), U64(0xAC62E055, 0xC10AB33A), /* ~= 10^159 */
-    U64(0xB616A12B, 0x7FE617AA), U64(0x577B986B, 0x314D6009), /* ~= 10^160 */
-    U64(0xE39C4976, 0x5FDF9D94), U64(0xED5A7E85, 0xFDA0B80B), /* ~= 10^161 */
-    U64(0x8E41ADE9, 0xFBEBC27D), U64(0x14588F13, 0xBE847307), /* ~= 10^162 */
-    U64(0xB1D21964, 0x7AE6B31C), U64(0x596EB2D8, 0xAE258FC8), /* ~= 10^163 */
-    U64(0xDE469FBD, 0x99A05FE3), U64(0x6FCA5F8E, 0xD9AEF3BB), /* ~= 10^164 */
-    U64(0x8AEC23D6, 0x80043BEE), U64(0x25DE7BB9, 0x480D5854), /* ~= 10^165 */
-    U64(0xADA72CCC, 0x20054AE9), U64(0xAF561AA7, 0x9A10AE6A), /* ~= 10^166 */
-    U64(0xD910F7FF, 0x28069DA4), U64(0x1B2BA151, 0x8094DA04), /* ~= 10^167 */
-    U64(0x87AA9AFF, 0x79042286), U64(0x90FB44D2, 0xF05D0842), /* ~= 10^168 */
-    U64(0xA99541BF, 0x57452B28), U64(0x353A1607, 0xAC744A53), /* ~= 10^169 */
-    U64(0xD3FA922F, 0x2D1675F2), U64(0x42889B89, 0x97915CE8), /* ~= 10^170 */
-    U64(0x847C9B5D, 0x7C2E09B7), U64(0x69956135, 0xFEBADA11), /* ~= 10^171 */
-    U64(0xA59BC234, 0xDB398C25), U64(0x43FAB983, 0x7E699095), /* ~= 10^172 */
-    U64(0xCF02B2C2, 0x1207EF2E), U64(0x94F967E4, 0x5E03F4BB), /* ~= 10^173 */
-    U64(0x8161AFB9, 0x4B44F57D), U64(0x1D1BE0EE, 0xBAC278F5), /* ~= 10^174 */
-    U64(0xA1BA1BA7, 0x9E1632DC), U64(0x6462D92A, 0x69731732), /* ~= 10^175 */
-    U64(0xCA28A291, 0x859BBF93), U64(0x7D7B8F75, 0x03CFDCFE), /* ~= 10^176 */
-    U64(0xFCB2CB35, 0xE702AF78), U64(0x5CDA7352, 0x44C3D43E), /* ~= 10^177 */
-    U64(0x9DEFBF01, 0xB061ADAB), U64(0x3A088813, 0x6AFA64A7), /* ~= 10^178 */
-    U64(0xC56BAEC2, 0x1C7A1916), U64(0x088AAA18, 0x45B8FDD0), /* ~= 10^179 */
-    U64(0xF6C69A72, 0xA3989F5B), U64(0x8AAD549E, 0x57273D45), /* ~= 10^180 */
-    U64(0x9A3C2087, 0xA63F6399), U64(0x36AC54E2, 0xF678864B), /* ~= 10^181 */
-    U64(0xC0CB28A9, 0x8FCF3C7F), U64(0x84576A1B, 0xB416A7DD), /* ~= 10^182 */
-    U64(0xF0FDF2D3, 0xF3C30B9F), U64(0x656D44A2, 0xA11C51D5), /* ~= 10^183 */
-    U64(0x969EB7C4, 0x7859E743), U64(0x9F644AE5, 0xA4B1B325), /* ~= 10^184 */
-    U64(0xBC4665B5, 0x96706114), U64(0x873D5D9F, 0x0DDE1FEE), /* ~= 10^185 */
-    U64(0xEB57FF22, 0xFC0C7959), U64(0xA90CB506, 0xD155A7EA), /* ~= 10^186 */
-    U64(0x9316FF75, 0xDD87CBD8), U64(0x09A7F124, 0x42D588F2), /* ~= 10^187 */
-    U64(0xB7DCBF53, 0x54E9BECE), U64(0x0C11ED6D, 0x538AEB2F), /* ~= 10^188 */
-    U64(0xE5D3EF28, 0x2A242E81), U64(0x8F1668C8, 0xA86DA5FA), /* ~= 10^189 */
-    U64(0x8FA47579, 0x1A569D10), U64(0xF96E017D, 0x694487BC), /* ~= 10^190 */
-    U64(0xB38D92D7, 0x60EC4455), U64(0x37C981DC, 0xC395A9AC), /* ~= 10^191 */
-    U64(0xE070F78D, 0x3927556A), U64(0x85BBE253, 0xF47B1417), /* ~= 10^192 */
-    U64(0x8C469AB8, 0x43B89562), U64(0x93956D74, 0x78CCEC8E), /* ~= 10^193 */
-    U64(0xAF584166, 0x54A6BABB), U64(0x387AC8D1, 0x970027B2), /* ~= 10^194 */
-    U64(0xDB2E51BF, 0xE9D0696A), U64(0x06997B05, 0xFCC0319E), /* ~= 10^195 */
-    U64(0x88FCF317, 0xF22241E2), U64(0x441FECE3, 0xBDF81F03), /* ~= 10^196 */
-    U64(0xAB3C2FDD, 0xEEAAD25A), U64(0xD527E81C, 0xAD7626C3), /* ~= 10^197 */
-    U64(0xD60B3BD5, 0x6A5586F1), U64(0x8A71E223, 0xD8D3B074), /* ~= 10^198 */
-    U64(0x85C70565, 0x62757456), U64(0xF6872D56, 0x67844E49), /* ~= 10^199 */
-    U64(0xA738C6BE, 0xBB12D16C), U64(0xB428F8AC, 0x016561DB), /* ~= 10^200 */
-    U64(0xD106F86E, 0x69D785C7), U64(0xE13336D7, 0x01BEBA52), /* ~= 10^201 */
-    U64(0x82A45B45, 0x0226B39C), U64(0xECC00246, 0x61173473), /* ~= 10^202 */
-    U64(0xA34D7216, 0x42B06084), U64(0x27F002D7, 0xF95D0190), /* ~= 10^203 */
-    U64(0xCC20CE9B, 0xD35C78A5), U64(0x31EC038D, 0xF7B441F4), /* ~= 10^204 */
-    U64(0xFF290242, 0xC83396CE), U64(0x7E670471, 0x75A15271), /* ~= 10^205 */
-    U64(0x9F79A169, 0xBD203E41), U64(0x0F0062C6, 0xE984D386), /* ~= 10^206 */
-    U64(0xC75809C4, 0x2C684DD1), U64(0x52C07B78, 0xA3E60868), /* ~= 10^207 */
-    U64(0xF92E0C35, 0x37826145), U64(0xA7709A56, 0xCCDF8A82), /* ~= 10^208 */
-    U64(0x9BBCC7A1, 0x42B17CCB), U64(0x88A66076, 0x400BB691), /* ~= 10^209 */
-    U64(0xC2ABF989, 0x935DDBFE), U64(0x6ACFF893, 0xD00EA435), /* ~= 10^210 */
-    U64(0xF356F7EB, 0xF83552FE), U64(0x0583F6B8, 0xC4124D43), /* ~= 10^211 */
-    U64(0x98165AF3, 0x7B2153DE), U64(0xC3727A33, 0x7A8B704A), /* ~= 10^212 */
-    U64(0xBE1BF1B0, 0x59E9A8D6), U64(0x744F18C0, 0x592E4C5C), /* ~= 10^213 */
-    U64(0xEDA2EE1C, 0x7064130C), U64(0x1162DEF0, 0x6F79DF73), /* ~= 10^214 */
-    U64(0x9485D4D1, 0xC63E8BE7), U64(0x8ADDCB56, 0x45AC2BA8), /* ~= 10^215 */
-    U64(0xB9A74A06, 0x37CE2EE1), U64(0x6D953E2B, 0xD7173692), /* ~= 10^216 */
-    U64(0xE8111C87, 0xC5C1BA99), U64(0xC8FA8DB6, 0xCCDD0437), /* ~= 10^217 */
-    U64(0x910AB1D4, 0xDB9914A0), U64(0x1D9C9892, 0x400A22A2), /* ~= 10^218 */
-    U64(0xB54D5E4A, 0x127F59C8), U64(0x2503BEB6, 0xD00CAB4B), /* ~= 10^219 */
-    U64(0xE2A0B5DC, 0x971F303A), U64(0x2E44AE64, 0x840FD61D), /* ~= 10^220 */
-    U64(0x8DA471A9, 0xDE737E24), U64(0x5CEAECFE, 0xD289E5D2), /* ~= 10^221 */
-    U64(0xB10D8E14, 0x56105DAD), U64(0x7425A83E, 0x872C5F47), /* ~= 10^222 */
-    U64(0xDD50F199, 0x6B947518), U64(0xD12F124E, 0x28F77719), /* ~= 10^223 */
-    U64(0x8A5296FF, 0xE33CC92F), U64(0x82BD6B70, 0xD99AAA6F), /* ~= 10^224 */
-    U64(0xACE73CBF, 0xDC0BFB7B), U64(0x636CC64D, 0x1001550B), /* ~= 10^225 */
-    U64(0xD8210BEF, 0xD30EFA5A), U64(0x3C47F7E0, 0x5401AA4E), /* ~= 10^226 */
-    U64(0x8714A775, 0xE3E95C78), U64(0x65ACFAEC, 0x34810A71), /* ~= 10^227 */
-    U64(0xA8D9D153, 0x5CE3B396), U64(0x7F1839A7, 0x41A14D0D), /* ~= 10^228 */
-    U64(0xD31045A8, 0x341CA07C), U64(0x1EDE4811, 0x1209A050), /* ~= 10^229 */
-    U64(0x83EA2B89, 0x2091E44D), U64(0x934AED0A, 0xAB460432), /* ~= 10^230 */
-    U64(0xA4E4B66B, 0x68B65D60), U64(0xF81DA84D, 0x5617853F), /* ~= 10^231 */
-    U64(0xCE1DE406, 0x42E3F4B9), U64(0x36251260, 0xAB9D668E), /* ~= 10^232 */
-    U64(0x80D2AE83, 0xE9CE78F3), U64(0xC1D72B7C, 0x6B426019), /* ~= 10^233 */
-    U64(0xA1075A24, 0xE4421730), U64(0xB24CF65B, 0x8612F81F), /* ~= 10^234 */
-    U64(0xC94930AE, 0x1D529CFC), U64(0xDEE033F2, 0x6797B627), /* ~= 10^235 */
-    U64(0xFB9B7CD9, 0xA4A7443C), U64(0x169840EF, 0x017DA3B1), /* ~= 10^236 */
-    U64(0x9D412E08, 0x06E88AA5), U64(0x8E1F2895, 0x60EE864E), /* ~= 10^237 */
-    U64(0xC491798A, 0x08A2AD4E), U64(0xF1A6F2BA, 0xB92A27E2), /* ~= 10^238 */
-    U64(0xF5B5D7EC, 0x8ACB58A2), U64(0xAE10AF69, 0x6774B1DB), /* ~= 10^239 */
-    U64(0x9991A6F3, 0xD6BF1765), U64(0xACCA6DA1, 0xE0A8EF29), /* ~= 10^240 */
-    U64(0xBFF610B0, 0xCC6EDD3F), U64(0x17FD090A, 0x58D32AF3), /* ~= 10^241 */
-    U64(0xEFF394DC, 0xFF8A948E), U64(0xDDFC4B4C, 0xEF07F5B0), /* ~= 10^242 */
-    U64(0x95F83D0A, 0x1FB69CD9), U64(0x4ABDAF10, 0x1564F98E), /* ~= 10^243 */
-    U64(0xBB764C4C, 0xA7A4440F), U64(0x9D6D1AD4, 0x1ABE37F1), /* ~= 10^244 */
-    U64(0xEA53DF5F, 0xD18D5513), U64(0x84C86189, 0x216DC5ED), /* ~= 10^245 */
-    U64(0x92746B9B, 0xE2F8552C), U64(0x32FD3CF5, 0xB4E49BB4), /* ~= 10^246 */
-    U64(0xB7118682, 0xDBB66A77), U64(0x3FBC8C33, 0x221DC2A1), /* ~= 10^247 */
-    U64(0xE4D5E823, 0x92A40515), U64(0x0FABAF3F, 0xEAA5334A), /* ~= 10^248 */
-    U64(0x8F05B116, 0x3BA6832D), U64(0x29CB4D87, 0xF2A7400E), /* ~= 10^249 */
-    U64(0xB2C71D5B, 0xCA9023F8), U64(0x743E20E9, 0xEF511012), /* ~= 10^250 */
-    U64(0xDF78E4B2, 0xBD342CF6), U64(0x914DA924, 0x6B255416), /* ~= 10^251 */
-    U64(0x8BAB8EEF, 0xB6409C1A), U64(0x1AD089B6, 0xC2F7548E), /* ~= 10^252 */
-    U64(0xAE9672AB, 0xA3D0C320), U64(0xA184AC24, 0x73B529B1), /* ~= 10^253 */
-    U64(0xDA3C0F56, 0x8CC4F3E8), U64(0xC9E5D72D, 0x90A2741E), /* ~= 10^254 */
-    U64(0x88658996, 0x17FB1871), U64(0x7E2FA67C, 0x7A658892), /* ~= 10^255 */
-    U64(0xAA7EEBFB, 0x9DF9DE8D), U64(0xDDBB901B, 0x98FEEAB7), /* ~= 10^256 */
-    U64(0xD51EA6FA, 0x85785631), U64(0x552A7422, 0x7F3EA565), /* ~= 10^257 */
-    U64(0x8533285C, 0x936B35DE), U64(0xD53A8895, 0x8F87275F), /* ~= 10^258 */
-    U64(0xA67FF273, 0xB8460356), U64(0x8A892ABA, 0xF368F137), /* ~= 10^259 */
-    U64(0xD01FEF10, 0xA657842C), U64(0x2D2B7569, 0xB0432D85), /* ~= 10^260 */
-    U64(0x8213F56A, 0x67F6B29B), U64(0x9C3B2962, 0x0E29FC73), /* ~= 10^261 */
-    U64(0xA298F2C5, 0x01F45F42), U64(0x8349F3BA, 0x91B47B8F), /* ~= 10^262 */
-    U64(0xCB3F2F76, 0x42717713), U64(0x241C70A9, 0x36219A73), /* ~= 10^263 */
-    U64(0xFE0EFB53, 0xD30DD4D7), U64(0xED238CD3, 0x83AA0110), /* ~= 10^264 */
-    U64(0x9EC95D14, 0x63E8A506), U64(0xF4363804, 0x324A40AA), /* ~= 10^265 */
-    U64(0xC67BB459, 0x7CE2CE48), U64(0xB143C605, 0x3EDCD0D5), /* ~= 10^266 */
-    U64(0xF81AA16F, 0xDC1B81DA), U64(0xDD94B786, 0x8E94050A), /* ~= 10^267 */
-    U64(0x9B10A4E5, 0xE9913128), U64(0xCA7CF2B4, 0x191C8326), /* ~= 10^268 */
-    U64(0xC1D4CE1F, 0x63F57D72), U64(0xFD1C2F61, 0x1F63A3F0), /* ~= 10^269 */
-    U64(0xF24A01A7, 0x3CF2DCCF), U64(0xBC633B39, 0x673C8CEC), /* ~= 10^270 */
-    U64(0x976E4108, 0x8617CA01), U64(0xD5BE0503, 0xE085D813), /* ~= 10^271 */
-    U64(0xBD49D14A, 0xA79DBC82), U64(0x4B2D8644, 0xD8A74E18), /* ~= 10^272 */
-    U64(0xEC9C459D, 0x51852BA2), U64(0xDDF8E7D6, 0x0ED1219E), /* ~= 10^273 */
-    U64(0x93E1AB82, 0x52F33B45), U64(0xCABB90E5, 0xC942B503), /* ~= 10^274 */
-    U64(0xB8DA1662, 0xE7B00A17), U64(0x3D6A751F, 0x3B936243), /* ~= 10^275 */
-    U64(0xE7109BFB, 0xA19C0C9D), U64(0x0CC51267, 0x0A783AD4), /* ~= 10^276 */
-    U64(0x906A617D, 0x450187E2), U64(0x27FB2B80, 0x668B24C5), /* ~= 10^277 */
-    U64(0xB484F9DC, 0x9641E9DA), U64(0xB1F9F660, 0x802DEDF6), /* ~= 10^278 */
-    U64(0xE1A63853, 0xBBD26451), U64(0x5E7873F8, 0xA0396973), /* ~= 10^279 */
-    U64(0x8D07E334, 0x55637EB2), U64(0xDB0B487B, 0x6423E1E8), /* ~= 10^280 */
-    U64(0xB049DC01, 0x6ABC5E5F), U64(0x91CE1A9A, 0x3D2CDA62), /* ~= 10^281 */
-    U64(0xDC5C5301, 0xC56B75F7), U64(0x7641A140, 0xCC7810FB), /* ~= 10^282 */
-    U64(0x89B9B3E1, 0x1B6329BA), U64(0xA9E904C8, 0x7FCB0A9D), /* ~= 10^283 */
-    U64(0xAC2820D9, 0x623BF429), U64(0x546345FA, 0x9FBDCD44), /* ~= 10^284 */
-    U64(0xD732290F, 0xBACAF133), U64(0xA97C1779, 0x47AD4095), /* ~= 10^285 */
-    U64(0x867F59A9, 0xD4BED6C0), U64(0x49ED8EAB, 0xCCCC485D), /* ~= 10^286 */
-    U64(0xA81F3014, 0x49EE8C70), U64(0x5C68F256, 0xBFFF5A74), /* ~= 10^287 */
-    U64(0xD226FC19, 0x5C6A2F8C), U64(0x73832EEC, 0x6FFF3111), /* ~= 10^288 */
-    U64(0x83585D8F, 0xD9C25DB7), U64(0xC831FD53, 0xC5FF7EAB), /* ~= 10^289 */
-    U64(0xA42E74F3, 0xD032F525), U64(0xBA3E7CA8, 0xB77F5E55), /* ~= 10^290 */
-    U64(0xCD3A1230, 0xC43FB26F), U64(0x28CE1BD2, 0xE55F35EB), /* ~= 10^291 */
-    U64(0x80444B5E, 0x7AA7CF85), U64(0x7980D163, 0xCF5B81B3), /* ~= 10^292 */
-    U64(0xA0555E36, 0x1951C366), U64(0xD7E105BC, 0xC332621F), /* ~= 10^293 */
-    U64(0xC86AB5C3, 0x9FA63440), U64(0x8DD9472B, 0xF3FEFAA7), /* ~= 10^294 */
-    U64(0xFA856334, 0x878FC150), U64(0xB14F98F6, 0xF0FEB951), /* ~= 10^295 */
-    U64(0x9C935E00, 0xD4B9D8D2), U64(0x6ED1BF9A, 0x569F33D3), /* ~= 10^296 */
-    U64(0xC3B83581, 0x09E84F07), U64(0x0A862F80, 0xEC4700C8), /* ~= 10^297 */
-    U64(0xF4A642E1, 0x4C6262C8), U64(0xCD27BB61, 0x2758C0FA), /* ~= 10^298 */
-    U64(0x98E7E9CC, 0xCFBD7DBD), U64(0x8038D51C, 0xB897789C), /* ~= 10^299 */
-    U64(0xBF21E440, 0x03ACDD2C), U64(0xE0470A63, 0xE6BD56C3), /* ~= 10^300 */
-    U64(0xEEEA5D50, 0x04981478), U64(0x1858CCFC, 0xE06CAC74), /* ~= 10^301 */
-    U64(0x95527A52, 0x02DF0CCB), U64(0x0F37801E, 0x0C43EBC8), /* ~= 10^302 */
-    U64(0xBAA718E6, 0x8396CFFD), U64(0xD3056025, 0x8F54E6BA), /* ~= 10^303 */
-    U64(0xE950DF20, 0x247C83FD), U64(0x47C6B82E, 0xF32A2069), /* ~= 10^304 */
-    U64(0x91D28B74, 0x16CDD27E), U64(0x4CDC331D, 0x57FA5441), /* ~= 10^305 */
-    U64(0xB6472E51, 0x1C81471D), U64(0xE0133FE4, 0xADF8E952), /* ~= 10^306 */
-    U64(0xE3D8F9E5, 0x63A198E5), U64(0x58180FDD, 0xD97723A6), /* ~= 10^307 */
-    U64(0x8E679C2F, 0x5E44FF8F), U64(0x570F09EA, 0xA7EA7648), /* ~= 10^308 */
-    U64(0xB201833B, 0x35D63F73), U64(0x2CD2CC65, 0x51E513DA), /* ~= 10^309 */
-    U64(0xDE81E40A, 0x034BCF4F), U64(0xF8077F7E, 0xA65E58D1), /* ~= 10^310 */
-    U64(0x8B112E86, 0x420F6191), U64(0xFB04AFAF, 0x27FAF782), /* ~= 10^311 */
-    U64(0xADD57A27, 0xD29339F6), U64(0x79C5DB9A, 0xF1F9B563), /* ~= 10^312 */
-    U64(0xD94AD8B1, 0xC7380874), U64(0x18375281, 0xAE7822BC), /* ~= 10^313 */
-    U64(0x87CEC76F, 0x1C830548), U64(0x8F229391, 0x0D0B15B5), /* ~= 10^314 */
-    U64(0xA9C2794A, 0xE3A3C69A), U64(0xB2EB3875, 0x504DDB22), /* ~= 10^315 */
-    U64(0xD433179D, 0x9C8CB841), U64(0x5FA60692, 0xA46151EB), /* ~= 10^316 */
-    U64(0x849FEEC2, 0x81D7F328), U64(0xDBC7C41B, 0xA6BCD333), /* ~= 10^317 */
-    U64(0xA5C7EA73, 0x224DEFF3), U64(0x12B9B522, 0x906C0800), /* ~= 10^318 */
-    U64(0xCF39E50F, 0xEAE16BEF), U64(0xD768226B, 0x34870A00), /* ~= 10^319 */
-    U64(0x81842F29, 0xF2CCE375), U64(0xE6A11583, 0x00D46640), /* ~= 10^320 */
-    U64(0xA1E53AF4, 0x6F801C53), U64(0x60495AE3, 0xC1097FD0), /* ~= 10^321 */
-    U64(0xCA5E89B1, 0x8B602368), U64(0x385BB19C, 0xB14BDFC4), /* ~= 10^322 */
-    U64(0xFCF62C1D, 0xEE382C42), U64(0x46729E03, 0xDD9ED7B5), /* ~= 10^323 */
-    U64(0x9E19DB92, 0xB4E31BA9), U64(0x6C07A2C2, 0x6A8346D1)  /* ~= 10^324 */
+    U64 (0xBF29DCAB, 0xA82FDEAE), U64 (0x7432EE87, 0x3880FC33), /* ~= 10^-343 */
+    U64 (0xEEF453D6, 0x923BD65A), U64 (0x113FAA29, 0x06A13B3F), /* ~= 10^-342 */
+    U64 (0x9558B466, 0x1B6565F8), U64 (0x4AC7CA59, 0xA424C507), /* ~= 10^-341 */
+    U64 (0xBAAEE17F, 0xA23EBF76), U64 (0x5D79BCF0, 0x0D2DF649), /* ~= 10^-340 */
+    U64 (0xE95A99DF, 0x8ACE6F53), U64 (0xF4D82C2C, 0x107973DC), /* ~= 10^-339 */
+    U64 (0x91D8A02B, 0xB6C10594), U64 (0x79071B9B, 0x8A4BE869), /* ~= 10^-338 */
+    U64 (0xB64EC836, 0xA47146F9), U64 (0x9748E282, 0x6CDEE284), /* ~= 10^-337 */
+    U64 (0xE3E27A44, 0x4D8D98B7), U64 (0xFD1B1B23, 0x08169B25), /* ~= 10^-336 */
+    U64 (0x8E6D8C6A, 0xB0787F72), U64 (0xFE30F0F5, 0xE50E20F7), /* ~= 10^-335 */
+    U64 (0xB208EF85, 0x5C969F4F), U64 (0xBDBD2D33, 0x5E51A935), /* ~= 10^-334 */
+    U64 (0xDE8B2B66, 0xB3BC4723), U64 (0xAD2C7880, 0x35E61382), /* ~= 10^-333 */
+    U64 (0x8B16FB20, 0x3055AC76), U64 (0x4C3BCB50, 0x21AFCC31), /* ~= 10^-332 */
+    U64 (0xADDCB9E8, 0x3C6B1793), U64 (0xDF4ABE24, 0x2A1BBF3D), /* ~= 10^-331 */
+    U64 (0xD953E862, 0x4B85DD78), U64 (0xD71D6DAD, 0x34A2AF0D), /* ~= 10^-330 */
+    U64 (0x87D4713D, 0x6F33AA6B), U64 (0x8672648C, 0x40E5AD68), /* ~= 10^-329 */
+    U64 (0xA9C98D8C, 0xCB009506), U64 (0x680EFDAF, 0x511F18C2), /* ~= 10^-328 */
+    U64 (0xD43BF0EF, 0xFDC0BA48), U64 (0x0212BD1B, 0x2566DEF2), /* ~= 10^-327 */
+    U64 (0x84A57695, 0xFE98746D), U64 (0x014BB630, 0xF7604B57), /* ~= 10^-326 */
+    U64 (0xA5CED43B, 0x7E3E9188), U64 (0x419EA3BD, 0x35385E2D), /* ~= 10^-325 */
+    U64 (0xCF42894A, 0x5DCE35EA), U64 (0x52064CAC, 0x828675B9), /* ~= 10^-324 */
+    U64 (0x818995CE, 0x7AA0E1B2), U64 (0x7343EFEB, 0xD1940993), /* ~= 10^-323 */
+    U64 (0xA1EBFB42, 0x19491A1F), U64 (0x1014EBE6, 0xC5F90BF8), /* ~= 10^-322 */
+    U64 (0xCA66FA12, 0x9F9B60A6), U64 (0xD41A26E0, 0x77774EF6), /* ~= 10^-321 */
+    U64 (0xFD00B897, 0x478238D0), U64 (0x8920B098, 0x955522B4), /* ~= 10^-320 */
+    U64 (0x9E20735E, 0x8CB16382), U64 (0x55B46E5F, 0x5D5535B0), /* ~= 10^-319 */
+    U64 (0xC5A89036, 0x2FDDBC62), U64 (0xEB2189F7, 0x34AA831D), /* ~= 10^-318 */
+    U64 (0xF712B443, 0xBBD52B7B), U64 (0xA5E9EC75, 0x01D523E4), /* ~= 10^-317 */
+    U64 (0x9A6BB0AA, 0x55653B2D), U64 (0x47B233C9, 0x2125366E), /* ~= 10^-316 */
+    U64 (0xC1069CD4, 0xEABE89F8), U64 (0x999EC0BB, 0x696E840A), /* ~= 10^-315 */
+    U64 (0xF148440A, 0x256E2C76), U64 (0xC00670EA, 0x43CA250D), /* ~= 10^-314 */
+    U64 (0x96CD2A86, 0x5764DBCA), U64 (0x38040692, 0x6A5E5728), /* ~= 10^-313 */
+    U64 (0xBC807527, 0xED3E12BC), U64 (0xC6050837, 0x04F5ECF2), /* ~= 10^-312 */
+    U64 (0xEBA09271, 0xE88D976B), U64 (0xF7864A44, 0xC633682E), /* ~= 10^-311 */
+    U64 (0x93445B87, 0x31587EA3), U64 (0x7AB3EE6A, 0xFBE0211D), /* ~= 10^-310 */
+    U64 (0xB8157268, 0xFDAE9E4C), U64 (0x5960EA05, 0xBAD82964), /* ~= 10^-309 */
+    U64 (0xE61ACF03, 0x3D1A45DF), U64 (0x6FB92487, 0x298E33BD), /* ~= 10^-308 */
+    U64 (0x8FD0C162, 0x06306BAB), U64 (0xA5D3B6D4, 0x79F8E056), /* ~= 10^-307 */
+    U64 (0xB3C4F1BA, 0x87BC8696), U64 (0x8F48A489, 0x9877186C), /* ~= 10^-306 */
+    U64 (0xE0B62E29, 0x29ABA83C), U64 (0x331ACDAB, 0xFE94DE87), /* ~= 10^-305 */
+    U64 (0x8C71DCD9, 0xBA0B4925), U64 (0x9FF0C08B, 0x7F1D0B14), /* ~= 10^-304 */
+    U64 (0xAF8E5410, 0x288E1B6F), U64 (0x07ECF0AE, 0x5EE44DD9), /* ~= 10^-303 */
+    U64 (0xDB71E914, 0x32B1A24A), U64 (0xC9E82CD9, 0xF69D6150), /* ~= 10^-302 */
+    U64 (0x892731AC, 0x9FAF056E), U64 (0xBE311C08, 0x3A225CD2), /* ~= 10^-301 */
+    U64 (0xAB70FE17, 0xC79AC6CA), U64 (0x6DBD630A, 0x48AAF406), /* ~= 10^-300 */
+    U64 (0xD64D3D9D, 0xB981787D), U64 (0x092CBBCC, 0xDAD5B108), /* ~= 10^-299 */
+    U64 (0x85F04682, 0x93F0EB4E), U64 (0x25BBF560, 0x08C58EA5), /* ~= 10^-298 */
+    U64 (0xA76C5823, 0x38ED2621), U64 (0xAF2AF2B8, 0x0AF6F24E), /* ~= 10^-297 */
+    U64 (0xD1476E2C, 0x07286FAA), U64 (0x1AF5AF66, 0x0DB4AEE1), /* ~= 10^-296 */
+    U64 (0x82CCA4DB, 0x847945CA), U64 (0x50D98D9F, 0xC890ED4D), /* ~= 10^-295 */
+    U64 (0xA37FCE12, 0x6597973C), U64 (0xE50FF107, 0xBAB528A0), /* ~= 10^-294 */
+    U64 (0xCC5FC196, 0xFEFD7D0C), U64 (0x1E53ED49, 0xA96272C8), /* ~= 10^-293 */
+    U64 (0xFF77B1FC, 0xBEBCDC4F), U64 (0x25E8E89C, 0x13BB0F7A), /* ~= 10^-292 */
+    U64 (0x9FAACF3D, 0xF73609B1), U64 (0x77B19161, 0x8C54E9AC), /* ~= 10^-291 */
+    U64 (0xC795830D, 0x75038C1D), U64 (0xD59DF5B9, 0xEF6A2417), /* ~= 10^-290 */
+    U64 (0xF97AE3D0, 0xD2446F25), U64 (0x4B057328, 0x6B44AD1D), /* ~= 10^-289 */
+    U64 (0x9BECCE62, 0x836AC577), U64 (0x4EE367F9, 0x430AEC32), /* ~= 10^-288 */
+    U64 (0xC2E801FB, 0x244576D5), U64 (0x229C41F7, 0x93CDA73F), /* ~= 10^-287 */
+    U64 (0xF3A20279, 0xED56D48A), U64 (0x6B435275, 0x78C1110F), /* ~= 10^-286 */
+    U64 (0x9845418C, 0x345644D6), U64 (0x830A1389, 0x6B78AAA9), /* ~= 10^-285 */
+    U64 (0xBE5691EF, 0x416BD60C), U64 (0x23CC986B, 0xC656D553), /* ~= 10^-284 */
+    U64 (0xEDEC366B, 0x11C6CB8F), U64 (0x2CBFBE86, 0xB7EC8AA8), /* ~= 10^-283 */
+    U64 (0x94B3A202, 0xEB1C3F39), U64 (0x7BF7D714, 0x32F3D6A9), /* ~= 10^-282 */
+    U64 (0xB9E08A83, 0xA5E34F07), U64 (0xDAF5CCD9, 0x3FB0CC53), /* ~= 10^-281 */
+    U64 (0xE858AD24, 0x8F5C22C9), U64 (0xD1B3400F, 0x8F9CFF68), /* ~= 10^-280 */
+    U64 (0x91376C36, 0xD99995BE), U64 (0x23100809, 0xB9C21FA1), /* ~= 10^-279 */
+    U64 (0xB5854744, 0x8FFFFB2D), U64 (0xABD40A0C, 0x2832A78A), /* ~= 10^-278 */
+    U64 (0xE2E69915, 0xB3FFF9F9), U64 (0x16C90C8F, 0x323F516C), /* ~= 10^-277 */
+    U64 (0x8DD01FAD, 0x907FFC3B), U64 (0xAE3DA7D9, 0x7F6792E3), /* ~= 10^-276 */
+    U64 (0xB1442798, 0xF49FFB4A), U64 (0x99CD11CF, 0xDF41779C), /* ~= 10^-275 */
+    U64 (0xDD95317F, 0x31C7FA1D), U64 (0x40405643, 0xD711D583), /* ~= 10^-274 */
+    U64 (0x8A7D3EEF, 0x7F1CFC52), U64 (0x482835EA, 0x666B2572), /* ~= 10^-273 */
+    U64 (0xAD1C8EAB, 0x5EE43B66), U64 (0xDA324365, 0x0005EECF), /* ~= 10^-272 */
+    U64 (0xD863B256, 0x369D4A40), U64 (0x90BED43E, 0x40076A82), /* ~= 10^-271 */
+    U64 (0x873E4F75, 0xE2224E68), U64 (0x5A7744A6, 0xE804A291), /* ~= 10^-270 */
+    U64 (0xA90DE353, 0x5AAAE202), U64 (0x711515D0, 0xA205CB36), /* ~= 10^-269 */
+    U64 (0xD3515C28, 0x31559A83), U64 (0x0D5A5B44, 0xCA873E03), /* ~= 10^-268 */
+    U64 (0x8412D999, 0x1ED58091), U64 (0xE858790A, 0xFE9486C2), /* ~= 10^-267 */
+    U64 (0xA5178FFF, 0x668AE0B6), U64 (0x626E974D, 0xBE39A872), /* ~= 10^-266 */
+    U64 (0xCE5D73FF, 0x402D98E3), U64 (0xFB0A3D21, 0x2DC8128F), /* ~= 10^-265 */
+    U64 (0x80FA687F, 0x881C7F8E), U64 (0x7CE66634, 0xBC9D0B99), /* ~= 10^-264 */
+    U64 (0xA139029F, 0x6A239F72), U64 (0x1C1FFFC1, 0xEBC44E80), /* ~= 10^-263 */
+    U64 (0xC9874347, 0x44AC874E), U64 (0xA327FFB2, 0x66B56220), /* ~= 10^-262 */
+    U64 (0xFBE91419, 0x15D7A922), U64 (0x4BF1FF9F, 0x0062BAA8), /* ~= 10^-261 */
+    U64 (0x9D71AC8F, 0xADA6C9B5), U64 (0x6F773FC3, 0x603DB4A9), /* ~= 10^-260 */
+    U64 (0xC4CE17B3, 0x99107C22), U64 (0xCB550FB4, 0x384D21D3), /* ~= 10^-259 */
+    U64 (0xF6019DA0, 0x7F549B2B), U64 (0x7E2A53A1, 0x46606A48), /* ~= 10^-258 */
+    U64 (0x99C10284, 0x4F94E0FB), U64 (0x2EDA7444, 0xCBFC426D), /* ~= 10^-257 */
+    U64 (0xC0314325, 0x637A1939), U64 (0xFA911155, 0xFEFB5308), /* ~= 10^-256 */
+    U64 (0xF03D93EE, 0xBC589F88), U64 (0x793555AB, 0x7EBA27CA), /* ~= 10^-255 */
+    U64 (0x96267C75, 0x35B763B5), U64 (0x4BC1558B, 0x2F3458DE), /* ~= 10^-254 */
+    U64 (0xBBB01B92, 0x83253CA2), U64 (0x9EB1AAED, 0xFB016F16), /* ~= 10^-253 */
+    U64 (0xEA9C2277, 0x23EE8BCB), U64 (0x465E15A9, 0x79C1CADC), /* ~= 10^-252 */
+    U64 (0x92A1958A, 0x7675175F), U64 (0x0BFACD89, 0xEC191EC9), /* ~= 10^-251 */
+    U64 (0xB749FAED, 0x14125D36), U64 (0xCEF980EC, 0x671F667B), /* ~= 10^-250 */
+    U64 (0xE51C79A8, 0x5916F484), U64 (0x82B7E127, 0x80E7401A), /* ~= 10^-249 */
+    U64 (0x8F31CC09, 0x37AE58D2), U64 (0xD1B2ECB8, 0xB0908810), /* ~= 10^-248 */
+    U64 (0xB2FE3F0B, 0x8599EF07), U64 (0x861FA7E6, 0xDCB4AA15), /* ~= 10^-247 */
+    U64 (0xDFBDCECE, 0x67006AC9), U64 (0x67A791E0, 0x93E1D49A), /* ~= 10^-246 */
+    U64 (0x8BD6A141, 0x006042BD), U64 (0xE0C8BB2C, 0x5C6D24E0), /* ~= 10^-245 */
+    U64 (0xAECC4991, 0x4078536D), U64 (0x58FAE9F7, 0x73886E18), /* ~= 10^-244 */
+    U64 (0xDA7F5BF5, 0x90966848), U64 (0xAF39A475, 0x506A899E), /* ~= 10^-243 */
+    U64 (0x888F9979, 0x7A5E012D), U64 (0x6D8406C9, 0x52429603), /* ~= 10^-242 */
+    U64 (0xAAB37FD7, 0xD8F58178), U64 (0xC8E5087B, 0xA6D33B83), /* ~= 10^-241 */
+    U64 (0xD5605FCD, 0xCF32E1D6), U64 (0xFB1E4A9A, 0x90880A64), /* ~= 10^-240 */
+    U64 (0x855C3BE0, 0xA17FCD26), U64 (0x5CF2EEA0, 0x9A55067F), /* ~= 10^-239 */
+    U64 (0xA6B34AD8, 0xC9DFC06F), U64 (0xF42FAA48, 0xC0EA481E), /* ~= 10^-238 */
+    U64 (0xD0601D8E, 0xFC57B08B), U64 (0xF13B94DA, 0xF124DA26), /* ~= 10^-237 */
+    U64 (0x823C1279, 0x5DB6CE57), U64 (0x76C53D08, 0xD6B70858), /* ~= 10^-236 */
+    U64 (0xA2CB1717, 0xB52481ED), U64 (0x54768C4B, 0x0C64CA6E), /* ~= 10^-235 */
+    U64 (0xCB7DDCDD, 0xA26DA268), U64 (0xA9942F5D, 0xCF7DFD09), /* ~= 10^-234 */
+    U64 (0xFE5D5415, 0x0B090B02), U64 (0xD3F93B35, 0x435D7C4C), /* ~= 10^-233 */
+    U64 (0x9EFA548D, 0x26E5A6E1), U64 (0xC47BC501, 0x4A1A6DAF), /* ~= 10^-232 */
+    U64 (0xC6B8E9B0, 0x709F109A), U64 (0x359AB641, 0x9CA1091B), /* ~= 10^-231 */
+    U64 (0xF867241C, 0x8CC6D4C0), U64 (0xC30163D2, 0x03C94B62), /* ~= 10^-230 */
+    U64 (0x9B407691, 0xD7FC44F8), U64 (0x79E0DE63, 0x425DCF1D), /* ~= 10^-229 */
+    U64 (0xC2109436, 0x4DFB5636), U64 (0x985915FC, 0x12F542E4), /* ~= 10^-228 */
+    U64 (0xF294B943, 0xE17A2BC4), U64 (0x3E6F5B7B, 0x17B2939D), /* ~= 10^-227 */
+    U64 (0x979CF3CA, 0x6CEC5B5A), U64 (0xA705992C, 0xEECF9C42), /* ~= 10^-226 */
+    U64 (0xBD8430BD, 0x08277231), U64 (0x50C6FF78, 0x2A838353), /* ~= 10^-225 */
+    U64 (0xECE53CEC, 0x4A314EBD), U64 (0xA4F8BF56, 0x35246428), /* ~= 10^-224 */
+    U64 (0x940F4613, 0xAE5ED136), U64 (0x871B7795, 0xE136BE99), /* ~= 10^-223 */
+    U64 (0xB9131798, 0x99F68584), U64 (0x28E2557B, 0x59846E3F), /* ~= 10^-222 */
+    U64 (0xE757DD7E, 0xC07426E5), U64 (0x331AEADA, 0x2FE589CF), /* ~= 10^-221 */
+    U64 (0x9096EA6F, 0x3848984F), U64 (0x3FF0D2C8, 0x5DEF7621), /* ~= 10^-220 */
+    U64 (0xB4BCA50B, 0x065ABE63), U64 (0x0FED077A, 0x756B53A9), /* ~= 10^-219 */
+    U64 (0xE1EBCE4D, 0xC7F16DFB), U64 (0xD3E84959, 0x12C62894), /* ~= 10^-218 */
+    U64 (0x8D3360F0, 0x9CF6E4BD), U64 (0x64712DD7, 0xABBBD95C), /* ~= 10^-217 */
+    U64 (0xB080392C, 0xC4349DEC), U64 (0xBD8D794D, 0x96AACFB3), /* ~= 10^-216 */
+    U64 (0xDCA04777, 0xF541C567), U64 (0xECF0D7A0, 0xFC5583A0), /* ~= 10^-215 */
+    U64 (0x89E42CAA, 0xF9491B60), U64 (0xF41686C4, 0x9DB57244), /* ~= 10^-214 */
+    U64 (0xAC5D37D5, 0xB79B6239), U64 (0x311C2875, 0xC522CED5), /* ~= 10^-213 */
+    U64 (0xD77485CB, 0x25823AC7), U64 (0x7D633293, 0x366B828B), /* ~= 10^-212 */
+    U64 (0x86A8D39E, 0xF77164BC), U64 (0xAE5DFF9C, 0x02033197), /* ~= 10^-211 */
+    U64 (0xA8530886, 0xB54DBDEB), U64 (0xD9F57F83, 0x0283FDFC), /* ~= 10^-210 */
+    U64 (0xD267CAA8, 0x62A12D66), U64 (0xD072DF63, 0xC324FD7B), /* ~= 10^-209 */
+    U64 (0x8380DEA9, 0x3DA4BC60), U64 (0x4247CB9E, 0x59F71E6D), /* ~= 10^-208 */
+    U64 (0xA4611653, 0x8D0DEB78), U64 (0x52D9BE85, 0xF074E608), /* ~= 10^-207 */
+    U64 (0xCD795BE8, 0x70516656), U64 (0x67902E27, 0x6C921F8B), /* ~= 10^-206 */
+    U64 (0x806BD971, 0x4632DFF6), U64 (0x00BA1CD8, 0xA3DB53B6), /* ~= 10^-205 */
+    U64 (0xA086CFCD, 0x97BF97F3), U64 (0x80E8A40E, 0xCCD228A4), /* ~= 10^-204 */
+    U64 (0xC8A883C0, 0xFDAF7DF0), U64 (0x6122CD12, 0x8006B2CD), /* ~= 10^-203 */
+    U64 (0xFAD2A4B1, 0x3D1B5D6C), U64 (0x796B8057, 0x20085F81), /* ~= 10^-202 */
+    U64 (0x9CC3A6EE, 0xC6311A63), U64 (0xCBE33036, 0x74053BB0), /* ~= 10^-201 */
+    U64 (0xC3F490AA, 0x77BD60FC), U64 (0xBEDBFC44, 0x11068A9C), /* ~= 10^-200 */
+    U64 (0xF4F1B4D5, 0x15ACB93B), U64 (0xEE92FB55, 0x15482D44), /* ~= 10^-199 */
+    U64 (0x99171105, 0x2D8BF3C5), U64 (0x751BDD15, 0x2D4D1C4A), /* ~= 10^-198 */
+    U64 (0xBF5CD546, 0x78EEF0B6), U64 (0xD262D45A, 0x78A0635D), /* ~= 10^-197 */
+    U64 (0xEF340A98, 0x172AACE4), U64 (0x86FB8971, 0x16C87C34), /* ~= 10^-196 */
+    U64 (0x9580869F, 0x0E7AAC0E), U64 (0xD45D35E6, 0xAE3D4DA0), /* ~= 10^-195 */
+    U64 (0xBAE0A846, 0xD2195712), U64 (0x89748360, 0x59CCA109), /* ~= 10^-194 */
+    U64 (0xE998D258, 0x869FACD7), U64 (0x2BD1A438, 0x703FC94B), /* ~= 10^-193 */
+    U64 (0x91FF8377, 0x5423CC06), U64 (0x7B6306A3, 0x4627DDCF), /* ~= 10^-192 */
+    U64 (0xB67F6455, 0x292CBF08), U64 (0x1A3BC84C, 0x17B1D542), /* ~= 10^-191 */
+    U64 (0xE41F3D6A, 0x7377EECA), U64 (0x20CABA5F, 0x1D9E4A93), /* ~= 10^-190 */
+    U64 (0x8E938662, 0x882AF53E), U64 (0x547EB47B, 0x7282EE9C), /* ~= 10^-189 */
+    U64 (0xB23867FB, 0x2A35B28D), U64 (0xE99E619A, 0x4F23AA43), /* ~= 10^-188 */
+    U64 (0xDEC681F9, 0xF4C31F31), U64 (0x6405FA00, 0xE2EC94D4), /* ~= 10^-187 */
+    U64 (0x8B3C113C, 0x38F9F37E), U64 (0xDE83BC40, 0x8DD3DD04), /* ~= 10^-186 */
+    U64 (0xAE0B158B, 0x4738705E), U64 (0x9624AB50, 0xB148D445), /* ~= 10^-185 */
+    U64 (0xD98DDAEE, 0x19068C76), U64 (0x3BADD624, 0xDD9B0957), /* ~= 10^-184 */
+    U64 (0x87F8A8D4, 0xCFA417C9), U64 (0xE54CA5D7, 0x0A80E5D6), /* ~= 10^-183 */
+    U64 (0xA9F6D30A, 0x038D1DBC), U64 (0x5E9FCF4C, 0xCD211F4C), /* ~= 10^-182 */
+    U64 (0xD47487CC, 0x8470652B), U64 (0x7647C320, 0x0069671F), /* ~= 10^-181 */
+    U64 (0x84C8D4DF, 0xD2C63F3B), U64 (0x29ECD9F4, 0x0041E073), /* ~= 10^-180 */
+    U64 (0xA5FB0A17, 0xC777CF09), U64 (0xF4681071, 0x00525890), /* ~= 10^-179 */
+    U64 (0xCF79CC9D, 0xB955C2CC), U64 (0x7182148D, 0x4066EEB4), /* ~= 10^-178 */
+    U64 (0x81AC1FE2, 0x93D599BF), U64 (0xC6F14CD8, 0x48405530), /* ~= 10^-177 */
+    U64 (0xA21727DB, 0x38CB002F), U64 (0xB8ADA00E, 0x5A506A7C), /* ~= 10^-176 */
+    U64 (0xCA9CF1D2, 0x06FDC03B), U64 (0xA6D90811, 0xF0E4851C), /* ~= 10^-175 */
+    U64 (0xFD442E46, 0x88BD304A), U64 (0x908F4A16, 0x6D1DA663), /* ~= 10^-174 */
+    U64 (0x9E4A9CEC, 0x15763E2E), U64 (0x9A598E4E, 0x043287FE), /* ~= 10^-173 */
+    U64 (0xC5DD4427, 0x1AD3CDBA), U64 (0x40EFF1E1, 0x853F29FD), /* ~= 10^-172 */
+    U64 (0xF7549530, 0xE188C128), U64 (0xD12BEE59, 0xE68EF47C), /* ~= 10^-171 */
+    U64 (0x9A94DD3E, 0x8CF578B9), U64 (0x82BB74F8, 0x301958CE), /* ~= 10^-170 */
+    U64 (0xC13A148E, 0x3032D6E7), U64 (0xE36A5236, 0x3C1FAF01), /* ~= 10^-169 */
+    U64 (0xF18899B1, 0xBC3F8CA1), U64 (0xDC44E6C3, 0xCB279AC1), /* ~= 10^-168 */
+    U64 (0x96F5600F, 0x15A7B7E5), U64 (0x29AB103A, 0x5EF8C0B9), /* ~= 10^-167 */
+    U64 (0xBCB2B812, 0xDB11A5DE), U64 (0x7415D448, 0xF6B6F0E7), /* ~= 10^-166 */
+    U64 (0xEBDF6617, 0x91D60F56), U64 (0x111B495B, 0x3464AD21), /* ~= 10^-165 */
+    U64 (0x936B9FCE, 0xBB25C995), U64 (0xCAB10DD9, 0x00BEEC34), /* ~= 10^-164 */
+    U64 (0xB84687C2, 0x69EF3BFB), U64 (0x3D5D514F, 0x40EEA742), /* ~= 10^-163 */
+    U64 (0xE65829B3, 0x046B0AFA), U64 (0x0CB4A5A3, 0x112A5112), /* ~= 10^-162 */
+    U64 (0x8FF71A0F, 0xE2C2E6DC), U64 (0x47F0E785, 0xEABA72AB), /* ~= 10^-161 */
+    U64 (0xB3F4E093, 0xDB73A093), U64 (0x59ED2167, 0x65690F56), /* ~= 10^-160 */
+    U64 (0xE0F218B8, 0xD25088B8), U64 (0x306869C1, 0x3EC3532C), /* ~= 10^-159 */
+    U64 (0x8C974F73, 0x83725573), U64 (0x1E414218, 0xC73A13FB), /* ~= 10^-158 */
+    U64 (0xAFBD2350, 0x644EEACF), U64 (0xE5D1929E, 0xF90898FA), /* ~= 10^-157 */
+    U64 (0xDBAC6C24, 0x7D62A583), U64 (0xDF45F746, 0xB74ABF39), /* ~= 10^-156 */
+    U64 (0x894BC396, 0xCE5DA772), U64 (0x6B8BBA8C, 0x328EB783), /* ~= 10^-155 */
+    U64 (0xAB9EB47C, 0x81F5114F), U64 (0x066EA92F, 0x3F326564), /* ~= 10^-154 */
+    U64 (0xD686619B, 0xA27255A2), U64 (0xC80A537B, 0x0EFEFEBD), /* ~= 10^-153 */
+    U64 (0x8613FD01, 0x45877585), U64 (0xBD06742C, 0xE95F5F36), /* ~= 10^-152 */
+    U64 (0xA798FC41, 0x96E952E7), U64 (0x2C481138, 0x23B73704), /* ~= 10^-151 */
+    U64 (0xD17F3B51, 0xFCA3A7A0), U64 (0xF75A1586, 0x2CA504C5), /* ~= 10^-150 */
+    U64 (0x82EF8513, 0x3DE648C4), U64 (0x9A984D73, 0xDBE722FB), /* ~= 10^-149 */
+    U64 (0xA3AB6658, 0x0D5FDAF5), U64 (0xC13E60D0, 0xD2E0EBBA), /* ~= 10^-148 */
+    U64 (0xCC963FEE, 0x10B7D1B3), U64 (0x318DF905, 0x079926A8), /* ~= 10^-147 */
+    U64 (0xFFBBCFE9, 0x94E5C61F), U64 (0xFDF17746, 0x497F7052), /* ~= 10^-146 */
+    U64 (0x9FD561F1, 0xFD0F9BD3), U64 (0xFEB6EA8B, 0xEDEFA633), /* ~= 10^-145 */
+    U64 (0xC7CABA6E, 0x7C5382C8), U64 (0xFE64A52E, 0xE96B8FC0), /* ~= 10^-144 */
+    U64 (0xF9BD690A, 0x1B68637B), U64 (0x3DFDCE7A, 0xA3C673B0), /* ~= 10^-143 */
+    U64 (0x9C1661A6, 0x51213E2D), U64 (0x06BEA10C, 0xA65C084E), /* ~= 10^-142 */
+    U64 (0xC31BFA0F, 0xE5698DB8), U64 (0x486E494F, 0xCFF30A62), /* ~= 10^-141 */
+    U64 (0xF3E2F893, 0xDEC3F126), U64 (0x5A89DBA3, 0xC3EFCCFA), /* ~= 10^-140 */
+    U64 (0x986DDB5C, 0x6B3A76B7), U64 (0xF8962946, 0x5A75E01C), /* ~= 10^-139 */
+    U64 (0xBE895233, 0x86091465), U64 (0xF6BBB397, 0xF1135823), /* ~= 10^-138 */
+    U64 (0xEE2BA6C0, 0x678B597F), U64 (0x746AA07D, 0xED582E2C), /* ~= 10^-137 */
+    U64 (0x94DB4838, 0x40B717EF), U64 (0xA8C2A44E, 0xB4571CDC), /* ~= 10^-136 */
+    U64 (0xBA121A46, 0x50E4DDEB), U64 (0x92F34D62, 0x616CE413), /* ~= 10^-135 */
+    U64 (0xE896A0D7, 0xE51E1566), U64 (0x77B020BA, 0xF9C81D17), /* ~= 10^-134 */
+    U64 (0x915E2486, 0xEF32CD60), U64 (0x0ACE1474, 0xDC1D122E), /* ~= 10^-133 */
+    U64 (0xB5B5ADA8, 0xAAFF80B8), U64 (0x0D819992, 0x132456BA), /* ~= 10^-132 */
+    U64 (0xE3231912, 0xD5BF60E6), U64 (0x10E1FFF6, 0x97ED6C69), /* ~= 10^-131 */
+    U64 (0x8DF5EFAB, 0xC5979C8F), U64 (0xCA8D3FFA, 0x1EF463C1), /* ~= 10^-130 */
+    U64 (0xB1736B96, 0xB6FD83B3), U64 (0xBD308FF8, 0xA6B17CB2), /* ~= 10^-129 */
+    U64 (0xDDD0467C, 0x64BCE4A0), U64 (0xAC7CB3F6, 0xD05DDBDE), /* ~= 10^-128 */
+    U64 (0x8AA22C0D, 0xBEF60EE4), U64 (0x6BCDF07A, 0x423AA96B), /* ~= 10^-127 */
+    U64 (0xAD4AB711, 0x2EB3929D), U64 (0x86C16C98, 0xD2C953C6), /* ~= 10^-126 */
+    U64 (0xD89D64D5, 0x7A607744), U64 (0xE871C7BF, 0x077BA8B7), /* ~= 10^-125 */
+    U64 (0x87625F05, 0x6C7C4A8B), U64 (0x11471CD7, 0x64AD4972), /* ~= 10^-124 */
+    U64 (0xA93AF6C6, 0xC79B5D2D), U64 (0xD598E40D, 0x3DD89BCF), /* ~= 10^-123 */
+    U64 (0xD389B478, 0x79823479), U64 (0x4AFF1D10, 0x8D4EC2C3), /* ~= 10^-122 */
+    U64 (0x843610CB, 0x4BF160CB), U64 (0xCEDF722A, 0x585139BA), /* ~= 10^-121 */
+    U64 (0xA54394FE, 0x1EEDB8FE), U64 (0xC2974EB4, 0xEE658828), /* ~= 10^-120 */
+    U64 (0xCE947A3D, 0xA6A9273E), U64 (0x733D2262, 0x29FEEA32), /* ~= 10^-119 */
+    U64 (0x811CCC66, 0x8829B887), U64 (0x0806357D, 0x5A3F525F), /* ~= 10^-118 */
+    U64 (0xA163FF80, 0x2A3426A8), U64 (0xCA07C2DC, 0xB0CF26F7), /* ~= 10^-117 */
+    U64 (0xC9BCFF60, 0x34C13052), U64 (0xFC89B393, 0xDD02F0B5), /* ~= 10^-116 */
+    U64 (0xFC2C3F38, 0x41F17C67), U64 (0xBBAC2078, 0xD443ACE2), /* ~= 10^-115 */
+    U64 (0x9D9BA783, 0x2936EDC0), U64 (0xD54B944B, 0x84AA4C0D), /* ~= 10^-114 */
+    U64 (0xC5029163, 0xF384A931), U64 (0x0A9E795E, 0x65D4DF11), /* ~= 10^-113 */
+    U64 (0xF64335BC, 0xF065D37D), U64 (0x4D4617B5, 0xFF4A16D5), /* ~= 10^-112 */
+    U64 (0x99EA0196, 0x163FA42E), U64 (0x504BCED1, 0xBF8E4E45), /* ~= 10^-111 */
+    U64 (0xC06481FB, 0x9BCF8D39), U64 (0xE45EC286, 0x2F71E1D6), /* ~= 10^-110 */
+    U64 (0xF07DA27A, 0x82C37088), U64 (0x5D767327, 0xBB4E5A4C), /* ~= 10^-109 */
+    U64 (0x964E858C, 0x91BA2655), U64 (0x3A6A07F8, 0xD510F86F), /* ~= 10^-108 */
+    U64 (0xBBE226EF, 0xB628AFEA), U64 (0x890489F7, 0x0A55368B), /* ~= 10^-107 */
+    U64 (0xEADAB0AB, 0xA3B2DBE5), U64 (0x2B45AC74, 0xCCEA842E), /* ~= 10^-106 */
+    U64 (0x92C8AE6B, 0x464FC96F), U64 (0x3B0B8BC9, 0x0012929D), /* ~= 10^-105 */
+    U64 (0xB77ADA06, 0x17E3BBCB), U64 (0x09CE6EBB, 0x40173744), /* ~= 10^-104 */
+    U64 (0xE5599087, 0x9DDCAABD), U64 (0xCC420A6A, 0x101D0515), /* ~= 10^-103 */
+    U64 (0x8F57FA54, 0xC2A9EAB6), U64 (0x9FA94682, 0x4A12232D), /* ~= 10^-102 */
+    U64 (0xB32DF8E9, 0xF3546564), U64 (0x47939822, 0xDC96ABF9), /* ~= 10^-101 */
+    U64 (0xDFF97724, 0x70297EBD), U64 (0x59787E2B, 0x93BC56F7), /* ~= 10^-100 */
+    U64 (0x8BFBEA76, 0xC619EF36), U64 (0x57EB4EDB, 0x3C55B65A), /* ~= 10^-99 */
+    U64 (0xAEFAE514, 0x77A06B03), U64 (0xEDE62292, 0x0B6B23F1), /* ~= 10^-98 */
+    U64 (0xDAB99E59, 0x958885C4), U64 (0xE95FAB36, 0x8E45ECED), /* ~= 10^-97 */
+    U64 (0x88B402F7, 0xFD75539B), U64 (0x11DBCB02, 0x18EBB414), /* ~= 10^-96 */
+    U64 (0xAAE103B5, 0xFCD2A881), U64 (0xD652BDC2, 0x9F26A119), /* ~= 10^-95 */
+    U64 (0xD59944A3, 0x7C0752A2), U64 (0x4BE76D33, 0x46F0495F), /* ~= 10^-94 */
+    U64 (0x857FCAE6, 0x2D8493A5), U64 (0x6F70A440, 0x0C562DDB), /* ~= 10^-93 */
+    U64 (0xA6DFBD9F, 0xB8E5B88E), U64 (0xCB4CCD50, 0x0F6BB952), /* ~= 10^-92 */
+    U64 (0xD097AD07, 0xA71F26B2), U64 (0x7E2000A4, 0x1346A7A7), /* ~= 10^-91 */
+    U64 (0x825ECC24, 0xC873782F), U64 (0x8ED40066, 0x8C0C28C8), /* ~= 10^-90 */
+    U64 (0xA2F67F2D, 0xFA90563B), U64 (0x72890080, 0x2F0F32FA), /* ~= 10^-89 */
+    U64 (0xCBB41EF9, 0x79346BCA), U64 (0x4F2B40A0, 0x3AD2FFB9), /* ~= 10^-88 */
+    U64 (0xFEA126B7, 0xD78186BC), U64 (0xE2F610C8, 0x4987BFA8), /* ~= 10^-87 */
+    U64 (0x9F24B832, 0xE6B0F436), U64 (0x0DD9CA7D, 0x2DF4D7C9), /* ~= 10^-86 */
+    U64 (0xC6EDE63F, 0xA05D3143), U64 (0x91503D1C, 0x79720DBB), /* ~= 10^-85 */
+    U64 (0xF8A95FCF, 0x88747D94), U64 (0x75A44C63, 0x97CE912A), /* ~= 10^-84 */
+    U64 (0x9B69DBE1, 0xB548CE7C), U64 (0xC986AFBE, 0x3EE11ABA), /* ~= 10^-83 */
+    U64 (0xC24452DA, 0x229B021B), U64 (0xFBE85BAD, 0xCE996168), /* ~= 10^-82 */
+    U64 (0xF2D56790, 0xAB41C2A2), U64 (0xFAE27299, 0x423FB9C3), /* ~= 10^-81 */
+    U64 (0x97C560BA, 0x6B0919A5), U64 (0xDCCD879F, 0xC967D41A), /* ~= 10^-80 */
+    U64 (0xBDB6B8E9, 0x05CB600F), U64 (0x5400E987, 0xBBC1C920), /* ~= 10^-79 */
+    U64 (0xED246723, 0x473E3813), U64 (0x290123E9, 0xAAB23B68), /* ~= 10^-78 */
+    U64 (0x9436C076, 0x0C86E30B), U64 (0xF9A0B672, 0x0AAF6521), /* ~= 10^-77 */
+    U64 (0xB9447093, 0x8FA89BCE), U64 (0xF808E40E, 0x8D5B3E69), /* ~= 10^-76 */
+    U64 (0xE7958CB8, 0x7392C2C2), U64 (0xB60B1D12, 0x30B20E04), /* ~= 10^-75 */
+    U64 (0x90BD77F3, 0x483BB9B9), U64 (0xB1C6F22B, 0x5E6F48C2), /* ~= 10^-74 */
+    U64 (0xB4ECD5F0, 0x1A4AA828), U64 (0x1E38AEB6, 0x360B1AF3), /* ~= 10^-73 */
+    U64 (0xE2280B6C, 0x20DD5232), U64 (0x25C6DA63, 0xC38DE1B0), /* ~= 10^-72 */
+    U64 (0x8D590723, 0x948A535F), U64 (0x579C487E, 0x5A38AD0E), /* ~= 10^-71 */
+    U64 (0xB0AF48EC, 0x79ACE837), U64 (0x2D835A9D, 0xF0C6D851), /* ~= 10^-70 */
+    U64 (0xDCDB1B27, 0x98182244), U64 (0xF8E43145, 0x6CF88E65), /* ~= 10^-69 */
+    U64 (0x8A08F0F8, 0xBF0F156B), U64 (0x1B8E9ECB, 0x641B58FF), /* ~= 10^-68 */
+    U64 (0xAC8B2D36, 0xEED2DAC5), U64 (0xE272467E, 0x3D222F3F), /* ~= 10^-67 */
+    U64 (0xD7ADF884, 0xAA879177), U64 (0x5B0ED81D, 0xCC6ABB0F), /* ~= 10^-66 */
+    U64 (0x86CCBB52, 0xEA94BAEA), U64 (0x98E94712, 0x9FC2B4E9), /* ~= 10^-65 */
+    U64 (0xA87FEA27, 0xA539E9A5), U64 (0x3F2398D7, 0x47B36224), /* ~= 10^-64 */
+    U64 (0xD29FE4B1, 0x8E88640E), U64 (0x8EEC7F0D, 0x19A03AAD), /* ~= 10^-63 */
+    U64 (0x83A3EEEE, 0xF9153E89), U64 (0x1953CF68, 0x300424AC), /* ~= 10^-62 */
+    U64 (0xA48CEAAA, 0xB75A8E2B), U64 (0x5FA8C342, 0x3C052DD7), /* ~= 10^-61 */
+    U64 (0xCDB02555, 0x653131B6), U64 (0x3792F412, 0xCB06794D), /* ~= 10^-60 */
+    U64 (0x808E1755, 0x5F3EBF11), U64 (0xE2BBD88B, 0xBEE40BD0), /* ~= 10^-59 */
+    U64 (0xA0B19D2A, 0xB70E6ED6), U64 (0x5B6ACEAE, 0xAE9D0EC4), /* ~= 10^-58 */
+    U64 (0xC8DE0475, 0x64D20A8B), U64 (0xF245825A, 0x5A445275), /* ~= 10^-57 */
+    U64 (0xFB158592, 0xBE068D2E), U64 (0xEED6E2F0, 0xF0D56712), /* ~= 10^-56 */
+    U64 (0x9CED737B, 0xB6C4183D), U64 (0x55464DD6, 0x9685606B), /* ~= 10^-55 */
+    U64 (0xC428D05A, 0xA4751E4C), U64 (0xAA97E14C, 0x3C26B886), /* ~= 10^-54 */
+    U64 (0xF5330471, 0x4D9265DF), U64 (0xD53DD99F, 0x4B3066A8), /* ~= 10^-53 */
+    U64 (0x993FE2C6, 0xD07B7FAB), U64 (0xE546A803, 0x8EFE4029), /* ~= 10^-52 */
+    U64 (0xBF8FDB78, 0x849A5F96), U64 (0xDE985204, 0x72BDD033), /* ~= 10^-51 */
+    U64 (0xEF73D256, 0xA5C0F77C), U64 (0x963E6685, 0x8F6D4440), /* ~= 10^-50 */
+    U64 (0x95A86376, 0x27989AAD), U64 (0xDDE70013, 0x79A44AA8), /* ~= 10^-49 */
+    U64 (0xBB127C53, 0xB17EC159), U64 (0x5560C018, 0x580D5D52), /* ~= 10^-48 */
+    U64 (0xE9D71B68, 0x9DDE71AF), U64 (0xAAB8F01E, 0x6E10B4A6), /* ~= 10^-47 */
+    U64 (0x92267121, 0x62AB070D), U64 (0xCAB39613, 0x04CA70E8), /* ~= 10^-46 */
+    U64 (0xB6B00D69, 0xBB55C8D1), U64 (0x3D607B97, 0xC5FD0D22), /* ~= 10^-45 */
+    U64 (0xE45C10C4, 0x2A2B3B05), U64 (0x8CB89A7D, 0xB77C506A), /* ~= 10^-44 */
+    U64 (0x8EB98A7A, 0x9A5B04E3), U64 (0x77F3608E, 0x92ADB242), /* ~= 10^-43 */
+    U64 (0xB267ED19, 0x40F1C61C), U64 (0x55F038B2, 0x37591ED3), /* ~= 10^-42 */
+    U64 (0xDF01E85F, 0x912E37A3), U64 (0x6B6C46DE, 0xC52F6688), /* ~= 10^-41 */
+    U64 (0x8B61313B, 0xBABCE2C6), U64 (0x2323AC4B, 0x3B3DA015), /* ~= 10^-40 */
+    U64 (0xAE397D8A, 0xA96C1B77), U64 (0xABEC975E, 0x0A0D081A), /* ~= 10^-39 */
+    U64 (0xD9C7DCED, 0x53C72255), U64 (0x96E7BD35, 0x8C904A21), /* ~= 10^-38 */
+    U64 (0x881CEA14, 0x545C7575), U64 (0x7E50D641, 0x77DA2E54), /* ~= 10^-37 */
+    U64 (0xAA242499, 0x697392D2), U64 (0xDDE50BD1, 0xD5D0B9E9), /* ~= 10^-36 */
+    U64 (0xD4AD2DBF, 0xC3D07787), U64 (0x955E4EC6, 0x4B44E864), /* ~= 10^-35 */
+    U64 (0x84EC3C97, 0xDA624AB4), U64 (0xBD5AF13B, 0xEF0B113E), /* ~= 10^-34 */
+    U64 (0xA6274BBD, 0xD0FADD61), U64 (0xECB1AD8A, 0xEACDD58E), /* ~= 10^-33 */
+    U64 (0xCFB11EAD, 0x453994BA), U64 (0x67DE18ED, 0xA5814AF2), /* ~= 10^-32 */
+    U64 (0x81CEB32C, 0x4B43FCF4), U64 (0x80EACF94, 0x8770CED7), /* ~= 10^-31 */
+    U64 (0xA2425FF7, 0x5E14FC31), U64 (0xA1258379, 0xA94D028D), /* ~= 10^-30 */
+    U64 (0xCAD2F7F5, 0x359A3B3E), U64 (0x096EE458, 0x13A04330), /* ~= 10^-29 */
+    U64 (0xFD87B5F2, 0x8300CA0D), U64 (0x8BCA9D6E, 0x188853FC), /* ~= 10^-28 */
+    U64 (0x9E74D1B7, 0x91E07E48), U64 (0x775EA264, 0xCF55347D), /* ~= 10^-27 */
+    U64 (0xC6120625, 0x76589DDA), U64 (0x95364AFE, 0x032A819D), /* ~= 10^-26 */
+    U64 (0xF79687AE, 0xD3EEC551), U64 (0x3A83DDBD, 0x83F52204), /* ~= 10^-25 */
+    U64 (0x9ABE14CD, 0x44753B52), U64 (0xC4926A96, 0x72793542), /* ~= 10^-24 */
+    U64 (0xC16D9A00, 0x95928A27), U64 (0x75B7053C, 0x0F178293), /* ~= 10^-23 */
+    U64 (0xF1C90080, 0xBAF72CB1), U64 (0x5324C68B, 0x12DD6338), /* ~= 10^-22 */
+    U64 (0x971DA050, 0x74DA7BEE), U64 (0xD3F6FC16, 0xEBCA5E03), /* ~= 10^-21 */
+    U64 (0xBCE50864, 0x92111AEA), U64 (0x88F4BB1C, 0xA6BCF584), /* ~= 10^-20 */
+    U64 (0xEC1E4A7D, 0xB69561A5), U64 (0x2B31E9E3, 0xD06C32E5), /* ~= 10^-19 */
+    U64 (0x9392EE8E, 0x921D5D07), U64 (0x3AFF322E, 0x62439FCF), /* ~= 10^-18 */
+    U64 (0xB877AA32, 0x36A4B449), U64 (0x09BEFEB9, 0xFAD487C2), /* ~= 10^-17 */
+    U64 (0xE69594BE, 0xC44DE15B), U64 (0x4C2EBE68, 0x7989A9B3), /* ~= 10^-16 */
+    U64 (0x901D7CF7, 0x3AB0ACD9), U64 (0x0F9D3701, 0x4BF60A10), /* ~= 10^-15 */
+    U64 (0xB424DC35, 0x095CD80F), U64 (0x538484C1, 0x9EF38C94), /* ~= 10^-14 */
+    U64 (0xE12E1342, 0x4BB40E13), U64 (0x2865A5F2, 0x06B06FB9), /* ~= 10^-13 */
+    U64 (0x8CBCCC09, 0x6F5088CB), U64 (0xF93F87B7, 0x442E45D3), /* ~= 10^-12 */
+    U64 (0xAFEBFF0B, 0xCB24AAFE), U64 (0xF78F69A5, 0x1539D748), /* ~= 10^-11 */
+    U64 (0xDBE6FECE, 0xBDEDD5BE), U64 (0xB573440E, 0x5A884D1B), /* ~= 10^-10 */
+    U64 (0x89705F41, 0x36B4A597), U64 (0x31680A88, 0xF8953030), /* ~= 10^-9 */
+    U64 (0xABCC7711, 0x8461CEFC), U64 (0xFDC20D2B, 0x36BA7C3D), /* ~= 10^-8 */
+    U64 (0xD6BF94D5, 0xE57A42BC), U64 (0x3D329076, 0x04691B4C), /* ~= 10^-7 */
+    U64 (0x8637BD05, 0xAF6C69B5), U64 (0xA63F9A49, 0xC2C1B10F), /* ~= 10^-6 */
+    U64 (0xA7C5AC47, 0x1B478423), U64 (0x0FCF80DC, 0x33721D53), /* ~= 10^-5 */
+    U64 (0xD1B71758, 0xE219652B), U64 (0xD3C36113, 0x404EA4A8), /* ~= 10^-4 */
+    U64 (0x83126E97, 0x8D4FDF3B), U64 (0x645A1CAC, 0x083126E9), /* ~= 10^-3 */
+    U64 (0xA3D70A3D, 0x70A3D70A), U64 (0x3D70A3D7, 0x0A3D70A3), /* ~= 10^-2 */
+    U64 (0xCCCCCCCC, 0xCCCCCCCC), U64 (0xCCCCCCCC, 0xCCCCCCCC), /* ~= 10^-1 */
+    U64 (0x80000000, 0x00000000), U64 (0x00000000, 0x00000000), /* == 10^0 */
+    U64 (0xA0000000, 0x00000000), U64 (0x00000000, 0x00000000), /* == 10^1 */
+    U64 (0xC8000000, 0x00000000), U64 (0x00000000, 0x00000000), /* == 10^2 */
+    U64 (0xFA000000, 0x00000000), U64 (0x00000000, 0x00000000), /* == 10^3 */
+    U64 (0x9C400000, 0x00000000), U64 (0x00000000, 0x00000000), /* == 10^4 */
+    U64 (0xC3500000, 0x00000000), U64 (0x00000000, 0x00000000), /* == 10^5 */
+    U64 (0xF4240000, 0x00000000), U64 (0x00000000, 0x00000000), /* == 10^6 */
+    U64 (0x98968000, 0x00000000), U64 (0x00000000, 0x00000000), /* == 10^7 */
+    U64 (0xBEBC2000, 0x00000000), U64 (0x00000000, 0x00000000), /* == 10^8 */
+    U64 (0xEE6B2800, 0x00000000), U64 (0x00000000, 0x00000000), /* == 10^9 */
+    U64 (0x9502F900, 0x00000000), U64 (0x00000000, 0x00000000), /* == 10^10 */
+    U64 (0xBA43B740, 0x00000000), U64 (0x00000000, 0x00000000), /* == 10^11 */
+    U64 (0xE8D4A510, 0x00000000), U64 (0x00000000, 0x00000000), /* == 10^12 */
+    U64 (0x9184E72A, 0x00000000), U64 (0x00000000, 0x00000000), /* == 10^13 */
+    U64 (0xB5E620F4, 0x80000000), U64 (0x00000000, 0x00000000), /* == 10^14 */
+    U64 (0xE35FA931, 0xA0000000), U64 (0x00000000, 0x00000000), /* == 10^15 */
+    U64 (0x8E1BC9BF, 0x04000000), U64 (0x00000000, 0x00000000), /* == 10^16 */
+    U64 (0xB1A2BC2E, 0xC5000000), U64 (0x00000000, 0x00000000), /* == 10^17 */
+    U64 (0xDE0B6B3A, 0x76400000), U64 (0x00000000, 0x00000000), /* == 10^18 */
+    U64 (0x8AC72304, 0x89E80000), U64 (0x00000000, 0x00000000), /* == 10^19 */
+    U64 (0xAD78EBC5, 0xAC620000), U64 (0x00000000, 0x00000000), /* == 10^20 */
+    U64 (0xD8D726B7, 0x177A8000), U64 (0x00000000, 0x00000000), /* == 10^21 */
+    U64 (0x87867832, 0x6EAC9000), U64 (0x00000000, 0x00000000), /* == 10^22 */
+    U64 (0xA968163F, 0x0A57B400), U64 (0x00000000, 0x00000000), /* == 10^23 */
+    U64 (0xD3C21BCE, 0xCCEDA100), U64 (0x00000000, 0x00000000), /* == 10^24 */
+    U64 (0x84595161, 0x401484A0), U64 (0x00000000, 0x00000000), /* == 10^25 */
+    U64 (0xA56FA5B9, 0x9019A5C8), U64 (0x00000000, 0x00000000), /* == 10^26 */
+    U64 (0xCECB8F27, 0xF4200F3A), U64 (0x00000000, 0x00000000), /* == 10^27 */
+    U64 (0x813F3978, 0xF8940984), U64 (0x40000000, 0x00000000), /* == 10^28 */
+    U64 (0xA18F07D7, 0x36B90BE5), U64 (0x50000000, 0x00000000), /* == 10^29 */
+    U64 (0xC9F2C9CD, 0x04674EDE), U64 (0xA4000000, 0x00000000), /* == 10^30 */
+    U64 (0xFC6F7C40, 0x45812296), U64 (0x4D000000, 0x00000000), /* == 10^31 */
+    U64 (0x9DC5ADA8, 0x2B70B59D), U64 (0xF0200000, 0x00000000), /* == 10^32 */
+    U64 (0xC5371912, 0x364CE305), U64 (0x6C280000, 0x00000000), /* == 10^33 */
+    U64 (0xF684DF56, 0xC3E01BC6), U64 (0xC7320000, 0x00000000), /* == 10^34 */
+    U64 (0x9A130B96, 0x3A6C115C), U64 (0x3C7F4000, 0x00000000), /* == 10^35 */
+    U64 (0xC097CE7B, 0xC90715B3), U64 (0x4B9F1000, 0x00000000), /* == 10^36 */
+    U64 (0xF0BDC21A, 0xBB48DB20), U64 (0x1E86D400, 0x00000000), /* == 10^37 */
+    U64 (0x96769950, 0xB50D88F4), U64 (0x13144480, 0x00000000), /* == 10^38 */
+    U64 (0xBC143FA4, 0xE250EB31), U64 (0x17D955A0, 0x00000000), /* == 10^39 */
+    U64 (0xEB194F8E, 0x1AE525FD), U64 (0x5DCFAB08, 0x00000000), /* == 10^40 */
+    U64 (0x92EFD1B8, 0xD0CF37BE), U64 (0x5AA1CAE5, 0x00000000), /* == 10^41 */
+    U64 (0xB7ABC627, 0x050305AD), U64 (0xF14A3D9E, 0x40000000), /* == 10^42 */
+    U64 (0xE596B7B0, 0xC643C719), U64 (0x6D9CCD05, 0xD0000000), /* == 10^43 */
+    U64 (0x8F7E32CE, 0x7BEA5C6F), U64 (0xE4820023, 0xA2000000), /* == 10^44 */
+    U64 (0xB35DBF82, 0x1AE4F38B), U64 (0xDDA2802C, 0x8A800000), /* == 10^45 */
+    U64 (0xE0352F62, 0xA19E306E), U64 (0xD50B2037, 0xAD200000), /* == 10^46 */
+    U64 (0x8C213D9D, 0xA502DE45), U64 (0x4526F422, 0xCC340000), /* == 10^47 */
+    U64 (0xAF298D05, 0x0E4395D6), U64 (0x9670B12B, 0x7F410000), /* == 10^48 */
+    U64 (0xDAF3F046, 0x51D47B4C), U64 (0x3C0CDD76, 0x5F114000), /* == 10^49 */
+    U64 (0x88D8762B, 0xF324CD0F), U64 (0xA5880A69, 0xFB6AC800), /* == 10^50 */
+    U64 (0xAB0E93B6, 0xEFEE0053), U64 (0x8EEA0D04, 0x7A457A00), /* == 10^51 */
+    U64 (0xD5D238A4, 0xABE98068), U64 (0x72A49045, 0x98D6D880), /* == 10^52 */
+    U64 (0x85A36366, 0xEB71F041), U64 (0x47A6DA2B, 0x7F864750), /* == 10^53 */
+    U64 (0xA70C3C40, 0xA64E6C51), U64 (0x999090B6, 0x5F67D924), /* == 10^54 */
+    U64 (0xD0CF4B50, 0xCFE20765), U64 (0xFFF4B4E3, 0xF741CF6D), /* == 10^55 */
+    U64 (0x82818F12, 0x81ED449F), U64 (0xBFF8F10E, 0x7A8921A4), /* ~= 10^56 */
+    U64 (0xA321F2D7, 0x226895C7), U64 (0xAFF72D52, 0x192B6A0D), /* ~= 10^57 */
+    U64 (0xCBEA6F8C, 0xEB02BB39), U64 (0x9BF4F8A6, 0x9F764490), /* ~= 10^58 */
+    U64 (0xFEE50B70, 0x25C36A08), U64 (0x02F236D0, 0x4753D5B4), /* ~= 10^59 */
+    U64 (0x9F4F2726, 0x179A2245), U64 (0x01D76242, 0x2C946590), /* ~= 10^60 */
+    U64 (0xC722F0EF, 0x9D80AAD6), U64 (0x424D3AD2, 0xB7B97EF5), /* ~= 10^61 */
+    U64 (0xF8EBAD2B, 0x84E0D58B), U64 (0xD2E08987, 0x65A7DEB2), /* ~= 10^62 */
+    U64 (0x9B934C3B, 0x330C8577), U64 (0x63CC55F4, 0x9F88EB2F), /* ~= 10^63 */
+    U64 (0xC2781F49, 0xFFCFA6D5), U64 (0x3CBF6B71, 0xC76B25FB), /* ~= 10^64 */
+    U64 (0xF316271C, 0x7FC3908A), U64 (0x8BEF464E, 0x3945EF7A), /* ~= 10^65 */
+    U64 (0x97EDD871, 0xCFDA3A56), U64 (0x97758BF0, 0xE3CBB5AC), /* ~= 10^66 */
+    U64 (0xBDE94E8E, 0x43D0C8EC), U64 (0x3D52EEED, 0x1CBEA317), /* ~= 10^67 */
+    U64 (0xED63A231, 0xD4C4FB27), U64 (0x4CA7AAA8, 0x63EE4BDD), /* ~= 10^68 */
+    U64 (0x945E455F, 0x24FB1CF8), U64 (0x8FE8CAA9, 0x3E74EF6A), /* ~= 10^69 */
+    U64 (0xB975D6B6, 0xEE39E436), U64 (0xB3E2FD53, 0x8E122B44), /* ~= 10^70 */
+    U64 (0xE7D34C64, 0xA9C85D44), U64 (0x60DBBCA8, 0x7196B616), /* ~= 10^71 */
+    U64 (0x90E40FBE, 0xEA1D3A4A), U64 (0xBC8955E9, 0x46FE31CD), /* ~= 10^72 */
+    U64 (0xB51D13AE, 0xA4A488DD), U64 (0x6BABAB63, 0x98BDBE41), /* ~= 10^73 */
+    U64 (0xE264589A, 0x4DCDAB14), U64 (0xC696963C, 0x7EED2DD1), /* ~= 10^74 */
+    U64 (0x8D7EB760, 0x70A08AEC), U64 (0xFC1E1DE5, 0xCF543CA2), /* ~= 10^75 */
+    U64 (0xB0DE6538, 0x8CC8ADA8), U64 (0x3B25A55F, 0x43294BCB), /* ~= 10^76 */
+    U64 (0xDD15FE86, 0xAFFAD912), U64 (0x49EF0EB7, 0x13F39EBE), /* ~= 10^77 */
+    U64 (0x8A2DBF14, 0x2DFCC7AB), U64 (0x6E356932, 0x6C784337), /* ~= 10^78 */
+    U64 (0xACB92ED9, 0x397BF996), U64 (0x49C2C37F, 0x07965404), /* ~= 10^79 */
+    U64 (0xD7E77A8F, 0x87DAF7FB), U64 (0xDC33745E, 0xC97BE906), /* ~= 10^80 */
+    U64 (0x86F0AC99, 0xB4E8DAFD), U64 (0x69A028BB, 0x3DED71A3), /* ~= 10^81 */
+    U64 (0xA8ACD7C0, 0x222311BC), U64 (0xC40832EA, 0x0D68CE0C), /* ~= 10^82 */
+    U64 (0xD2D80DB0, 0x2AABD62B), U64 (0xF50A3FA4, 0x90C30190), /* ~= 10^83 */
+    U64 (0x83C7088E, 0x1AAB65DB), U64 (0x792667C6, 0xDA79E0FA), /* ~= 10^84 */
+    U64 (0xA4B8CAB1, 0xA1563F52), U64 (0x577001B8, 0x91185938), /* ~= 10^85 */
+    U64 (0xCDE6FD5E, 0x09ABCF26), U64 (0xED4C0226, 0xB55E6F86), /* ~= 10^86 */
+    U64 (0x80B05E5A, 0xC60B6178), U64 (0x544F8158, 0x315B05B4), /* ~= 10^87 */
+    U64 (0xA0DC75F1, 0x778E39D6), U64 (0x696361AE, 0x3DB1C721), /* ~= 10^88 */
+    U64 (0xC913936D, 0xD571C84C), U64 (0x03BC3A19, 0xCD1E38E9), /* ~= 10^89 */
+    U64 (0xFB587849, 0x4ACE3A5F), U64 (0x04AB48A0, 0x4065C723), /* ~= 10^90 */
+    U64 (0x9D174B2D, 0xCEC0E47B), U64 (0x62EB0D64, 0x283F9C76), /* ~= 10^91 */
+    U64 (0xC45D1DF9, 0x42711D9A), U64 (0x3BA5D0BD, 0x324F8394), /* ~= 10^92 */
+    U64 (0xF5746577, 0x930D6500), U64 (0xCA8F44EC, 0x7EE36479), /* ~= 10^93 */
+    U64 (0x9968BF6A, 0xBBE85F20), U64 (0x7E998B13, 0xCF4E1ECB), /* ~= 10^94 */
+    U64 (0xBFC2EF45, 0x6AE276E8), U64 (0x9E3FEDD8, 0xC321A67E), /* ~= 10^95 */
+    U64 (0xEFB3AB16, 0xC59B14A2), U64 (0xC5CFE94E, 0xF3EA101E), /* ~= 10^96 */
+    U64 (0x95D04AEE, 0x3B80ECE5), U64 (0xBBA1F1D1, 0x58724A12), /* ~= 10^97 */
+    U64 (0xBB445DA9, 0xCA61281F), U64 (0x2A8A6E45, 0xAE8EDC97), /* ~= 10^98 */
+    U64 (0xEA157514, 0x3CF97226), U64 (0xF52D09D7, 0x1A3293BD), /* ~= 10^99 */
+    U64 (0x924D692C, 0xA61BE758), U64 (0x593C2626, 0x705F9C56), /* ~= 10^100 */
+    U64 (0xB6E0C377, 0xCFA2E12E), U64 (0x6F8B2FB0, 0x0C77836C), /* ~= 10^101 */
+    U64 (0xE498F455, 0xC38B997A), U64 (0x0B6DFB9C, 0x0F956447), /* ~= 10^102 */
+    U64 (0x8EDF98B5, 0x9A373FEC), U64 (0x4724BD41, 0x89BD5EAC), /* ~= 10^103 */
+    U64 (0xB2977EE3, 0x00C50FE7), U64 (0x58EDEC91, 0xEC2CB657), /* ~= 10^104 */
+    U64 (0xDF3D5E9B, 0xC0F653E1), U64 (0x2F2967B6, 0x6737E3ED), /* ~= 10^105 */
+    U64 (0x8B865B21, 0x5899F46C), U64 (0xBD79E0D2, 0x0082EE74), /* ~= 10^106 */
+    U64 (0xAE67F1E9, 0xAEC07187), U64 (0xECD85906, 0x80A3AA11), /* ~= 10^107 */
+    U64 (0xDA01EE64, 0x1A708DE9), U64 (0xE80E6F48, 0x20CC9495), /* ~= 10^108 */
+    U64 (0x884134FE, 0x908658B2), U64 (0x3109058D, 0x147FDCDD), /* ~= 10^109 */
+    U64 (0xAA51823E, 0x34A7EEDE), U64 (0xBD4B46F0, 0x599FD415), /* ~= 10^110 */
+    U64 (0xD4E5E2CD, 0xC1D1EA96), U64 (0x6C9E18AC, 0x7007C91A), /* ~= 10^111 */
+    U64 (0x850FADC0, 0x9923329E), U64 (0x03E2CF6B, 0xC604DDB0), /* ~= 10^112 */
+    U64 (0xA6539930, 0xBF6BFF45), U64 (0x84DB8346, 0xB786151C), /* ~= 10^113 */
+    U64 (0xCFE87F7C, 0xEF46FF16), U64 (0xE6126418, 0x65679A63), /* ~= 10^114 */
+    U64 (0x81F14FAE, 0x158C5F6E), U64 (0x4FCB7E8F, 0x3F60C07E), /* ~= 10^115 */
+    U64 (0xA26DA399, 0x9AEF7749), U64 (0xE3BE5E33, 0x0F38F09D), /* ~= 10^116 */
+    U64 (0xCB090C80, 0x01AB551C), U64 (0x5CADF5BF, 0xD3072CC5), /* ~= 10^117 */
+    U64 (0xFDCB4FA0, 0x02162A63), U64 (0x73D9732F, 0xC7C8F7F6), /* ~= 10^118 */
+    U64 (0x9E9F11C4, 0x014DDA7E), U64 (0x2867E7FD, 0xDCDD9AFA), /* ~= 10^119 */
+    U64 (0xC646D635, 0x01A1511D), U64 (0xB281E1FD, 0x541501B8), /* ~= 10^120 */
+    U64 (0xF7D88BC2, 0x4209A565), U64 (0x1F225A7C, 0xA91A4226), /* ~= 10^121 */
+    U64 (0x9AE75759, 0x6946075F), U64 (0x3375788D, 0xE9B06958), /* ~= 10^122 */
+    U64 (0xC1A12D2F, 0xC3978937), U64 (0x0052D6B1, 0x641C83AE), /* ~= 10^123 */
+    U64 (0xF209787B, 0xB47D6B84), U64 (0xC0678C5D, 0xBD23A49A), /* ~= 10^124 */
+    U64 (0x9745EB4D, 0x50CE6332), U64 (0xF840B7BA, 0x963646E0), /* ~= 10^125 */
+    U64 (0xBD176620, 0xA501FBFF), U64 (0xB650E5A9, 0x3BC3D898), /* ~= 10^126 */
+    U64 (0xEC5D3FA8, 0xCE427AFF), U64 (0xA3E51F13, 0x8AB4CEBE), /* ~= 10^127 */
+    U64 (0x93BA47C9, 0x80E98CDF), U64 (0xC66F336C, 0x36B10137), /* ~= 10^128 */
+    U64 (0xB8A8D9BB, 0xE123F017), U64 (0xB80B0047, 0x445D4184), /* ~= 10^129 */
+    U64 (0xE6D3102A, 0xD96CEC1D), U64 (0xA60DC059, 0x157491E5), /* ~= 10^130 */
+    U64 (0x9043EA1A, 0xC7E41392), U64 (0x87C89837, 0xAD68DB2F), /* ~= 10^131 */
+    U64 (0xB454E4A1, 0x79DD1877), U64 (0x29BABE45, 0x98C311FB), /* ~= 10^132 */
+    U64 (0xE16A1DC9, 0xD8545E94), U64 (0xF4296DD6, 0xFEF3D67A), /* ~= 10^133 */
+    U64 (0x8CE2529E, 0x2734BB1D), U64 (0x1899E4A6, 0x5F58660C), /* ~= 10^134 */
+    U64 (0xB01AE745, 0xB101E9E4), U64 (0x5EC05DCF, 0xF72E7F8F), /* ~= 10^135 */
+    U64 (0xDC21A117, 0x1D42645D), U64 (0x76707543, 0xF4FA1F73), /* ~= 10^136 */
+    U64 (0x899504AE, 0x72497EBA), U64 (0x6A06494A, 0x791C53A8), /* ~= 10^137 */
+    U64 (0xABFA45DA, 0x0EDBDE69), U64 (0x0487DB9D, 0x17636892), /* ~= 10^138 */
+    U64 (0xD6F8D750, 0x9292D603), U64 (0x45A9D284, 0x5D3C42B6), /* ~= 10^139 */
+    U64 (0x865B8692, 0x5B9BC5C2), U64 (0x0B8A2392, 0xBA45A9B2), /* ~= 10^140 */
+    U64 (0xA7F26836, 0xF282B732), U64 (0x8E6CAC77, 0x68D7141E), /* ~= 10^141 */
+    U64 (0xD1EF0244, 0xAF2364FF), U64 (0x3207D795, 0x430CD926), /* ~= 10^142 */
+    U64 (0x8335616A, 0xED761F1F), U64 (0x7F44E6BD, 0x49E807B8), /* ~= 10^143 */
+    U64 (0xA402B9C5, 0xA8D3A6E7), U64 (0x5F16206C, 0x9C6209A6), /* ~= 10^144 */
+    U64 (0xCD036837, 0x130890A1), U64 (0x36DBA887, 0xC37A8C0F), /* ~= 10^145 */
+    U64 (0x80222122, 0x6BE55A64), U64 (0xC2494954, 0xDA2C9789), /* ~= 10^146 */
+    U64 (0xA02AA96B, 0x06DEB0FD), U64 (0xF2DB9BAA, 0x10B7BD6C), /* ~= 10^147 */
+    U64 (0xC83553C5, 0xC8965D3D), U64 (0x6F928294, 0x94E5ACC7), /* ~= 10^148 */
+    U64 (0xFA42A8B7, 0x3ABBF48C), U64 (0xCB772339, 0xBA1F17F9), /* ~= 10^149 */
+    U64 (0x9C69A972, 0x84B578D7), U64 (0xFF2A7604, 0x14536EFB), /* ~= 10^150 */
+    U64 (0xC38413CF, 0x25E2D70D), U64 (0xFEF51385, 0x19684ABA), /* ~= 10^151 */
+    U64 (0xF46518C2, 0xEF5B8CD1), U64 (0x7EB25866, 0x5FC25D69), /* ~= 10^152 */
+    U64 (0x98BF2F79, 0xD5993802), U64 (0xEF2F773F, 0xFBD97A61), /* ~= 10^153 */
+    U64 (0xBEEEFB58, 0x4AFF8603), U64 (0xAAFB550F, 0xFACFD8FA), /* ~= 10^154 */
+    U64 (0xEEAABA2E, 0x5DBF6784), U64 (0x95BA2A53, 0xF983CF38), /* ~= 10^155 */
+    U64 (0x952AB45C, 0xFA97A0B2), U64 (0xDD945A74, 0x7BF26183), /* ~= 10^156 */
+    U64 (0xBA756174, 0x393D88DF), U64 (0x94F97111, 0x9AEEF9E4), /* ~= 10^157 */
+    U64 (0xE912B9D1, 0x478CEB17), U64 (0x7A37CD56, 0x01AAB85D), /* ~= 10^158 */
+    U64 (0x91ABB422, 0xCCB812EE), U64 (0xAC62E055, 0xC10AB33A), /* ~= 10^159 */
+    U64 (0xB616A12B, 0x7FE617AA), U64 (0x577B986B, 0x314D6009), /* ~= 10^160 */
+    U64 (0xE39C4976, 0x5FDF9D94), U64 (0xED5A7E85, 0xFDA0B80B), /* ~= 10^161 */
+    U64 (0x8E41ADE9, 0xFBEBC27D), U64 (0x14588F13, 0xBE847307), /* ~= 10^162 */
+    U64 (0xB1D21964, 0x7AE6B31C), U64 (0x596EB2D8, 0xAE258FC8), /* ~= 10^163 */
+    U64 (0xDE469FBD, 0x99A05FE3), U64 (0x6FCA5F8E, 0xD9AEF3BB), /* ~= 10^164 */
+    U64 (0x8AEC23D6, 0x80043BEE), U64 (0x25DE7BB9, 0x480D5854), /* ~= 10^165 */
+    U64 (0xADA72CCC, 0x20054AE9), U64 (0xAF561AA7, 0x9A10AE6A), /* ~= 10^166 */
+    U64 (0xD910F7FF, 0x28069DA4), U64 (0x1B2BA151, 0x8094DA04), /* ~= 10^167 */
+    U64 (0x87AA9AFF, 0x79042286), U64 (0x90FB44D2, 0xF05D0842), /* ~= 10^168 */
+    U64 (0xA99541BF, 0x57452B28), U64 (0x353A1607, 0xAC744A53), /* ~= 10^169 */
+    U64 (0xD3FA922F, 0x2D1675F2), U64 (0x42889B89, 0x97915CE8), /* ~= 10^170 */
+    U64 (0x847C9B5D, 0x7C2E09B7), U64 (0x69956135, 0xFEBADA11), /* ~= 10^171 */
+    U64 (0xA59BC234, 0xDB398C25), U64 (0x43FAB983, 0x7E699095), /* ~= 10^172 */
+    U64 (0xCF02B2C2, 0x1207EF2E), U64 (0x94F967E4, 0x5E03F4BB), /* ~= 10^173 */
+    U64 (0x8161AFB9, 0x4B44F57D), U64 (0x1D1BE0EE, 0xBAC278F5), /* ~= 10^174 */
+    U64 (0xA1BA1BA7, 0x9E1632DC), U64 (0x6462D92A, 0x69731732), /* ~= 10^175 */
+    U64 (0xCA28A291, 0x859BBF93), U64 (0x7D7B8F75, 0x03CFDCFE), /* ~= 10^176 */
+    U64 (0xFCB2CB35, 0xE702AF78), U64 (0x5CDA7352, 0x44C3D43E), /* ~= 10^177 */
+    U64 (0x9DEFBF01, 0xB061ADAB), U64 (0x3A088813, 0x6AFA64A7), /* ~= 10^178 */
+    U64 (0xC56BAEC2, 0x1C7A1916), U64 (0x088AAA18, 0x45B8FDD0), /* ~= 10^179 */
+    U64 (0xF6C69A72, 0xA3989F5B), U64 (0x8AAD549E, 0x57273D45), /* ~= 10^180 */
+    U64 (0x9A3C2087, 0xA63F6399), U64 (0x36AC54E2, 0xF678864B), /* ~= 10^181 */
+    U64 (0xC0CB28A9, 0x8FCF3C7F), U64 (0x84576A1B, 0xB416A7DD), /* ~= 10^182 */
+    U64 (0xF0FDF2D3, 0xF3C30B9F), U64 (0x656D44A2, 0xA11C51D5), /* ~= 10^183 */
+    U64 (0x969EB7C4, 0x7859E743), U64 (0x9F644AE5, 0xA4B1B325), /* ~= 10^184 */
+    U64 (0xBC4665B5, 0x96706114), U64 (0x873D5D9F, 0x0DDE1FEE), /* ~= 10^185 */
+    U64 (0xEB57FF22, 0xFC0C7959), U64 (0xA90CB506, 0xD155A7EA), /* ~= 10^186 */
+    U64 (0x9316FF75, 0xDD87CBD8), U64 (0x09A7F124, 0x42D588F2), /* ~= 10^187 */
+    U64 (0xB7DCBF53, 0x54E9BECE), U64 (0x0C11ED6D, 0x538AEB2F), /* ~= 10^188 */
+    U64 (0xE5D3EF28, 0x2A242E81), U64 (0x8F1668C8, 0xA86DA5FA), /* ~= 10^189 */
+    U64 (0x8FA47579, 0x1A569D10), U64 (0xF96E017D, 0x694487BC), /* ~= 10^190 */
+    U64 (0xB38D92D7, 0x60EC4455), U64 (0x37C981DC, 0xC395A9AC), /* ~= 10^191 */
+    U64 (0xE070F78D, 0x3927556A), U64 (0x85BBE253, 0xF47B1417), /* ~= 10^192 */
+    U64 (0x8C469AB8, 0x43B89562), U64 (0x93956D74, 0x78CCEC8E), /* ~= 10^193 */
+    U64 (0xAF584166, 0x54A6BABB), U64 (0x387AC8D1, 0x970027B2), /* ~= 10^194 */
+    U64 (0xDB2E51BF, 0xE9D0696A), U64 (0x06997B05, 0xFCC0319E), /* ~= 10^195 */
+    U64 (0x88FCF317, 0xF22241E2), U64 (0x441FECE3, 0xBDF81F03), /* ~= 10^196 */
+    U64 (0xAB3C2FDD, 0xEEAAD25A), U64 (0xD527E81C, 0xAD7626C3), /* ~= 10^197 */
+    U64 (0xD60B3BD5, 0x6A5586F1), U64 (0x8A71E223, 0xD8D3B074), /* ~= 10^198 */
+    U64 (0x85C70565, 0x62757456), U64 (0xF6872D56, 0x67844E49), /* ~= 10^199 */
+    U64 (0xA738C6BE, 0xBB12D16C), U64 (0xB428F8AC, 0x016561DB), /* ~= 10^200 */
+    U64 (0xD106F86E, 0x69D785C7), U64 (0xE13336D7, 0x01BEBA52), /* ~= 10^201 */
+    U64 (0x82A45B45, 0x0226B39C), U64 (0xECC00246, 0x61173473), /* ~= 10^202 */
+    U64 (0xA34D7216, 0x42B06084), U64 (0x27F002D7, 0xF95D0190), /* ~= 10^203 */
+    U64 (0xCC20CE9B, 0xD35C78A5), U64 (0x31EC038D, 0xF7B441F4), /* ~= 10^204 */
+    U64 (0xFF290242, 0xC83396CE), U64 (0x7E670471, 0x75A15271), /* ~= 10^205 */
+    U64 (0x9F79A169, 0xBD203E41), U64 (0x0F0062C6, 0xE984D386), /* ~= 10^206 */
+    U64 (0xC75809C4, 0x2C684DD1), U64 (0x52C07B78, 0xA3E60868), /* ~= 10^207 */
+    U64 (0xF92E0C35, 0x37826145), U64 (0xA7709A56, 0xCCDF8A82), /* ~= 10^208 */
+    U64 (0x9BBCC7A1, 0x42B17CCB), U64 (0x88A66076, 0x400BB691), /* ~= 10^209 */
+    U64 (0xC2ABF989, 0x935DDBFE), U64 (0x6ACFF893, 0xD00EA435), /* ~= 10^210 */
+    U64 (0xF356F7EB, 0xF83552FE), U64 (0x0583F6B8, 0xC4124D43), /* ~= 10^211 */
+    U64 (0x98165AF3, 0x7B2153DE), U64 (0xC3727A33, 0x7A8B704A), /* ~= 10^212 */
+    U64 (0xBE1BF1B0, 0x59E9A8D6), U64 (0x744F18C0, 0x592E4C5C), /* ~= 10^213 */
+    U64 (0xEDA2EE1C, 0x7064130C), U64 (0x1162DEF0, 0x6F79DF73), /* ~= 10^214 */
+    U64 (0x9485D4D1, 0xC63E8BE7), U64 (0x8ADDCB56, 0x45AC2BA8), /* ~= 10^215 */
+    U64 (0xB9A74A06, 0x37CE2EE1), U64 (0x6D953E2B, 0xD7173692), /* ~= 10^216 */
+    U64 (0xE8111C87, 0xC5C1BA99), U64 (0xC8FA8DB6, 0xCCDD0437), /* ~= 10^217 */
+    U64 (0x910AB1D4, 0xDB9914A0), U64 (0x1D9C9892, 0x400A22A2), /* ~= 10^218 */
+    U64 (0xB54D5E4A, 0x127F59C8), U64 (0x2503BEB6, 0xD00CAB4B), /* ~= 10^219 */
+    U64 (0xE2A0B5DC, 0x971F303A), U64 (0x2E44AE64, 0x840FD61D), /* ~= 10^220 */
+    U64 (0x8DA471A9, 0xDE737E24), U64 (0x5CEAECFE, 0xD289E5D2), /* ~= 10^221 */
+    U64 (0xB10D8E14, 0x56105DAD), U64 (0x7425A83E, 0x872C5F47), /* ~= 10^222 */
+    U64 (0xDD50F199, 0x6B947518), U64 (0xD12F124E, 0x28F77719), /* ~= 10^223 */
+    U64 (0x8A5296FF, 0xE33CC92F), U64 (0x82BD6B70, 0xD99AAA6F), /* ~= 10^224 */
+    U64 (0xACE73CBF, 0xDC0BFB7B), U64 (0x636CC64D, 0x1001550B), /* ~= 10^225 */
+    U64 (0xD8210BEF, 0xD30EFA5A), U64 (0x3C47F7E0, 0x5401AA4E), /* ~= 10^226 */
+    U64 (0x8714A775, 0xE3E95C78), U64 (0x65ACFAEC, 0x34810A71), /* ~= 10^227 */
+    U64 (0xA8D9D153, 0x5CE3B396), U64 (0x7F1839A7, 0x41A14D0D), /* ~= 10^228 */
+    U64 (0xD31045A8, 0x341CA07C), U64 (0x1EDE4811, 0x1209A050), /* ~= 10^229 */
+    U64 (0x83EA2B89, 0x2091E44D), U64 (0x934AED0A, 0xAB460432), /* ~= 10^230 */
+    U64 (0xA4E4B66B, 0x68B65D60), U64 (0xF81DA84D, 0x5617853F), /* ~= 10^231 */
+    U64 (0xCE1DE406, 0x42E3F4B9), U64 (0x36251260, 0xAB9D668E), /* ~= 10^232 */
+    U64 (0x80D2AE83, 0xE9CE78F3), U64 (0xC1D72B7C, 0x6B426019), /* ~= 10^233 */
+    U64 (0xA1075A24, 0xE4421730), U64 (0xB24CF65B, 0x8612F81F), /* ~= 10^234 */
+    U64 (0xC94930AE, 0x1D529CFC), U64 (0xDEE033F2, 0x6797B627), /* ~= 10^235 */
+    U64 (0xFB9B7CD9, 0xA4A7443C), U64 (0x169840EF, 0x017DA3B1), /* ~= 10^236 */
+    U64 (0x9D412E08, 0x06E88AA5), U64 (0x8E1F2895, 0x60EE864E), /* ~= 10^237 */
+    U64 (0xC491798A, 0x08A2AD4E), U64 (0xF1A6F2BA, 0xB92A27E2), /* ~= 10^238 */
+    U64 (0xF5B5D7EC, 0x8ACB58A2), U64 (0xAE10AF69, 0x6774B1DB), /* ~= 10^239 */
+    U64 (0x9991A6F3, 0xD6BF1765), U64 (0xACCA6DA1, 0xE0A8EF29), /* ~= 10^240 */
+    U64 (0xBFF610B0, 0xCC6EDD3F), U64 (0x17FD090A, 0x58D32AF3), /* ~= 10^241 */
+    U64 (0xEFF394DC, 0xFF8A948E), U64 (0xDDFC4B4C, 0xEF07F5B0), /* ~= 10^242 */
+    U64 (0x95F83D0A, 0x1FB69CD9), U64 (0x4ABDAF10, 0x1564F98E), /* ~= 10^243 */
+    U64 (0xBB764C4C, 0xA7A4440F), U64 (0x9D6D1AD4, 0x1ABE37F1), /* ~= 10^244 */
+    U64 (0xEA53DF5F, 0xD18D5513), U64 (0x84C86189, 0x216DC5ED), /* ~= 10^245 */
+    U64 (0x92746B9B, 0xE2F8552C), U64 (0x32FD3CF5, 0xB4E49BB4), /* ~= 10^246 */
+    U64 (0xB7118682, 0xDBB66A77), U64 (0x3FBC8C33, 0x221DC2A1), /* ~= 10^247 */
+    U64 (0xE4D5E823, 0x92A40515), U64 (0x0FABAF3F, 0xEAA5334A), /* ~= 10^248 */
+    U64 (0x8F05B116, 0x3BA6832D), U64 (0x29CB4D87, 0xF2A7400E), /* ~= 10^249 */
+    U64 (0xB2C71D5B, 0xCA9023F8), U64 (0x743E20E9, 0xEF511012), /* ~= 10^250 */
+    U64 (0xDF78E4B2, 0xBD342CF6), U64 (0x914DA924, 0x6B255416), /* ~= 10^251 */
+    U64 (0x8BAB8EEF, 0xB6409C1A), U64 (0x1AD089B6, 0xC2F7548E), /* ~= 10^252 */
+    U64 (0xAE9672AB, 0xA3D0C320), U64 (0xA184AC24, 0x73B529B1), /* ~= 10^253 */
+    U64 (0xDA3C0F56, 0x8CC4F3E8), U64 (0xC9E5D72D, 0x90A2741E), /* ~= 10^254 */
+    U64 (0x88658996, 0x17FB1871), U64 (0x7E2FA67C, 0x7A658892), /* ~= 10^255 */
+    U64 (0xAA7EEBFB, 0x9DF9DE8D), U64 (0xDDBB901B, 0x98FEEAB7), /* ~= 10^256 */
+    U64 (0xD51EA6FA, 0x85785631), U64 (0x552A7422, 0x7F3EA565), /* ~= 10^257 */
+    U64 (0x8533285C, 0x936B35DE), U64 (0xD53A8895, 0x8F87275F), /* ~= 10^258 */
+    U64 (0xA67FF273, 0xB8460356), U64 (0x8A892ABA, 0xF368F137), /* ~= 10^259 */
+    U64 (0xD01FEF10, 0xA657842C), U64 (0x2D2B7569, 0xB0432D85), /* ~= 10^260 */
+    U64 (0x8213F56A, 0x67F6B29B), U64 (0x9C3B2962, 0x0E29FC73), /* ~= 10^261 */
+    U64 (0xA298F2C5, 0x01F45F42), U64 (0x8349F3BA, 0x91B47B8F), /* ~= 10^262 */
+    U64 (0xCB3F2F76, 0x42717713), U64 (0x241C70A9, 0x36219A73), /* ~= 10^263 */
+    U64 (0xFE0EFB53, 0xD30DD4D7), U64 (0xED238CD3, 0x83AA0110), /* ~= 10^264 */
+    U64 (0x9EC95D14, 0x63E8A506), U64 (0xF4363804, 0x324A40AA), /* ~= 10^265 */
+    U64 (0xC67BB459, 0x7CE2CE48), U64 (0xB143C605, 0x3EDCD0D5), /* ~= 10^266 */
+    U64 (0xF81AA16F, 0xDC1B81DA), U64 (0xDD94B786, 0x8E94050A), /* ~= 10^267 */
+    U64 (0x9B10A4E5, 0xE9913128), U64 (0xCA7CF2B4, 0x191C8326), /* ~= 10^268 */
+    U64 (0xC1D4CE1F, 0x63F57D72), U64 (0xFD1C2F61, 0x1F63A3F0), /* ~= 10^269 */
+    U64 (0xF24A01A7, 0x3CF2DCCF), U64 (0xBC633B39, 0x673C8CEC), /* ~= 10^270 */
+    U64 (0x976E4108, 0x8617CA01), U64 (0xD5BE0503, 0xE085D813), /* ~= 10^271 */
+    U64 (0xBD49D14A, 0xA79DBC82), U64 (0x4B2D8644, 0xD8A74E18), /* ~= 10^272 */
+    U64 (0xEC9C459D, 0x51852BA2), U64 (0xDDF8E7D6, 0x0ED1219E), /* ~= 10^273 */
+    U64 (0x93E1AB82, 0x52F33B45), U64 (0xCABB90E5, 0xC942B503), /* ~= 10^274 */
+    U64 (0xB8DA1662, 0xE7B00A17), U64 (0x3D6A751F, 0x3B936243), /* ~= 10^275 */
+    U64 (0xE7109BFB, 0xA19C0C9D), U64 (0x0CC51267, 0x0A783AD4), /* ~= 10^276 */
+    U64 (0x906A617D, 0x450187E2), U64 (0x27FB2B80, 0x668B24C5), /* ~= 10^277 */
+    U64 (0xB484F9DC, 0x9641E9DA), U64 (0xB1F9F660, 0x802DEDF6), /* ~= 10^278 */
+    U64 (0xE1A63853, 0xBBD26451), U64 (0x5E7873F8, 0xA0396973), /* ~= 10^279 */
+    U64 (0x8D07E334, 0x55637EB2), U64 (0xDB0B487B, 0x6423E1E8), /* ~= 10^280 */
+    U64 (0xB049DC01, 0x6ABC5E5F), U64 (0x91CE1A9A, 0x3D2CDA62), /* ~= 10^281 */
+    U64 (0xDC5C5301, 0xC56B75F7), U64 (0x7641A140, 0xCC7810FB), /* ~= 10^282 */
+    U64 (0x89B9B3E1, 0x1B6329BA), U64 (0xA9E904C8, 0x7FCB0A9D), /* ~= 10^283 */
+    U64 (0xAC2820D9, 0x623BF429), U64 (0x546345FA, 0x9FBDCD44), /* ~= 10^284 */
+    U64 (0xD732290F, 0xBACAF133), U64 (0xA97C1779, 0x47AD4095), /* ~= 10^285 */
+    U64 (0x867F59A9, 0xD4BED6C0), U64 (0x49ED8EAB, 0xCCCC485D), /* ~= 10^286 */
+    U64 (0xA81F3014, 0x49EE8C70), U64 (0x5C68F256, 0xBFFF5A74), /* ~= 10^287 */
+    U64 (0xD226FC19, 0x5C6A2F8C), U64 (0x73832EEC, 0x6FFF3111), /* ~= 10^288 */
+    U64 (0x83585D8F, 0xD9C25DB7), U64 (0xC831FD53, 0xC5FF7EAB), /* ~= 10^289 */
+    U64 (0xA42E74F3, 0xD032F525), U64 (0xBA3E7CA8, 0xB77F5E55), /* ~= 10^290 */
+    U64 (0xCD3A1230, 0xC43FB26F), U64 (0x28CE1BD2, 0xE55F35EB), /* ~= 10^291 */
+    U64 (0x80444B5E, 0x7AA7CF85), U64 (0x7980D163, 0xCF5B81B3), /* ~= 10^292 */
+    U64 (0xA0555E36, 0x1951C366), U64 (0xD7E105BC, 0xC332621F), /* ~= 10^293 */
+    U64 (0xC86AB5C3, 0x9FA63440), U64 (0x8DD9472B, 0xF3FEFAA7), /* ~= 10^294 */
+    U64 (0xFA856334, 0x878FC150), U64 (0xB14F98F6, 0xF0FEB951), /* ~= 10^295 */
+    U64 (0x9C935E00, 0xD4B9D8D2), U64 (0x6ED1BF9A, 0x569F33D3), /* ~= 10^296 */
+    U64 (0xC3B83581, 0x09E84F07), U64 (0x0A862F80, 0xEC4700C8), /* ~= 10^297 */
+    U64 (0xF4A642E1, 0x4C6262C8), U64 (0xCD27BB61, 0x2758C0FA), /* ~= 10^298 */
+    U64 (0x98E7E9CC, 0xCFBD7DBD), U64 (0x8038D51C, 0xB897789C), /* ~= 10^299 */
+    U64 (0xBF21E440, 0x03ACDD2C), U64 (0xE0470A63, 0xE6BD56C3), /* ~= 10^300 */
+    U64 (0xEEEA5D50, 0x04981478), U64 (0x1858CCFC, 0xE06CAC74), /* ~= 10^301 */
+    U64 (0x95527A52, 0x02DF0CCB), U64 (0x0F37801E, 0x0C43EBC8), /* ~= 10^302 */
+    U64 (0xBAA718E6, 0x8396CFFD), U64 (0xD3056025, 0x8F54E6BA), /* ~= 10^303 */
+    U64 (0xE950DF20, 0x247C83FD), U64 (0x47C6B82E, 0xF32A2069), /* ~= 10^304 */
+    U64 (0x91D28B74, 0x16CDD27E), U64 (0x4CDC331D, 0x57FA5441), /* ~= 10^305 */
+    U64 (0xB6472E51, 0x1C81471D), U64 (0xE0133FE4, 0xADF8E952), /* ~= 10^306 */
+    U64 (0xE3D8F9E5, 0x63A198E5), U64 (0x58180FDD, 0xD97723A6), /* ~= 10^307 */
+    U64 (0x8E679C2F, 0x5E44FF8F), U64 (0x570F09EA, 0xA7EA7648), /* ~= 10^308 */
+    U64 (0xB201833B, 0x35D63F73), U64 (0x2CD2CC65, 0x51E513DA), /* ~= 10^309 */
+    U64 (0xDE81E40A, 0x034BCF4F), U64 (0xF8077F7E, 0xA65E58D1), /* ~= 10^310 */
+    U64 (0x8B112E86, 0x420F6191), U64 (0xFB04AFAF, 0x27FAF782), /* ~= 10^311 */
+    U64 (0xADD57A27, 0xD29339F6), U64 (0x79C5DB9A, 0xF1F9B563), /* ~= 10^312 */
+    U64 (0xD94AD8B1, 0xC7380874), U64 (0x18375281, 0xAE7822BC), /* ~= 10^313 */
+    U64 (0x87CEC76F, 0x1C830548), U64 (0x8F229391, 0x0D0B15B5), /* ~= 10^314 */
+    U64 (0xA9C2794A, 0xE3A3C69A), U64 (0xB2EB3875, 0x504DDB22), /* ~= 10^315 */
+    U64 (0xD433179D, 0x9C8CB841), U64 (0x5FA60692, 0xA46151EB), /* ~= 10^316 */
+    U64 (0x849FEEC2, 0x81D7F328), U64 (0xDBC7C41B, 0xA6BCD333), /* ~= 10^317 */
+    U64 (0xA5C7EA73, 0x224DEFF3), U64 (0x12B9B522, 0x906C0800), /* ~= 10^318 */
+    U64 (0xCF39E50F, 0xEAE16BEF), U64 (0xD768226B, 0x34870A00), /* ~= 10^319 */
+    U64 (0x81842F29, 0xF2CCE375), U64 (0xE6A11583, 0x00D46640), /* ~= 10^320 */
+    U64 (0xA1E53AF4, 0x6F801C53), U64 (0x60495AE3, 0xC1097FD0), /* ~= 10^321 */
+    U64 (0xCA5E89B1, 0x8B602368), U64 (0x385BB19C, 0xB14BDFC4), /* ~= 10^322 */
+    U64 (0xFCF62C1D, 0xEE382C42), U64 (0x46729E03, 0xDD9ED7B5), /* ~= 10^323 */
+    U64 (0x9E19DB92, 0xB4E31BA9), U64 (0x6C07A2C2, 0x6A8346D1)  /* ~= 10^324 */
 };
 
 /**
@@ -2648,24 +2979,26 @@ static const u64 pow10_sig_table[] = {
  @param hi    The highest 64 bits of pow(10, e).
  @param lo    The lower 64 bits after `hi`.
  */
-static_inline void pow10_table_get_sig(i32 exp10, u64 *hi, u64 *lo) {
-    i32 idx = exp10 - (POW10_SIG_TABLE_MIN_EXP);
-    *hi = pow10_sig_table[idx * 2];
-    *lo = pow10_sig_table[idx * 2 + 1];
+static_inline void
+pow10_table_get_sig (i32 exp10, u64 *hi, u64 *lo)
+{
+  i32 idx = exp10 - (POW10_SIG_TABLE_MIN_EXP);
+  *hi     = pow10_sig_table[idx * 2];
+  *lo     = pow10_sig_table[idx * 2 + 1];
 }
 
 /**
  Get the exponent (base 2) for highest 64 bits significand in pow10_sig_table.
  */
-static_inline void pow10_table_get_exp(i32 exp10, i32 *exp2) {
-    /* e2 = floor(log2(pow(10, e))) - 64 + 1 */
-    /*    = floor(e * log2(10) - 63)         */
-    *exp2 = (exp10 * 217706 - 4128768) >> 16;
+static_inline void
+pow10_table_get_exp (i32 exp10, i32 *exp2)
+{
+  /* e2 = floor(log2(pow(10, e))) - 64 + 1 */
+  /*    = floor(e * log2(10) - 63)         */
+  *exp2 = (exp10 * 217706 - 4128768) >> 16;
 }
 
 #endif
-
-
 
 #if !YYJSON_DISABLE_READER
 
@@ -2677,28 +3010,28 @@ static_inline void pow10_table_get_exp(i32 exp10, i32 *exp2) {
 typedef u8 char_type;
 
 /** Whitespace character: ' ', '\\t', '\\n', '\\r'. */
-static const char_type CHAR_TYPE_SPACE      = 1 << 0;
+static const char_type CHAR_TYPE_SPACE = 1 << 0;
 
 /** Number character: '-', [0-9]. */
-static const char_type CHAR_TYPE_NUMBER     = 1 << 1;
+static const char_type CHAR_TYPE_NUMBER = 1 << 1;
 
 /** JSON Escaped character: '"', '\', [0x00-0x1F]. */
-static const char_type CHAR_TYPE_ESC_ASCII  = 1 << 2;
+static const char_type CHAR_TYPE_ESC_ASCII = 1 << 2;
 
 /** Non-ASCII character: [0x80-0xFF]. */
-static const char_type CHAR_TYPE_NON_ASCII  = 1 << 3;
+static const char_type CHAR_TYPE_NON_ASCII = 1 << 3;
 
 /** JSON container character: '{', '['. */
-static const char_type CHAR_TYPE_CONTAINER  = 1 << 4;
+static const char_type CHAR_TYPE_CONTAINER = 1 << 4;
 
 /** Comment character: '/'. */
-static const char_type CHAR_TYPE_COMMENT    = 1 << 5;
+static const char_type CHAR_TYPE_COMMENT = 1 << 5;
 
 /** Line end character: '\\n', '\\r', '\0'. */
-static const char_type CHAR_TYPE_LINE_END   = 1 << 6;
+static const char_type CHAR_TYPE_LINE_END = 1 << 6;
 
 /** Hexadecimal numeric character: [0-9a-fA-F]. */
-static const char_type CHAR_TYPE_HEX        = 1 << 7;
+static const char_type CHAR_TYPE_HEX = 1 << 7;
 
 /** Character type table (generate with misc/make_tables.c) */
 static const char_type char_table[256] = {
@@ -2733,51 +3066,64 @@ static const char_type char_table[256] = {
     0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
     0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
     0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
-    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08
-};
+    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08};
 
 /** Match a character with specified type. */
-static_inline bool char_is_type(u8 c, char_type type) {
-    return (char_table[c] & type) != 0;
+static_inline bool
+char_is_type (u8 c, char_type type)
+{
+  return (char_table[c] & type) != 0;
 }
 
 /** Match a whitespace: ' ', '\\t', '\\n', '\\r'. */
-static_inline bool char_is_space(u8 c) {
-    return char_is_type(c, (char_type)CHAR_TYPE_SPACE);
+static_inline bool
+char_is_space (u8 c)
+{
+  return char_is_type (c, (char_type)CHAR_TYPE_SPACE);
 }
 
 /** Match a whitespace or comment: ' ', '\\t', '\\n', '\\r', '/'. */
-static_inline bool char_is_space_or_comment(u8 c) {
-    return char_is_type(c, (char_type)(CHAR_TYPE_SPACE | CHAR_TYPE_COMMENT));
+static_inline bool
+char_is_space_or_comment (u8 c)
+{
+  return char_is_type (c, (char_type)(CHAR_TYPE_SPACE | CHAR_TYPE_COMMENT));
 }
 
 /** Match a JSON number: '-', [0-9]. */
-static_inline bool char_is_number(u8 c) {
-    return char_is_type(c, (char_type)CHAR_TYPE_NUMBER);
+static_inline bool
+char_is_number (u8 c)
+{
+  return char_is_type (c, (char_type)CHAR_TYPE_NUMBER);
 }
 
 /** Match a JSON container: '{', '['. */
-static_inline bool char_is_container(u8 c) {
-    return char_is_type(c, (char_type)CHAR_TYPE_CONTAINER);
+static_inline bool
+char_is_container (u8 c)
+{
+  return char_is_type (c, (char_type)CHAR_TYPE_CONTAINER);
 }
 
 /** Match a stop character in ASCII string: '"', '\', [0x00-0x1F,0x80-0xFF]. */
-static_inline bool char_is_ascii_stop(u8 c) {
-    return char_is_type(c, (char_type)(CHAR_TYPE_ESC_ASCII |
-                                       CHAR_TYPE_NON_ASCII));
+static_inline bool
+char_is_ascii_stop (u8 c)
+{
+  return char_is_type (c, (char_type)(CHAR_TYPE_ESC_ASCII |
+                                      CHAR_TYPE_NON_ASCII));
 }
 
 /** Match a line end character: '\\n', '\\r', '\0'. */
-static_inline bool char_is_line_end(u8 c) {
-    return char_is_type(c, (char_type)CHAR_TYPE_LINE_END);
+static_inline bool
+char_is_line_end (u8 c)
+{
+  return char_is_type (c, (char_type)CHAR_TYPE_LINE_END);
 }
 
 /** Match a hexadecimal numeric character: [0-9a-fA-F]. */
-static_inline bool char_is_hex(u8 c) {
-    return char_is_type(c, (char_type)CHAR_TYPE_HEX);
+static_inline bool
+char_is_hex (u8 c)
+{
+  return char_is_type (c, (char_type)CHAR_TYPE_HEX);
 }
-
-
 
 /*==============================================================================
  * Digit Character Matcher
@@ -2787,22 +3133,22 @@ static_inline bool char_is_hex(u8 c) {
 typedef u8 digi_type;
 
 /** Digit: '0'. */
-static const digi_type DIGI_TYPE_ZERO       = 1 << 0;
+static const digi_type DIGI_TYPE_ZERO = 1 << 0;
 
 /** Digit: [1-9]. */
-static const digi_type DIGI_TYPE_NONZERO    = 1 << 1;
+static const digi_type DIGI_TYPE_NONZERO = 1 << 1;
 
 /** Plus sign (positive): '+'. */
-static const digi_type DIGI_TYPE_POS        = 1 << 2;
+static const digi_type DIGI_TYPE_POS = 1 << 2;
 
 /** Minus sign (negative): '-'. */
-static const digi_type DIGI_TYPE_NEG        = 1 << 3;
+static const digi_type DIGI_TYPE_NEG = 1 << 3;
 
 /** Decimal point: '.' */
-static const digi_type DIGI_TYPE_DOT        = 1 << 4;
+static const digi_type DIGI_TYPE_DOT = 1 << 4;
 
 /** Exponent sign: 'e, 'E'. */
-static const digi_type DIGI_TYPE_EXP        = 1 << 5;
+static const digi_type DIGI_TYPE_EXP = 1 << 5;
 
 /** Digit type table (generate with misc/make_tables.c) */
 static const digi_type digi_table[256] = {
@@ -2821,46 +3167,57 @@ static const digi_type digi_table[256] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-};
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
 /** Match a character with specified type. */
-static_inline bool digi_is_type(u8 d, digi_type type) {
-    return (digi_table[d] & type) != 0;
+static_inline bool
+digi_is_type (u8 d, digi_type type)
+{
+  return (digi_table[d] & type) != 0;
 }
 
 /** Match a sign: '+', '-' */
-static_inline bool digi_is_sign(u8 d) {
-    return digi_is_type(d, (digi_type)(DIGI_TYPE_POS | DIGI_TYPE_NEG));
+static_inline bool
+digi_is_sign (u8 d)
+{
+  return digi_is_type (d, (digi_type)(DIGI_TYPE_POS | DIGI_TYPE_NEG));
 }
 
 /** Match a none zero digit: [1-9] */
-static_inline bool digi_is_nonzero(u8 d) {
-    return digi_is_type(d, (digi_type)DIGI_TYPE_NONZERO);
+static_inline bool
+digi_is_nonzero (u8 d)
+{
+  return digi_is_type (d, (digi_type)DIGI_TYPE_NONZERO);
 }
 
 /** Match a digit: [0-9] */
-static_inline bool digi_is_digit(u8 d) {
-    return digi_is_type(d, (digi_type)(DIGI_TYPE_ZERO | DIGI_TYPE_NONZERO));
+static_inline bool
+digi_is_digit (u8 d)
+{
+  return digi_is_type (d, (digi_type)(DIGI_TYPE_ZERO | DIGI_TYPE_NONZERO));
 }
 
 /** Match an exponent sign: 'e', 'E'. */
-static_inline bool digi_is_exp(u8 d) {
-    return digi_is_type(d, (digi_type)DIGI_TYPE_EXP);
+static_inline bool
+digi_is_exp (u8 d)
+{
+  return digi_is_type (d, (digi_type)DIGI_TYPE_EXP);
 }
 
 /** Match a floating point indicator: '.', 'e', 'E'. */
-static_inline bool digi_is_fp(u8 d) {
-    return digi_is_type(d, (digi_type)(DIGI_TYPE_DOT | DIGI_TYPE_EXP));
+static_inline bool
+digi_is_fp (u8 d)
+{
+  return digi_is_type (d, (digi_type)(DIGI_TYPE_DOT | DIGI_TYPE_EXP));
 }
 
 /** Match a digit or floating point indicator: [0-9], '.', 'e', 'E'. */
-static_inline bool digi_is_digit_or_fp(u8 d) {
-    return digi_is_type(d, (digi_type)(DIGI_TYPE_ZERO | DIGI_TYPE_NONZERO |
-                                       DIGI_TYPE_DOT | DIGI_TYPE_EXP));
+static_inline bool
+digi_is_digit_or_fp (u8 d)
+{
+  return digi_is_type (d, (digi_type)(DIGI_TYPE_ZERO | DIGI_TYPE_NONZERO |
+                                      DIGI_TYPE_DOT | DIGI_TYPE_EXP));
 }
-
-
 
 /*==============================================================================
  * Hex Character Reader
@@ -2905,28 +3262,27 @@ static const u8 hex_conv_table[256] = {
     0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
     0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
     0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0
-};
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0};
 
 /**
  Scans an escaped character sequence as a UTF-16 code unit (branchless).
  e.g. "\\u005C" should pass "005C" as `cur`.
- 
+
  This requires the string has 4-byte zero padding.
  */
-static_inline bool read_hex_u16(const u8 *cur, u16 *val) {
-    u16 c0, c1, c2, c3, t0, t1;
-    c0 = hex_conv_table[cur[0]];
-    c1 = hex_conv_table[cur[1]];
-    c2 = hex_conv_table[cur[2]];
-    c3 = hex_conv_table[cur[3]];
-    t0 = (u16)((c0 << 8) | c2);
-    t1 = (u16)((c1 << 8) | c3);
-    *val = (u16)((t0 << 4) | t1);
-    return ((t0 | t1) & (u16)0xF0F0) == 0;
+static_inline bool
+read_hex_u16 (const u8 *cur, u16 *val)
+{
+  u16 c0, c1, c2, c3, t0, t1;
+  c0   = hex_conv_table[cur[0]];
+  c1   = hex_conv_table[cur[1]];
+  c2   = hex_conv_table[cur[2]];
+  c3   = hex_conv_table[cur[3]];
+  t0   = (u16)((c0 << 8) | c2);
+  t1   = (u16)((c1 << 8) | c3);
+  *val = (u16)((t0 << 4) | t1);
+  return ((t0 | t1) & (u16)0xF0F0) == 0;
 }
-
-
 
 /*==============================================================================
  * JSON Reader Utils
@@ -2934,339 +3290,438 @@ static_inline bool read_hex_u16(const u8 *cur, u16 *val) {
  *============================================================================*/
 
 /** Read 'true' literal, '*cur' should be 't'. */
-static_inline bool read_true(u8 **ptr, yyjson_val *val) {
-    u8 *cur = *ptr;
-    u8 **end = ptr;
-    if (likely(byte_match_4(cur, "true"))) {
-        val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE;
-        *end = cur + 4;
-        return true;
-    }
-    return false;
+static_inline bool
+read_true (u8 **ptr, yyjson_val *val)
+{
+  u8 *cur  = *ptr;
+  u8 **end = ptr;
+  if (likely (byte_match_4 (cur, "true")))
+  {
+    val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE;
+    *end     = cur + 4;
+    return true;
+  }
+  return false;
 }
 
 /** Read 'false' literal, '*cur' should be 'f'. */
-static_inline bool read_false(u8 **ptr, yyjson_val *val) {
-    u8 *cur = *ptr;
-    u8 **end = ptr;
-    if (likely(byte_match_4(cur + 1, "alse"))) {
-        val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE;
-        *end = cur + 5;
-        return true;
-    }
-    return false;
+static_inline bool
+read_false (u8 **ptr, yyjson_val *val)
+{
+  u8 *cur  = *ptr;
+  u8 **end = ptr;
+  if (likely (byte_match_4 (cur + 1, "alse")))
+  {
+    val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE;
+    *end     = cur + 5;
+    return true;
+  }
+  return false;
 }
 
 /** Read 'null' literal, '*cur' should be 'n'. */
-static_inline bool read_null(u8 **ptr, yyjson_val *val) {
-    u8 *cur = *ptr;
-    u8 **end = ptr;
-    if (likely(byte_match_4(cur, "null"))) {
-        val->tag = YYJSON_TYPE_NULL;
-        *end = cur + 4;
-        return true;
-    }
-    return false;
+static_inline bool
+read_null (u8 **ptr, yyjson_val *val)
+{
+  u8 *cur  = *ptr;
+  u8 **end = ptr;
+  if (likely (byte_match_4 (cur, "null")))
+  {
+    val->tag = YYJSON_TYPE_NULL;
+    *end     = cur + 4;
+    return true;
+  }
+  return false;
 }
 
 /** Read 'Inf' or 'Infinity' literal (ignoring case). */
-static_inline bool read_inf(bool sign, u8 **ptr, u8 **pre, yyjson_val *val) {
+static_inline bool
+read_inf (bool sign, u8 **ptr, u8 **pre, yyjson_val *val)
+{
 #if !YYJSON_DISABLE_NON_STANDARD
-    u8 *hdr = *ptr - sign;
-    u8 *cur = *ptr;
-    u8 **end = ptr;
-    if ((cur[0] == 'I' || cur[0] == 'i') &&
-        (cur[1] == 'N' || cur[1] == 'n') &&
-        (cur[2] == 'F' || cur[2] == 'f')) {
-        if ((cur[3] == 'I' || cur[3] == 'i') &&
-            (cur[4] == 'N' || cur[4] == 'n') &&
-            (cur[5] == 'I' || cur[5] == 'i') &&
-            (cur[6] == 'T' || cur[6] == 't') &&
-            (cur[7] == 'Y' || cur[7] == 'y')) {
-            cur += 8;
-        } else {
-            cur += 3;
-        }
-        *end = cur;
-        if (pre) {
-            /* add null-terminator for previous raw string */
-            if (*pre) **pre = '\0';
-            *pre = cur;
-            val->tag = ((u64)(cur - hdr) << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW;
-            val->uni.str = (const char *)hdr;
-        } else {
-            val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
-            val->uni.u64 = f64_raw_get_inf(sign);
-        }
-        return true;
+  u8 *hdr  = *ptr - sign;
+  u8 *cur  = *ptr;
+  u8 **end = ptr;
+  if ((cur[0] == 'I' || cur[0] == 'i') &&
+      (cur[1] == 'N' || cur[1] == 'n') &&
+      (cur[2] == 'F' || cur[2] == 'f'))
+  {
+    if ((cur[3] == 'I' || cur[3] == 'i') &&
+        (cur[4] == 'N' || cur[4] == 'n') &&
+        (cur[5] == 'I' || cur[5] == 'i') &&
+        (cur[6] == 'T' || cur[6] == 't') &&
+        (cur[7] == 'Y' || cur[7] == 'y'))
+    {
+      cur += 8;
     }
+    else
+    {
+      cur += 3;
+    }
+    *end = cur;
+    if (pre)
+    {
+      /* add null-terminator for previous raw string */
+      if (*pre)
+        **pre = '\0';
+      *pre         = cur;
+      val->tag     = ((u64)(cur - hdr) << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW;
+      val->uni.str = (const char *)hdr;
+    }
+    else
+    {
+      val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
+      val->uni.u64 = f64_raw_get_inf (sign);
+    }
+    return true;
+  }
 #endif
-    return false;
+  return false;
 }
 
 /** Read 'NaN' literal (ignoring case). */
-static_inline bool read_nan(bool sign, u8 **ptr, u8 **pre, yyjson_val *val) {
+static_inline bool
+read_nan (bool sign, u8 **ptr, u8 **pre, yyjson_val *val)
+{
 #if !YYJSON_DISABLE_NON_STANDARD
-    u8 *hdr = *ptr - sign;
-    u8 *cur = *ptr;
-    u8 **end = ptr;
-    if ((cur[0] == 'N' || cur[0] == 'n') &&
-        (cur[1] == 'A' || cur[1] == 'a') &&
-        (cur[2] == 'N' || cur[2] == 'n')) {
-        cur += 3;
-        *end = cur;
-        if (pre) {
-            /* add null-terminator for previous raw string */
-            if (*pre) **pre = '\0';
-            *pre = cur;
-            val->tag = ((u64)(cur - hdr) << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW;
-            val->uni.str = (const char *)hdr;
-        } else {
-            val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
-            val->uni.u64 = f64_raw_get_nan(sign);
-        }
-        return true;
+  u8 *hdr  = *ptr - sign;
+  u8 *cur  = *ptr;
+  u8 **end = ptr;
+  if ((cur[0] == 'N' || cur[0] == 'n') &&
+      (cur[1] == 'A' || cur[1] == 'a') &&
+      (cur[2] == 'N' || cur[2] == 'n'))
+  {
+    cur += 3;
+    *end = cur;
+    if (pre)
+    {
+      /* add null-terminator for previous raw string */
+      if (*pre)
+        **pre = '\0';
+      *pre         = cur;
+      val->tag     = ((u64)(cur - hdr) << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW;
+      val->uni.str = (const char *)hdr;
     }
+    else
+    {
+      val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
+      val->uni.u64 = f64_raw_get_nan (sign);
+    }
+    return true;
+  }
 #endif
-    return false;
+  return false;
 }
 
 /** Read 'Inf', 'Infinity' or 'NaN' literal (ignoring case). */
-static_inline bool read_inf_or_nan(bool sign, u8 **ptr, u8 **pre,
-                                   yyjson_val *val) {
-    if (read_inf(sign, ptr, pre, val)) return true;
-    if (read_nan(sign, ptr, pre, val)) return true;
-    return false;
+static_inline bool
+read_inf_or_nan (bool sign, u8 **ptr, u8 **pre,
+                 yyjson_val *val)
+{
+  if (read_inf (sign, ptr, pre, val))
+    return true;
+  if (read_nan (sign, ptr, pre, val))
+    return true;
+  return false;
 }
 
 /** Read a JSON number as raw string. */
-static_noinline bool read_number_raw(u8 **ptr,
-                                     u8 **pre,
-                                     bool ext,
-                                     yyjson_val *val,
-                                     const char **msg) {
-    
-#define return_err(_pos, _msg) do { \
-    *msg = _msg; \
-    *end = _pos; \
-    return false; \
-} while (false)
-    
-#define return_raw() do { \
-    val->tag = ((u64)(cur - hdr) << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW; \
-    val->uni.str = (const char *)hdr; \
-    *pre = cur; *end = cur; return true; \
-} while (false)
-    
-    u8 *hdr = *ptr;
-    u8 *cur = *ptr;
-    u8 **end = ptr;
-    
-    /* add null-terminator for previous raw string */
-    if (*pre) **pre = '\0';
-    
-    /* skip sign */
-    cur += (*cur == '-');
-    
-    /* read first digit, check leading zero */
-    if (unlikely(!digi_is_digit(*cur))) {
-        if (unlikely(ext)) {
-            if (read_inf_or_nan(*hdr == '-', &cur, pre, val)) return_raw();
-        }
-        return_err(cur, "no digit after minus sign");
+static_noinline bool
+read_number_raw (u8 **ptr,
+                 u8 **pre,
+                 bool ext,
+                 yyjson_val *val,
+                 const char **msg)
+{
+
+#define return_err(_pos, _msg) \
+  do                           \
+  {                            \
+    *msg = _msg;               \
+    *end = _pos;               \
+    return false;              \
+  } while (false)
+
+#define return_raw()                                                       \
+  do                                                                       \
+  {                                                                        \
+    val->tag     = ((u64)(cur - hdr) << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW; \
+    val->uni.str = (const char *)hdr;                                      \
+    *pre         = cur;                                                    \
+    *end         = cur;                                                    \
+    return true;                                                           \
+  } while (false)
+
+  u8 *hdr  = *ptr;
+  u8 *cur  = *ptr;
+  u8 **end = ptr;
+
+  /* add null-terminator for previous raw string */
+  if (*pre)
+    **pre = '\0';
+
+  /* skip sign */
+  cur += (*cur == '-');
+
+  /* read first digit, check leading zero */
+  if (unlikely (!digi_is_digit (*cur)))
+  {
+    if (unlikely (ext))
+    {
+      if (read_inf_or_nan (*hdr == '-', &cur, pre, val))
+        return_raw ();
     }
-    
-    /* read integral part */
-    if (*cur == '0') {
-        cur++;
-        if (unlikely(digi_is_digit(*cur))) {
-            return_err(cur - 1, "number with leading zero is not allowed");
-        }
-        if (!digi_is_fp(*cur)) return_raw();
-    } else {
-        while (digi_is_digit(*cur)) cur++;
-        if (!digi_is_fp(*cur)) return_raw();
+    return_err (cur, "no digit after minus sign");
+  }
+
+  /* read integral part */
+  if (*cur == '0')
+  {
+    cur++;
+    if (unlikely (digi_is_digit (*cur)))
+    {
+      return_err (cur - 1, "number with leading zero is not allowed");
     }
-    
-    /* read fraction part */
-    if (*cur == '.') {
-        cur++;
-        if (!digi_is_digit(*cur++)) {
-            return_err(cur, "no digit after decimal point");
-        }
-        while (digi_is_digit(*cur)) cur++;
+    if (!digi_is_fp (*cur))
+      return_raw ();
+  }
+  else
+  {
+    while (digi_is_digit (*cur))
+      cur++;
+    if (!digi_is_fp (*cur))
+      return_raw ();
+  }
+
+  /* read fraction part */
+  if (*cur == '.')
+  {
+    cur++;
+    if (!digi_is_digit (*cur++))
+    {
+      return_err (cur, "no digit after decimal point");
     }
-    
-    /* read exponent part */
-    if (digi_is_exp(*cur)) {
-        cur += 1 + digi_is_sign(cur[1]);
-        if (!digi_is_digit(*cur++)) {
-            return_err(cur, "no digit after exponent sign");
-        }
-        while (digi_is_digit(*cur)) cur++;
+    while (digi_is_digit (*cur))
+      cur++;
+  }
+
+  /* read exponent part */
+  if (digi_is_exp (*cur))
+  {
+    cur += 1 + digi_is_sign (cur[1]);
+    if (!digi_is_digit (*cur++))
+    {
+      return_err (cur, "no digit after exponent sign");
     }
-    
-    return_raw();
-    
+    while (digi_is_digit (*cur))
+      cur++;
+  }
+
+  return_raw ();
+
 #undef return_err
 #undef return_raw
 }
 
 /**
  Skips spaces and comments as many as possible.
- 
+
  It will return false in these cases:
     1. No character is skipped. The 'end' pointer is set as input cursor.
     2. A multiline comment is not closed. The 'end' pointer is set as the head
        of this comment block.
  */
-static_noinline bool skip_spaces_and_comments(u8 **ptr) {
-    u8 *hdr = *ptr;
-    u8 *cur = *ptr;
-    u8 **end = ptr;
-    while (true) {
-        if (byte_match_2(cur, "/*")) {
-            hdr = cur;
-            cur += 2;
-            while (true) {
-                if (byte_match_2(cur, "*/")) {
-                    cur += 2;
-                    break;
-                }
-                if (*cur == 0) {
-                    *end = hdr;
-                    return false;
-                }
-                cur++;
-            }
-            continue;
+static_noinline bool
+skip_spaces_and_comments (u8 **ptr)
+{
+  u8 *hdr  = *ptr;
+  u8 *cur  = *ptr;
+  u8 **end = ptr;
+  while (true)
+  {
+    if (byte_match_2 (cur, "/*"))
+    {
+      hdr = cur;
+      cur += 2;
+      while (true)
+      {
+        if (byte_match_2 (cur, "*/"))
+        {
+          cur += 2;
+          break;
         }
-        if (byte_match_2(cur, "//")) {
-            cur += 2;
-            while (!char_is_line_end(*cur)) cur++;
-            continue;
+        if (*cur == 0)
+        {
+          *end = hdr;
+          return false;
         }
-        if (char_is_space(*cur)) {
-            cur += 1;
-            while (char_is_space(*cur)) cur++;
-            continue;
-        }
-        break;
+        cur++;
+      }
+      continue;
     }
-    *end = cur;
-    return hdr != cur;
+    if (byte_match_2 (cur, "//"))
+    {
+      cur += 2;
+      while (!char_is_line_end (*cur))
+        cur++;
+      continue;
+    }
+    if (char_is_space (*cur))
+    {
+      cur += 1;
+      while (char_is_space (*cur))
+        cur++;
+      continue;
+    }
+    break;
+  }
+  *end = cur;
+  return hdr != cur;
 }
 
 /**
  Check truncated string.
  Returns true if `cur` match `str` but is truncated.
  */
-static_inline bool is_truncated_str(u8 *cur, u8 *end,
-                                    const char *str,
-                                    bool case_sensitive) {
-    usize len = strlen(str);
-    if (cur + len <= end || end <= cur) return false;
-    if (case_sensitive) {
-        return memcmp(cur, str, (usize)(end - cur)) == 0;
+static_inline bool
+is_truncated_str (u8 *cur, u8 *end,
+                  const char *str,
+                  bool case_sensitive)
+{
+  usize len = strlen (str);
+  if (cur + len <= end || end <= cur)
+    return false;
+  if (case_sensitive)
+  {
+    return memcmp (cur, str, (usize)(end - cur)) == 0;
+  }
+  for (; cur < end; cur++, str++)
+  {
+    if ((*cur != (u8)*str) && (*cur != (u8)*str - 'a' + 'A'))
+    {
+      return false;
     }
-    for (; cur < end; cur++, str++) {
-        if ((*cur != (u8)*str) && (*cur != (u8)*str - 'a' + 'A')) {
-            return false;
-        }
-    }
-    return true;
+  }
+  return true;
 }
 
 /**
  Check truncated JSON on parsing errors.
  Returns true if the input is valid but truncated.
  */
-static_noinline bool is_truncated_end(u8 *hdr, u8 *cur, u8 *end,
-                                      yyjson_read_code code,
-                                      yyjson_read_flag flg) {
-    if (cur >= end) return true;
-    if (code == YYJSON_READ_ERROR_LITERAL) {
-        if (is_truncated_str(cur, end, "true", true) ||
-            is_truncated_str(cur, end, "false", true) ||
-            is_truncated_str(cur, end, "null", true)) {
-            return true;
-        }
+static_noinline bool
+is_truncated_end (u8 *hdr, u8 *cur, u8 *end,
+                  yyjson_read_code code,
+                  yyjson_read_flag flg)
+{
+  if (cur >= end)
+    return true;
+  if (code == YYJSON_READ_ERROR_LITERAL)
+  {
+    if (is_truncated_str (cur, end, "true", true) ||
+        is_truncated_str (cur, end, "false", true) ||
+        is_truncated_str (cur, end, "null", true))
+    {
+      return true;
     }
-    if (code == YYJSON_READ_ERROR_UNEXPECTED_CHARACTER ||
-        code == YYJSON_READ_ERROR_INVALID_NUMBER ||
-        code == YYJSON_READ_ERROR_LITERAL) {
-        if ((flg & YYJSON_READ_ALLOW_INF_AND_NAN)) {
-            if (*cur == '-') cur++;
-            if (is_truncated_str(cur, end, "infinity", false) ||
-                is_truncated_str(cur, end, "nan", false)) {
-                return true;
-            }
-        }
+  }
+  if (code == YYJSON_READ_ERROR_UNEXPECTED_CHARACTER ||
+      code == YYJSON_READ_ERROR_INVALID_NUMBER ||
+      code == YYJSON_READ_ERROR_LITERAL)
+  {
+    if ((flg & YYJSON_READ_ALLOW_INF_AND_NAN))
+    {
+      if (*cur == '-')
+        cur++;
+      if (is_truncated_str (cur, end, "infinity", false) ||
+          is_truncated_str (cur, end, "nan", false))
+      {
+        return true;
+      }
     }
-    if (code == YYJSON_READ_ERROR_UNEXPECTED_CONTENT) {
-        if (flg & YYJSON_READ_ALLOW_INF_AND_NAN) {
-            if (hdr + 3 <= cur &&
-                is_truncated_str(cur - 3, end, "infinity", false)) {
-                return true; /* e.g. infin would be read as inf + in */
-            }
-        }
+  }
+  if (code == YYJSON_READ_ERROR_UNEXPECTED_CONTENT)
+  {
+    if (flg & YYJSON_READ_ALLOW_INF_AND_NAN)
+    {
+      if (hdr + 3 <= cur &&
+          is_truncated_str (cur - 3, end, "infinity", false))
+      {
+        return true; /* e.g. infin would be read as inf + in */
+      }
     }
-    if (code == YYJSON_READ_ERROR_INVALID_STRING) {
-        usize len = (usize)(end - cur);
-        
-        /* unicode escape sequence */
-        if (*cur == '\\') {
-            if (len == 1) return true;
-            if (len <= 5) {
-                if (*++cur != 'u') return false;
-                for (++cur; cur < end; cur++) {
-                    if (!char_is_hex(*cur)) return false;
-                }
-                return true;
-            }
+  }
+  if (code == YYJSON_READ_ERROR_INVALID_STRING)
+  {
+    usize len = (usize)(end - cur);
+
+    /* unicode escape sequence */
+    if (*cur == '\\')
+    {
+      if (len == 1)
+        return true;
+      if (len <= 5)
+      {
+        if (*++cur != 'u')
+          return false;
+        for (++cur; cur < end; cur++)
+        {
+          if (!char_is_hex (*cur))
             return false;
         }
-        
-        /* 2 to 4 bytes UTF-8, see `read_string()` for details. */
-        if (*cur & 0x80) {
-            u8 c0 = cur[0], c1 = cur[1], c2 = cur[2];
-            if (len == 1) {
-                /* 2 bytes UTF-8, truncated */
-                if ((c0 & 0xE0) == 0xC0 && (c0 & 0x1E) != 0x00) return true;
-                /* 3 bytes UTF-8, truncated */
-                if ((c0 & 0xF0) == 0xE0) return true;
-                /* 4 bytes UTF-8, truncated */
-                if ((c0 & 0xF8) == 0xF0 && (c0 & 0x07) <= 0x04) return true;
-            }
-            if (len == 2) {
-                /* 3 bytes UTF-8, truncated */
-                if ((c0 & 0xF0) == 0xE0 &&
-                    (c1 & 0xC0) == 0x80) {
-                    u8 pat = (u8)(((c0 & 0x0F) << 1) | ((c1 & 0x20) >> 5));
-                    return 0x01 <= pat && pat != 0x1B;
-                }
-                /* 4 bytes UTF-8, truncated */
-                if ((c0 & 0xF8) == 0xF0 &&
-                    (c1 & 0xC0) == 0x80) {
-                    u8 pat = (u8)(((c0 & 0x07) << 2) | ((c1 & 0x30) >> 4));
-                    return 0x01 <= pat && pat <= 0x10;
-                }
-            }
-            if (len == 3) {
-                /* 4 bytes UTF-8, truncated */
-                if ((c0 & 0xF8) == 0xF0 &&
-                    (c1 & 0xC0) == 0x80 &&
-                    (c2 & 0xC0) == 0x80) {
-                    u8 pat = (u8)(((c0 & 0x07) << 2) | ((c1 & 0x30) >> 4));
-                    return 0x01 <= pat && pat <= 0x10;
-                }
-            }
-        }
+        return true;
+      }
+      return false;
     }
-    return false;
+
+    /* 2 to 4 bytes UTF-8, see `read_string()` for details. */
+    if (*cur & 0x80)
+    {
+      u8 c0 = cur[0], c1 = cur[1], c2 = cur[2];
+      if (len == 1)
+      {
+        /* 2 bytes UTF-8, truncated */
+        if ((c0 & 0xE0) == 0xC0 && (c0 & 0x1E) != 0x00)
+          return true;
+        /* 3 bytes UTF-8, truncated */
+        if ((c0 & 0xF0) == 0xE0)
+          return true;
+        /* 4 bytes UTF-8, truncated */
+        if ((c0 & 0xF8) == 0xF0 && (c0 & 0x07) <= 0x04)
+          return true;
+      }
+      if (len == 2)
+      {
+        /* 3 bytes UTF-8, truncated */
+        if ((c0 & 0xF0) == 0xE0 &&
+            (c1 & 0xC0) == 0x80)
+        {
+          u8 pat = (u8)(((c0 & 0x0F) << 1) | ((c1 & 0x20) >> 5));
+          return 0x01 <= pat && pat != 0x1B;
+        }
+        /* 4 bytes UTF-8, truncated */
+        if ((c0 & 0xF8) == 0xF0 &&
+            (c1 & 0xC0) == 0x80)
+        {
+          u8 pat = (u8)(((c0 & 0x07) << 2) | ((c1 & 0x30) >> 4));
+          return 0x01 <= pat && pat <= 0x10;
+        }
+      }
+      if (len == 3)
+      {
+        /* 4 bytes UTF-8, truncated */
+        if ((c0 & 0xF8) == 0xF0 &&
+            (c1 & 0xC0) == 0x80 &&
+            (c2 & 0xC0) == 0x80)
+        {
+          u8 pat = (u8)(((c0 & 0x07) << 2) | ((c1 & 0x30) >> 4));
+          return 0x01 <= pat && pat <= 0x10;
+        }
+      }
+    }
+  }
+  return false;
 }
-
-
 
 #if YYJSON_HAS_IEEE_754 && !YYJSON_DISABLE_FAST_FP_CONV /* FP_READER */
 
@@ -3283,25 +3738,25 @@ static_noinline bool is_truncated_end(u8 *hdr, u8 *cur, u8 *end,
 
 /** Table: [ 10^0, ..., 10^19 ] (generate with misc/make_tables.c) */
 static const u64 u64_pow10_table[U64_POW10_MAX_EXP + 1] = {
-    U64(0x00000000, 0x00000001), U64(0x00000000, 0x0000000A),
-    U64(0x00000000, 0x00000064), U64(0x00000000, 0x000003E8),
-    U64(0x00000000, 0x00002710), U64(0x00000000, 0x000186A0),
-    U64(0x00000000, 0x000F4240), U64(0x00000000, 0x00989680),
-    U64(0x00000000, 0x05F5E100), U64(0x00000000, 0x3B9ACA00),
-    U64(0x00000002, 0x540BE400), U64(0x00000017, 0x4876E800),
-    U64(0x000000E8, 0xD4A51000), U64(0x00000918, 0x4E72A000),
-    U64(0x00005AF3, 0x107A4000), U64(0x00038D7E, 0xA4C68000),
-    U64(0x002386F2, 0x6FC10000), U64(0x01634578, 0x5D8A0000),
-    U64(0x0DE0B6B3, 0xA7640000), U64(0x8AC72304, 0x89E80000)
-};
+    U64 (0x00000000, 0x00000001), U64 (0x00000000, 0x0000000A),
+    U64 (0x00000000, 0x00000064), U64 (0x00000000, 0x000003E8),
+    U64 (0x00000000, 0x00002710), U64 (0x00000000, 0x000186A0),
+    U64 (0x00000000, 0x000F4240), U64 (0x00000000, 0x00989680),
+    U64 (0x00000000, 0x05F5E100), U64 (0x00000000, 0x3B9ACA00),
+    U64 (0x00000002, 0x540BE400), U64 (0x00000017, 0x4876E800),
+    U64 (0x000000E8, 0xD4A51000), U64 (0x00000918, 0x4E72A000),
+    U64 (0x00005AF3, 0x107A4000), U64 (0x00038D7E, 0xA4C68000),
+    U64 (0x002386F2, 0x6FC10000), U64 (0x01634578, 0x5D8A0000),
+    U64 (0x0DE0B6B3, 0xA7640000), U64 (0x8AC72304, 0x89E80000)};
 
 /** Maximum numbers of chunks used by a bigint (58 is enough here). */
 #define BIGINT_MAX_CHUNKS 64
 
 /** Unsigned arbitrarily large integer */
-typedef struct bigint {
-    u32 used; /* used chunks count, should not be 0 */
-    u64 bits[BIGINT_MAX_CHUNKS]; /* chunks */
+typedef struct bigint
+{
+  u32 used;                    /* used chunks count, should not be 0 */
+  u64 bits[BIGINT_MAX_CHUNKS]; /* chunks */
 } bigint;
 
 /**
@@ -3309,20 +3764,25 @@ typedef struct bigint {
  @param big A big number (can be 0).
  @param val An unsigned integer (can be 0).
  */
-static_inline void bigint_add_u64(bigint *big, u64 val) {
-    u32 idx, max;
-    u64 num = big->bits[0];
-    u64 add = num + val;
-    big->bits[0] = add;
-    if (likely((add >= num) || (add >= val))) return;
-    for ((void)(idx = 1), max = big->used; idx < max; idx++) {
-        if (likely(big->bits[idx] != U64_MAX)) {
-            big->bits[idx] += 1;
-            return;
-        }
-        big->bits[idx] = 0;
+static_inline void
+bigint_add_u64 (bigint *big, u64 val)
+{
+  u32 idx, max;
+  u64 num      = big->bits[0];
+  u64 add      = num + val;
+  big->bits[0] = add;
+  if (likely ((add >= num) || (add >= val)))
+    return;
+  for ((void)(idx = 1), max = big->used; idx < max; idx++)
+  {
+    if (likely (big->bits[idx] != U64_MAX))
+    {
+      big->bits[idx] += 1;
+      return;
     }
-    big->bits[big->used++] = 1;
+    big->bits[idx] = 0;
+  }
+  big->bits[big->used++] = 1;
 }
 
 /**
@@ -3330,18 +3790,24 @@ static_inline void bigint_add_u64(bigint *big, u64 val) {
  @param big A big number (can be 0).
  @param val An unsigned integer (cannot be 0).
  */
-static_inline void bigint_mul_u64(bigint *big, u64 val) {
-    u32 idx = 0, max = big->used;
-    u64 hi, lo, carry = 0;
-    for (; idx < max; idx++) {
-        if (big->bits[idx]) break;
-    }
-    for (; idx < max; idx++) {
-        u128_mul_add(big->bits[idx], val, carry, &hi, &lo);
-        big->bits[idx] = lo;
-        carry = hi;
-    }
-    if (carry) big->bits[big->used++] = carry;
+static_inline void
+bigint_mul_u64 (bigint *big, u64 val)
+{
+  u32 idx = 0, max = big->used;
+  u64 hi, lo, carry = 0;
+  for (; idx < max; idx++)
+  {
+    if (big->bits[idx])
+      break;
+  }
+  for (; idx < max; idx++)
+  {
+    u128_mul_add (big->bits[idx], val, carry, &hi, &lo);
+    big->bits[idx] = lo;
+    carry          = hi;
+  }
+  if (carry)
+    big->bits[big->used++] = carry;
 }
 
 /**
@@ -3349,27 +3815,36 @@ static_inline void bigint_mul_u64(bigint *big, u64 val) {
  @param big A big number (can be 0).
  @param exp An exponent integer (can be 0).
  */
-static_inline void bigint_mul_pow2(bigint *big, u32 exp) {
-    u32 shft = exp % 64;
-    u32 move = exp / 64;
-    u32 idx = big->used;
-    if (unlikely(shft == 0)) {
-        for (; idx > 0; idx--) {
-            big->bits[idx + move - 1] = big->bits[idx - 1];
-        }
-        big->used += move;
-        while (move) big->bits[--move] = 0;
-    } else {
-        big->bits[idx] = 0;
-        for (; idx > 0; idx--) {
-            u64 num = big->bits[idx] << shft;
-            num |= big->bits[idx - 1] >> (64 - shft);
-            big->bits[idx + move] = num;
-        }
-        big->bits[move] = big->bits[0] << shft;
-        big->used += move + (big->bits[big->used + move] > 0);
-        while (move) big->bits[--move] = 0;
+static_inline void
+bigint_mul_pow2 (bigint *big, u32 exp)
+{
+  u32 shft = exp % 64;
+  u32 move = exp / 64;
+  u32 idx  = big->used;
+  if (unlikely (shft == 0))
+  {
+    for (; idx > 0; idx--)
+    {
+      big->bits[idx + move - 1] = big->bits[idx - 1];
     }
+    big->used += move;
+    while (move)
+      big->bits[--move] = 0;
+  }
+  else
+  {
+    big->bits[idx] = 0;
+    for (; idx > 0; idx--)
+    {
+      u64 num = big->bits[idx] << shft;
+      num |= big->bits[idx - 1] >> (64 - shft);
+      big->bits[idx + move] = num;
+    }
+    big->bits[move] = big->bits[0] << shft;
+    big->used += move + (big->bits[big->used + move] > 0);
+    while (move)
+      big->bits[--move] = 0;
+  }
 }
 
 /**
@@ -3377,30 +3852,41 @@ static_inline void bigint_mul_pow2(bigint *big, u32 exp) {
  @param big A big number (can be 0).
  @param exp An exponent integer (cannot be 0).
  */
-static_inline void bigint_mul_pow10(bigint *big, i32 exp) {
-    for (; exp >= U64_POW10_MAX_EXP; exp -= U64_POW10_MAX_EXP) {
-        bigint_mul_u64(big, u64_pow10_table[U64_POW10_MAX_EXP]);
-    }
-    if (exp) {
-        bigint_mul_u64(big, u64_pow10_table[exp]);
-    }
+static_inline void
+bigint_mul_pow10 (bigint *big, i32 exp)
+{
+  for (; exp >= U64_POW10_MAX_EXP; exp -= U64_POW10_MAX_EXP)
+  {
+    bigint_mul_u64 (big, u64_pow10_table[U64_POW10_MAX_EXP]);
+  }
+  if (exp)
+  {
+    bigint_mul_u64 (big, u64_pow10_table[exp]);
+  }
 }
 
 /**
  Compare two bigint.
  @return -1 if 'a < b', +1 if 'a > b', 0 if 'a == b'.
  */
-static_inline i32 bigint_cmp(bigint *a, bigint *b) {
-    u32 idx = a->used;
-    if (a->used < b->used) return -1;
-    if (a->used > b->used) return +1;
-    while (idx-- > 0) {
-        u64 av = a->bits[idx];
-        u64 bv = b->bits[idx];
-        if (av < bv) return -1;
-        if (av > bv) return +1;
-    }
-    return 0;
+static_inline i32
+bigint_cmp (bigint *a, bigint *b)
+{
+  u32 idx = a->used;
+  if (a->used < b->used)
+    return -1;
+  if (a->used > b->used)
+    return +1;
+  while (idx-- > 0)
+  {
+    u64 av = a->bits[idx];
+    u64 bv = b->bits[idx];
+    if (av < bv)
+      return -1;
+    if (av > bv)
+      return +1;
+  }
+  return 0;
 }
 
 /**
@@ -3408,127 +3894,151 @@ static_inline i32 bigint_cmp(bigint *a, bigint *b) {
  @param big A big number (can be 0).
  @param val An unsigned integer (can be 0).
  */
-static_inline void bigint_set_u64(bigint *big, u64 val) {
-    big->used = 1;
-    big->bits[0] = val;
+static_inline void
+bigint_set_u64 (bigint *big, u64 val)
+{
+  big->used    = 1;
+  big->bits[0] = val;
 }
 
 /** Set a bigint with floating point number string. */
-static_noinline void bigint_set_buf(bigint *big, u64 sig, i32 *exp,
-                                    u8 *sig_cut, u8 *sig_end, u8 *dot_pos) {
-    
-    if (unlikely(!sig_cut)) {
-        /* no digit cut, set significant part only */
-        bigint_set_u64(big, sig);
-        return;
-        
-    } else {
-        /* some digits were cut, read them from 'sig_cut' to 'sig_end' */
-        u8 *hdr = sig_cut;
-        u8 *cur = hdr;
-        u32 len = 0;
-        u64 val = 0;
-        bool dig_big_cut = false;
-        bool has_dot = (hdr < dot_pos) & (dot_pos < sig_end);
-        u32 dig_len_total = U64_SAFE_DIG + (u32)(sig_end - hdr) - has_dot;
-        
-        sig -= (*sig_cut >= '5'); /* sig was rounded before */
-        if (dig_len_total > F64_MAX_DEC_DIG) {
-            dig_big_cut = true;
-            sig_end -= dig_len_total - (F64_MAX_DEC_DIG + 1);
-            sig_end -= (dot_pos + 1 == sig_end);
-            dig_len_total = (F64_MAX_DEC_DIG + 1);
-        }
-        *exp -= (i32)dig_len_total - U64_SAFE_DIG;
-        
-        big->used = 1;
-        big->bits[0] = sig;
-        while (cur < sig_end) {
-            if (likely(cur != dot_pos)) {
-                val = val * 10 + (u8)(*cur++ - '0');
-                len++;
-                if (unlikely(cur == sig_end && dig_big_cut)) {
-                    /* The last digit must be non-zero,    */
-                    /* set it to '1' for correct rounding. */
-                    val = val - (val % 10) + 1;
-                }
-                if (len == U64_SAFE_DIG || cur == sig_end) {
-                    bigint_mul_pow10(big, (i32)len);
-                    bigint_add_u64(big, val);
-                    val = 0;
-                    len = 0;
-                }
-            } else {
-                cur++;
-            }
-        }
+static_noinline void
+bigint_set_buf (bigint *big, u64 sig, i32 *exp,
+                u8 *sig_cut, u8 *sig_end, u8 *dot_pos)
+{
+
+  if (unlikely (!sig_cut))
+  {
+    /* no digit cut, set significant part only */
+    bigint_set_u64 (big, sig);
+    return;
+  }
+  else
+  {
+    /* some digits were cut, read them from 'sig_cut' to 'sig_end' */
+    u8 *hdr           = sig_cut;
+    u8 *cur           = hdr;
+    u32 len           = 0;
+    u64 val           = 0;
+    bool dig_big_cut  = false;
+    bool has_dot      = (hdr < dot_pos) & (dot_pos < sig_end);
+    u32 dig_len_total = U64_SAFE_DIG + (u32)(sig_end - hdr) - has_dot;
+
+    sig -= (*sig_cut >= '5'); /* sig was rounded before */
+    if (dig_len_total > F64_MAX_DEC_DIG)
+    {
+      dig_big_cut = true;
+      sig_end -= dig_len_total - (F64_MAX_DEC_DIG + 1);
+      sig_end -= (dot_pos + 1 == sig_end);
+      dig_len_total = (F64_MAX_DEC_DIG + 1);
     }
+    *exp -= (i32)dig_len_total - U64_SAFE_DIG;
+
+    big->used    = 1;
+    big->bits[0] = sig;
+    while (cur < sig_end)
+    {
+      if (likely (cur != dot_pos))
+      {
+        val = val * 10 + (u8)(*cur++ - '0');
+        len++;
+        if (unlikely (cur == sig_end && dig_big_cut))
+        {
+          /* The last digit must be non-zero,    */
+          /* set it to '1' for correct rounding. */
+          val = val - (val % 10) + 1;
+        }
+        if (len == U64_SAFE_DIG || cur == sig_end)
+        {
+          bigint_mul_pow10 (big, (i32)len);
+          bigint_add_u64 (big, val);
+          val = 0;
+          len = 0;
+        }
+      }
+      else
+      {
+        cur++;
+      }
+    }
+  }
 }
-
-
 
 /*==============================================================================
  * Diy Floating Point
  *============================================================================*/
 
 /** "Do It Yourself Floating Point" struct. */
-typedef struct diy_fp {
-    u64 sig; /* significand */
-    i32 exp; /* exponent, base 2 */
-    i32 pad; /* padding, useless */
+typedef struct diy_fp
+{
+  u64 sig; /* significand */
+  i32 exp; /* exponent, base 2 */
+  i32 pad; /* padding, useless */
 } diy_fp;
 
 /** Get cached rounded diy_fp with pow(10, e) The input value must in range
     [POW10_SIG_TABLE_MIN_EXP, POW10_SIG_TABLE_MAX_EXP]. */
-static_inline diy_fp diy_fp_get_cached_pow10(i32 exp10) {
-    diy_fp fp;
-    u64 sig_ext;
-    pow10_table_get_sig(exp10, &fp.sig, &sig_ext);
-    pow10_table_get_exp(exp10, &fp.exp);
-    fp.sig += (sig_ext >> 63);
-    return fp;
+static_inline diy_fp
+diy_fp_get_cached_pow10 (i32 exp10)
+{
+  diy_fp fp;
+  u64 sig_ext;
+  pow10_table_get_sig (exp10, &fp.sig, &sig_ext);
+  pow10_table_get_exp (exp10, &fp.exp);
+  fp.sig += (sig_ext >> 63);
+  return fp;
 }
 
 /** Returns fp * fp2. */
-static_inline diy_fp diy_fp_mul(diy_fp fp, diy_fp fp2) {
-    u64 hi, lo;
-    u128_mul(fp.sig, fp2.sig, &hi, &lo);
-    fp.sig = hi + (lo >> 63);
-    fp.exp += fp2.exp + 64;
-    return fp;
+static_inline diy_fp
+diy_fp_mul (diy_fp fp, diy_fp fp2)
+{
+  u64 hi, lo;
+  u128_mul (fp.sig, fp2.sig, &hi, &lo);
+  fp.sig = hi + (lo >> 63);
+  fp.exp += fp2.exp + 64;
+  return fp;
 }
 
 /** Convert diy_fp to IEEE-754 raw value. */
-static_inline u64 diy_fp_to_ieee_raw(diy_fp fp) {
-    u64 sig = fp.sig;
-    i32 exp = fp.exp;
-    u32 lz_bits;
-    if (unlikely(fp.sig == 0)) return 0;
-    
-    lz_bits = u64_lz_bits(sig);
-    sig <<= lz_bits;
-    sig >>= F64_BITS - F64_SIG_FULL_BITS;
-    exp -= (i32)lz_bits;
-    exp += F64_BITS - F64_SIG_FULL_BITS;
-    exp += F64_SIG_BITS;
-    
-    if (unlikely(exp >= F64_MAX_BIN_EXP)) {
-        /* overflow */
-        return F64_RAW_INF;
-    } else if (likely(exp >= F64_MIN_BIN_EXP - 1)) {
-        /* normal */
-        exp += F64_EXP_BIAS;
-        return ((u64)exp << F64_SIG_BITS) | (sig & F64_SIG_MASK);
-    } else if (likely(exp >= F64_MIN_BIN_EXP - F64_SIG_FULL_BITS)) {
-        /* subnormal */
-        return sig >> (F64_MIN_BIN_EXP - exp - 1);
-    } else {
-        /* underflow */
-        return 0;
-    }
+static_inline u64
+diy_fp_to_ieee_raw (diy_fp fp)
+{
+  u64 sig = fp.sig;
+  i32 exp = fp.exp;
+  u32 lz_bits;
+  if (unlikely (fp.sig == 0))
+    return 0;
+
+  lz_bits = u64_lz_bits (sig);
+  sig <<= lz_bits;
+  sig >>= F64_BITS - F64_SIG_FULL_BITS;
+  exp -= (i32)lz_bits;
+  exp += F64_BITS - F64_SIG_FULL_BITS;
+  exp += F64_SIG_BITS;
+
+  if (unlikely (exp >= F64_MAX_BIN_EXP))
+  {
+    /* overflow */
+    return F64_RAW_INF;
+  }
+  else if (likely (exp >= F64_MIN_BIN_EXP - 1))
+  {
+    /* normal */
+    exp += F64_EXP_BIAS;
+    return ((u64)exp << F64_SIG_BITS) | (sig & F64_SIG_MASK);
+  }
+  else if (likely (exp >= F64_MIN_BIN_EXP - F64_SIG_FULL_BITS))
+  {
+    /* subnormal */
+    return sig >> (F64_MIN_BIN_EXP - exp - 1);
+  }
+  else
+  {
+    /* underflow */
+    return 0;
+  }
 }
-
-
 
 /*==============================================================================
  * JSON Number Reader (IEEE-754)
@@ -3540,597 +4050,695 @@ static_inline u64 diy_fp_to_ieee_raw(diy_fp fp) {
 /** Cached pow10 table. */
 static const f64 f64_pow10_table[] = {
     1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12,
-    1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19, 1e20, 1e21, 1e22
-};
+    1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19, 1e20, 1e21, 1e22};
 
 /**
  Read a JSON number.
- 
+
  1. This function assume that the floating-point number is in IEEE-754 format.
  2. This function support uint64/int64/double number. If an integer number
     cannot fit in uint64/int64, it will returns as a double number. If a double
     number is infinite, the return value is based on flag.
  3. This function (with inline attribute) may generate a lot of instructions.
  */
-static_inline bool read_number(u8 **ptr,
-                               u8 **pre,
-                               bool ext,
-                               yyjson_val *val,
-                               const char **msg) {
-    
-#define return_err(_pos, _msg) do { \
-    *msg = _msg; \
-    *end = _pos; \
-    return false; \
-} while (false)
-    
-#define return_0() do { \
-    val->tag = YYJSON_TYPE_NUM | (u8)((u8)sign << 3); \
-    val->uni.u64 = 0; \
-    *end = cur; return true; \
-} while (false)
+static_inline bool
+read_number (u8 **ptr,
+             u8 **pre,
+             bool ext,
+             yyjson_val *val,
+             const char **msg)
+{
 
-#define return_i64(_v) do { \
-    val->tag = YYJSON_TYPE_NUM | (u8)((u8)sign << 3); \
+#define return_err(_pos, _msg) \
+  do                           \
+  {                            \
+    *msg = _msg;               \
+    *end = _pos;               \
+    return false;              \
+  } while (false)
+
+#define return_0()                                        \
+  do                                                      \
+  {                                                       \
+    val->tag     = YYJSON_TYPE_NUM | (u8)((u8)sign << 3); \
+    val->uni.u64 = 0;                                     \
+    *end         = cur;                                   \
+    return true;                                          \
+  } while (false)
+
+#define return_i64(_v)                                         \
+  do                                                           \
+  {                                                            \
+    val->tag     = YYJSON_TYPE_NUM | (u8)((u8)sign << 3);      \
     val->uni.u64 = (u64)(sign ? (u64)(~(_v) + 1) : (u64)(_v)); \
-    *end = cur; return true; \
-} while (false)
-    
-#define return_f64(_v) do { \
-    val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL; \
-    val->uni.f64 = sign ? -(f64)(_v) : (f64)(_v); \
-    *end = cur; return true; \
-} while (false)
-    
-#define return_f64_raw(_v) do { \
-    val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL; \
-    val->uni.u64 = ((u64)sign << 63) | (u64)(_v); \
-    *end = cur; return true; \
-} while (false)
-    
-#define return_inf() do { \
-    if (unlikely(ext)) return_f64_raw(F64_RAW_INF); \
-    else return_err(hdr, "number is infinity when parsed as double"); \
-} while (false)
-    
-    u8 *sig_cut = NULL; /* significant part cutting position for long number */
-    u8 *sig_end = NULL; /* significant part ending position */
-    u8 *dot_pos = NULL; /* decimal point position */
-    
-    u64 sig = 0; /* significant part of the number */
-    i32 exp = 0; /* exponent part of the number */
-    
-    bool exp_sign; /* temporary exponent sign from literal part */
-    i64 exp_sig = 0; /* temporary exponent number from significant part */
-    i64 exp_lit = 0; /* temporary exponent number from exponent literal part */
-    u64 num; /* temporary number for reading */
-    u8 *tmp; /* temporary cursor for reading */
-    
-    u8 *hdr = *ptr;
-    u8 *cur = *ptr;
-    u8 **end = ptr;
-    bool sign;
-    
-    /* read number as raw string if has flag */
-    if (unlikely(pre)) {
-        return read_number_raw(ptr, pre, ext, val, msg);
+    *end         = cur;                                        \
+    return true;                                               \
+  } while (false)
+
+#define return_f64(_v)                                    \
+  do                                                      \
+  {                                                       \
+    val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL; \
+    val->uni.f64 = sign ? -(f64)(_v) : (f64)(_v);         \
+    *end         = cur;                                   \
+    return true;                                          \
+  } while (false)
+
+#define return_f64_raw(_v)                                \
+  do                                                      \
+  {                                                       \
+    val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL; \
+    val->uni.u64 = ((u64)sign << 63) | (u64)(_v);         \
+    *end         = cur;                                   \
+    return true;                                          \
+  } while (false)
+
+#define return_inf()                                                \
+  do                                                                \
+  {                                                                 \
+    if (unlikely (ext))                                             \
+      return_f64_raw (F64_RAW_INF);                                 \
+    else                                                            \
+      return_err (hdr, "number is infinity when parsed as double"); \
+  } while (false)
+
+  u8 *sig_cut = NULL; /* significant part cutting position for long number */
+  u8 *sig_end = NULL; /* significant part ending position */
+  u8 *dot_pos = NULL; /* decimal point position */
+
+  u64 sig = 0; /* significant part of the number */
+  i32 exp = 0; /* exponent part of the number */
+
+  bool exp_sign;   /* temporary exponent sign from literal part */
+  i64 exp_sig = 0; /* temporary exponent number from significant part */
+  i64 exp_lit = 0; /* temporary exponent number from exponent literal part */
+  u64 num;         /* temporary number for reading */
+  u8 *tmp;         /* temporary cursor for reading */
+
+  u8 *hdr  = *ptr;
+  u8 *cur  = *ptr;
+  u8 **end = ptr;
+  bool sign;
+
+  /* read number as raw string if has flag */
+  if (unlikely (pre))
+  {
+    return read_number_raw (ptr, pre, ext, val, msg);
+  }
+
+  sign = (*hdr == '-');
+  cur += sign;
+
+  /* begin with a leading zero or non-digit */
+  if (unlikely (!digi_is_nonzero (*cur)))
+  { /* 0 or non-digit char */
+    if (unlikely (*cur != '0'))
+    { /* non-digit char */
+      if (unlikely (ext))
+      {
+        if (read_inf_or_nan (sign, &cur, pre, val))
+        {
+          *end = cur;
+          return true;
+        }
+      }
+      return_err (cur, "no digit after minus sign");
     }
-    
-    sign = (*hdr == '-');
-    cur += sign;
-    
-    /* begin with a leading zero or non-digit */
-    if (unlikely(!digi_is_nonzero(*cur))) { /* 0 or non-digit char */
-        if (unlikely(*cur != '0')) { /* non-digit char */
-            if (unlikely(ext)) {
-                if (read_inf_or_nan(sign, &cur, pre, val)) {
-                    *end = cur;
-                    return true;
-                }
-            }
-            return_err(cur, "no digit after minus sign");
-        }
-        /* begin with 0 */
-        if (likely(!digi_is_digit_or_fp(*++cur))) return_0();
-        if (likely(*cur == '.')) {
-            dot_pos = cur++;
-            if (unlikely(!digi_is_digit(*cur))) {
-                return_err(cur, "no digit after decimal point");
-            }
-            while (unlikely(*cur == '0')) cur++;
-            if (likely(digi_is_digit(*cur))) {
-                /* first non-zero digit after decimal point */
-                sig = (u64)(*cur - '0'); /* read first digit */
-                cur--;
-                goto digi_frac_1; /* continue read fraction part */
-            }
-        }
-        if (unlikely(digi_is_digit(*cur))) {
-            return_err(cur - 1, "number with leading zero is not allowed");
-        }
-        if (unlikely(digi_is_exp(*cur))) { /* 0 with any exponent is still 0 */
-            cur += (usize)1 + digi_is_sign(cur[1]);
-            if (unlikely(!digi_is_digit(*cur))) {
-                return_err(cur, "no digit after exponent sign");
-            }
-            while (digi_is_digit(*++cur));
-        }
-        return_f64_raw(0);
+    /* begin with 0 */
+    if (likely (!digi_is_digit_or_fp (*++cur)))
+      return_0 ();
+    if (likely (*cur == '.'))
+    {
+      dot_pos = cur++;
+      if (unlikely (!digi_is_digit (*cur)))
+      {
+        return_err (cur, "no digit after decimal point");
+      }
+      while (unlikely (*cur == '0'))
+        cur++;
+      if (likely (digi_is_digit (*cur)))
+      {
+        /* first non-zero digit after decimal point */
+        sig = (u64)(*cur - '0'); /* read first digit */
+        cur--;
+        goto digi_frac_1; /* continue read fraction part */
+      }
     }
-    
-    /* begin with non-zero digit */
-    sig = (u64)(*cur - '0');
-    
-    /*
-     Read integral part, same as the following code.
-     
-         for (int i = 1; i <= 18; i++) {
-            num = cur[i] - '0';
-            if (num <= 9) sig = num + sig * 10;
-            else goto digi_sepr_i;
-         }
-     */
-#define expr_intg(i) \
-    if (likely((num = (u64)(cur[i] - (u8)'0')) <= 9)) sig = num + sig * 10; \
-    else { goto digi_sepr_##i; }
-    repeat_in_1_18(expr_intg)
+    if (unlikely (digi_is_digit (*cur)))
+    {
+      return_err (cur - 1, "number with leading zero is not allowed");
+    }
+    if (unlikely (digi_is_exp (*cur)))
+    { /* 0 with any exponent is still 0 */
+      cur += (usize)1 + digi_is_sign (cur[1]);
+      if (unlikely (!digi_is_digit (*cur)))
+      {
+        return_err (cur, "no digit after exponent sign");
+      }
+      while (digi_is_digit (*++cur))
+        ;
+    }
+    return_f64_raw (0);
+  }
+
+  /* begin with non-zero digit */
+  sig = (u64)(*cur - '0');
+
+  /*
+   Read integral part, same as the following code.
+
+       for (int i = 1; i <= 18; i++) {
+          num = cur[i] - '0';
+          if (num <= 9) sig = num + sig * 10;
+          else goto digi_sepr_i;
+       }
+   */
+#define expr_intg(i)                                 \
+  if (likely ((num = (u64)(cur[i] - (u8)'0')) <= 9)) \
+    sig = num + sig * 10;                            \
+  else                                               \
+  {                                                  \
+    goto digi_sepr_##i;                              \
+  }
+  repeat_in_1_18 (expr_intg)
 #undef expr_intg
-    
-    
-    cur += 19; /* skip continuous 19 digits */
-    if (!digi_is_digit_or_fp(*cur)) {
-        /* this number is an integer consisting of 19 digits */
-        if (sign && (sig > ((u64)1 << 63))) { /* overflow */
-            return_f64(normalized_u64_to_f64(sig));
-        }
-        return_i64(sig);
+
+      cur += 19; /* skip continuous 19 digits */
+  if (!digi_is_digit_or_fp (*cur))
+  {
+    /* this number is an integer consisting of 19 digits */
+    if (sign && (sig > ((u64)1 << 63)))
+    { /* overflow */
+      return_f64 (normalized_u64_to_f64 (sig));
     }
-    goto digi_intg_more; /* read more digits in integral part */
-    
-    
-    /* process first non-digit character */
-#define expr_sepr(i) \
-    digi_sepr_##i: \
-    if (likely(!digi_is_fp(cur[i]))) { cur += i; return_i64(sig); } \
-    dot_pos = cur + i; \
-    if (likely(cur[i] == '.')) goto digi_frac_##i; \
-    cur += i; sig_end = cur; goto digi_exp_more;
-    repeat_in_1_18(expr_sepr)
+    return_i64 (sig);
+  }
+  goto digi_intg_more; /* read more digits in integral part */
+
+  /* process first non-digit character */
+#define expr_sepr(i)                                 \
+  digi_sepr_##i : if (likely (!digi_is_fp (cur[i]))) \
+  {                                                  \
+    cur += i;                                        \
+    return_i64 (sig);                                \
+  }                                                  \
+  dot_pos = cur + i;                                 \
+  if (likely (cur[i] == '.'))                        \
+    goto digi_frac_##i;                              \
+  cur += i;                                          \
+  sig_end = cur;                                     \
+  goto digi_exp_more;
+  repeat_in_1_18 (expr_sepr)
 #undef expr_sepr
-    
-    
-    /* read fraction part */
-#define expr_frac(i) \
-    digi_frac_##i: \
-    if (likely((num = (u64)(cur[i + 1] - (u8)'0')) <= 9)) \
-        sig = num + sig * 10; \
-    else { goto digi_stop_##i; }
-    repeat_in_1_18(expr_frac)
+
+  /* read fraction part */
+#define expr_frac(i)                                                     \
+  digi_frac_##i : if (likely ((num = (u64)(cur[i + 1] - (u8)'0')) <= 9)) \
+                      sig = num + sig * 10;                              \
+  else                                                                   \
+  {                                                                      \
+    goto digi_stop_##i;                                                  \
+  }
+      repeat_in_1_18 (expr_frac)
 #undef expr_frac
-    
-    cur += 20; /* skip 19 digits and 1 decimal point */
-    if (!digi_is_digit(*cur)) goto digi_frac_end; /* fraction part end */
-    goto digi_frac_more; /* read more digits in fraction part */
-    
-    
-    /* significant part end */
-#define expr_stop(i) \
-    digi_stop_##i: \
-    cur += i + 1; \
-    goto digi_frac_end;
-    repeat_in_1_18(expr_stop)
+
+          cur += 20; /* skip 19 digits and 1 decimal point */
+  if (!digi_is_digit (*cur))
+    goto digi_frac_end; /* fraction part end */
+  goto digi_frac_more;  /* read more digits in fraction part */
+
+  /* significant part end */
+#define expr_stop(i)            \
+  digi_stop_##i : cur += i + 1; \
+  goto digi_frac_end;
+  repeat_in_1_18 (expr_stop)
 #undef expr_stop
-    
-    
-    /* read more digits in integral part */
-digi_intg_more:
-    if (digi_is_digit(*cur)) {
-        if (!digi_is_digit_or_fp(cur[1])) {
-            /* this number is an integer consisting of 20 digits */
-            num = (u64)(*cur - '0');
-            if ((sig < (U64_MAX / 10)) ||
-                (sig == (U64_MAX / 10) && num <= (U64_MAX % 10))) {
-                sig = num + sig * 10;
-                cur++;
-                /* convert to double if overflow */
-                if (sign) return_f64(normalized_u64_to_f64(sig));
-                return_i64(sig);
-            }
-        }
+
+      /* read more digits in integral part */
+      digi_intg_more : if (digi_is_digit (*cur))
+  {
+    if (!digi_is_digit_or_fp (cur[1]))
+    {
+      /* this number is an integer consisting of 20 digits */
+      num = (u64)(*cur - '0');
+      if ((sig < (U64_MAX / 10)) ||
+          (sig == (U64_MAX / 10) && num <= (U64_MAX % 10)))
+      {
+        sig = num + sig * 10;
+        cur++;
+        /* convert to double if overflow */
+        if (sign)
+          return_f64 (normalized_u64_to_f64 (sig));
+        return_i64 (sig);
+      }
     }
-    
-    if (digi_is_exp(*cur)) {
-        dot_pos = cur;
-        goto digi_exp_more;
+  }
+
+  if (digi_is_exp (*cur))
+  {
+    dot_pos = cur;
+    goto digi_exp_more;
+  }
+
+  if (*cur == '.')
+  {
+    dot_pos = cur++;
+    if (!digi_is_digit (*cur))
+    {
+      return_err (cur, "no digit after decimal point");
     }
-    
-    if (*cur == '.') {
-        dot_pos = cur++;
-        if (!digi_is_digit(*cur)) {
-            return_err(cur, "no digit after decimal point");
-        }
-    }
-    
-    
-    /* read more digits in fraction part */
+  }
+
+  /* read more digits in fraction part */
 digi_frac_more:
-    sig_cut = cur; /* too large to fit in u64, excess digits need to be cut */
-    sig += (*cur >= '5'); /* round */
-    while (digi_is_digit(*++cur));
-    if (!dot_pos) {
-        dot_pos = cur;
-        if (*cur == '.') {
-            if (!digi_is_digit(*++cur)) {
-                return_err(cur, "no digit after decimal point");
-            }
-            while (digi_is_digit(*cur)) cur++;
-        }
+  sig_cut = cur;        /* too large to fit in u64, excess digits need to be cut */
+  sig += (*cur >= '5'); /* round */
+  while (digi_is_digit (*++cur))
+    ;
+  if (!dot_pos)
+  {
+    dot_pos = cur;
+    if (*cur == '.')
+    {
+      if (!digi_is_digit (*++cur))
+      {
+        return_err (cur, "no digit after decimal point");
+      }
+      while (digi_is_digit (*cur))
+        cur++;
     }
-    exp_sig = (i64)(dot_pos - sig_cut);
-    exp_sig += (dot_pos < sig_cut);
-    
-    /* ignore trailing zeros */
-    tmp = cur - 1;
-    while (*tmp == '0' || *tmp == '.') tmp--;
-    if (tmp < sig_cut) {
-        sig_cut = NULL;
-    } else {
-        sig_end = cur;
-    }
-    
-    if (digi_is_exp(*cur)) goto digi_exp_more;
-    goto digi_exp_finish;
-    
-    
-    /* fraction part end */
-digi_frac_end:
-    if (unlikely(dot_pos + 1 == cur)) {
-        return_err(cur, "no digit after decimal point");
-    }
+  }
+  exp_sig = (i64)(dot_pos - sig_cut);
+  exp_sig += (dot_pos < sig_cut);
+
+  /* ignore trailing zeros */
+  tmp = cur - 1;
+  while (*tmp == '0' || *tmp == '.')
+    tmp--;
+  if (tmp < sig_cut)
+  {
+    sig_cut = NULL;
+  }
+  else
+  {
     sig_end = cur;
-    exp_sig = -(i64)((u64)(cur - dot_pos) - 1);
-    if (likely(!digi_is_exp(*cur))) {
-        if (unlikely(exp_sig < F64_MIN_DEC_EXP - 19)) {
-            return_f64_raw(0); /* underflow */
-        }
-        exp = (i32)exp_sig;
-        goto digi_finish;
-    } else {
-        goto digi_exp_more;
-    }
-    
-    
-    /* read exponent part */
-digi_exp_more:
-    exp_sign = (*++cur == '-');
-    cur += digi_is_sign(*cur);
-    if (unlikely(!digi_is_digit(*cur))) {
-        return_err(cur, "no digit after exponent sign");
-    }
-    while (*cur == '0') cur++;
-    
-    /* read exponent literal */
-    tmp = cur;
-    while (digi_is_digit(*cur)) {
-        exp_lit = (i64)((u8)(*cur++ - '0') + (u64)exp_lit * 10);
-    }
-    if (unlikely(cur - tmp >= U64_SAFE_DIG)) {
-        if (exp_sign) {
-            return_f64_raw(0); /* underflow */
-        } else {
-            return_inf(); /* overflow */
-        }
-    }
-    exp_sig += exp_sign ? -exp_lit : exp_lit;
-    
-    
-    /* validate exponent value */
-digi_exp_finish:
-    if (unlikely(exp_sig < F64_MIN_DEC_EXP - 19)) {
-        return_f64_raw(0); /* underflow */
-    }
-    if (unlikely(exp_sig > F64_MAX_DEC_EXP)) {
-        return_inf(); /* overflow */
+  }
+
+  if (digi_is_exp (*cur))
+    goto digi_exp_more;
+  goto digi_exp_finish;
+
+  /* fraction part end */
+digi_frac_end:
+  if (unlikely (dot_pos + 1 == cur))
+  {
+    return_err (cur, "no digit after decimal point");
+  }
+  sig_end = cur;
+  exp_sig = -(i64)((u64)(cur - dot_pos) - 1);
+  if (likely (!digi_is_exp (*cur)))
+  {
+    if (unlikely (exp_sig < F64_MIN_DEC_EXP - 19))
+    {
+      return_f64_raw (0); /* underflow */
     }
     exp = (i32)exp_sig;
-    
-    
-    /* all digit read finished */
-digi_finish:
-    
-    /*
-     Fast path 1:
-     
-     1. The floating-point number calculation should be accurate, see the
-        comments of macro `YYJSON_DOUBLE_MATH_CORRECT`.
-     2. Correct rounding should be performed (fegetround() == FE_TONEAREST).
-     3. The input of floating point number calculation does not lose precision,
-        which means: 64 - leading_zero(input) - trailing_zero(input) < 53.
-    
-     We don't check all available inputs here, because that would make the code
-     more complicated, and not friendly to branch predictor.
-     */
-#if YYJSON_DOUBLE_MATH_CORRECT
-    if (sig < ((u64)1 << 53) &&
-        exp >= -F64_POW10_EXP_MAX_EXACT &&
-        exp <= +F64_POW10_EXP_MAX_EXACT) {
-        f64 dbl = (f64)sig;
-        if (exp < 0) {
-            dbl /= f64_pow10_table[-exp];
-        } else {
-            dbl *= f64_pow10_table[+exp];
-        }
-        return_f64(dbl);
-    }
-#endif
-    
-    /*
-     Fast path 2:
-     
-     To keep it simple, we only accept normal number here,
-     let the slow path to handle subnormal and infinity number.
-     */
-    if (likely(!sig_cut &&
-               exp > -F64_MAX_DEC_EXP + 1 &&
-               exp < +F64_MAX_DEC_EXP - 20)) {
-        /*
-         The result value is exactly equal to (sig * 10^exp),
-         the exponent part (10^exp) can be converted to (sig2 * 2^exp2).
-         
-         The sig2 can be an infinite length number, only the highest 128 bits
-         is cached in the pow10_sig_table.
-         
-         Now we have these bits:
-         sig1 (normalized 64bit)        : aaaaaaaa
-         sig2 (higher 64bit)            : bbbbbbbb
-         sig2_ext (lower 64bit)         : cccccccc
-         sig2_cut (extra unknown bits)  : dddddddddddd....
-         
-         And the calculation process is:
-         ----------------------------------------
-                 aaaaaaaa *
-                 bbbbbbbbccccccccdddddddddddd....
-         ----------------------------------------
-         abababababababab +
-                 acacacacacacacac +
-                         adadadadadadadadadad....
-         ----------------------------------------
-         [hi____][lo____] +
-                 [hi2___][lo2___] +
-                         [unknown___________....]
-         ----------------------------------------
-         
-         The addition with carry may affect higher bits, but if there is a 0
-         in higher bits, the bits higher than 0 will not be affected.
-         
-         `lo2` + `unknown` may get a carry bit and may affect `hi2`, the max
-         value of `hi2` is 0xFFFFFFFFFFFFFFFE, so `hi2` will not overflow.
-         
-         `lo` + `hi2` may also get a carry bit and may affect `hi`, but only
-         the highest significant 53 bits of `hi` is needed. If there is a 0
-         in the lower bits of `hi`, then all the following bits can be dropped.
-         
-         To convert the result to IEEE-754 double number, we need to perform
-         correct rounding:
-         1. if bit 54 is 0, round down,
-         2. if bit 54 is 1 and any bit beyond bit 54 is 1, round up,
-         3. if bit 54 is 1 and all bits beyond bit 54 are 0, round to even,
-            as the extra bits is unknown, this case will not be handled here.
-         */
-        
-        u64 raw;
-        u64 sig1, sig2, sig2_ext, hi, lo, hi2, lo2, add, bits;
-        i32 exp2;
-        u32 lz;
-        bool exact = false, carry, round_up;
-        
-        /* convert (10^exp) to (sig2 * 2^exp2) */
-        pow10_table_get_sig(exp, &sig2, &sig2_ext);
-        pow10_table_get_exp(exp, &exp2);
-        
-        /* normalize and multiply */
-        lz = u64_lz_bits(sig);
-        sig1 = sig << lz;
-        exp2 -= (i32)lz;
-        u128_mul(sig1, sig2, &hi, &lo);
-        
-        /*
-         The `hi` is in range [0x4000000000000000, 0xFFFFFFFFFFFFFFFE],
-         To get normalized value, `hi` should be shifted to the left by 0 or 1.
-         
-         The highest significant 53 bits is used by IEEE-754 double number,
-         and the bit 54 is used to detect rounding direction.
-         
-         The lowest (64 - 54 - 1) bits is used to check whether it contains 0.
-         */
-        bits = hi & (((u64)1 << (64 - 54 - 1)) - 1);
-        if (bits - 1 < (((u64)1 << (64 - 54 - 1)) - 2)) {
-            /*
-             (bits != 0 && bits != 0x1FF) => (bits - 1 < 0x1FF - 1)
-             The `bits` is not zero, so we don't need to check `round to even`
-             case. The `bits` contains bit `0`, so we can drop the extra bits
-             after `0`.
-             */
-            exact = true;
-            
-        } else {
-            /*
-             (bits == 0 || bits == 0x1FF)
-             The `bits` is filled with all `0` or all `1`, so we need to check
-             lower bits with another 64-bit multiplication.
-             */
-            u128_mul(sig1, sig2_ext, &hi2, &lo2);
-            
-            add = lo + hi2;
-            if (add + 1 > (u64)1) {
-                /*
-                 (add != 0 && add != U64_MAX) => (add + 1 > 1)
-                 The `add` is not zero, so we don't need to check `round to
-                 even` case. The `add` contains bit `0`, so we can drop the
-                 extra bits after `0`. The `hi` cannot be U64_MAX, so it will
-                 not overflow.
-                 */
-                carry = add < lo || add < hi2;
-                hi += carry;
-                exact = true;
-            }
-        }
-        
-        if (exact) {
-            /* normalize */
-            lz = hi < ((u64)1 << 63);
-            hi <<= lz;
-            exp2 -= (i32)lz;
-            exp2 += 64;
-            
-            /* test the bit 54 and get rounding direction */
-            round_up = (hi & ((u64)1 << (64 - 54))) > (u64)0;
-            hi += (round_up ? ((u64)1 << (64 - 54)) : (u64)0);
-            
-            /* test overflow */
-            if (hi < ((u64)1 << (64 - 54))) {
-                hi = ((u64)1 << 63);
-                exp2 += 1;
-            }
-            
-            /* This is a normal number, convert it to IEEE-754 format. */
-            hi >>= F64_BITS - F64_SIG_FULL_BITS;
-            exp2 += F64_BITS - F64_SIG_FULL_BITS + F64_SIG_BITS;
-            exp2 += F64_EXP_BIAS;
-            raw = ((u64)exp2 << F64_SIG_BITS) | (hi & F64_SIG_MASK);
-            return_f64_raw(raw);
-        }
-    }
-    
-    /*
-     Slow path: read double number exactly with diyfp.
-     1. Use cached diyfp to get an approximation value.
-     2. Use bigcomp to check the approximation value if needed.
-     
-     This algorithm refers to google's double-conversion project:
-     https://github.com/google/double-conversion
-     */
+    goto digi_finish;
+  }
+  else
+  {
+    goto digi_exp_more;
+  }
+
+  /* read exponent part */
+digi_exp_more:
+  exp_sign = (*++cur == '-');
+  cur += digi_is_sign (*cur);
+  if (unlikely (!digi_is_digit (*cur)))
+  {
+    return_err (cur, "no digit after exponent sign");
+  }
+  while (*cur == '0')
+    cur++;
+
+  /* read exponent literal */
+  tmp = cur;
+  while (digi_is_digit (*cur))
+  {
+    exp_lit = (i64)((u8)(*cur++ - '0') + (u64)exp_lit * 10);
+  }
+  if (unlikely (cur - tmp >= U64_SAFE_DIG))
+  {
+    if (exp_sign)
     {
-        const i32 ERR_ULP_LOG = 3;
-        const i32 ERR_ULP = 1 << ERR_ULP_LOG;
-        const i32 ERR_CACHED_POW = ERR_ULP / 2;
-        const i32 ERR_MUL_FIXED = ERR_ULP / 2;
-        const i32 DIY_SIG_BITS = 64;
-        const i32 EXP_BIAS = F64_EXP_BIAS + F64_SIG_BITS;
-        const i32 EXP_SUBNORMAL = -EXP_BIAS + 1;
-        
-        u64 fp_err;
-        u32 bits;
-        i32 order_of_magnitude;
-        i32 effective_significand_size;
-        i32 precision_digits_count;
-        u64 precision_bits;
-        u64 half_way;
-        
-        u64 raw;
-        diy_fp fp, fp_upper;
-        bigint big_full, big_comp;
-        i32 cmp;
-        
-        fp.sig = sig;
-        fp.exp = 0;
-        fp_err = sig_cut ? (u64)(ERR_ULP / 2) : (u64)0;
-        
-        /* normalize */
-        bits = u64_lz_bits(fp.sig);
-        fp.sig <<= bits;
-        fp.exp -= (i32)bits;
-        fp_err <<= bits;
-        
-        /* multiply and add error */
-        fp = diy_fp_mul(fp, diy_fp_get_cached_pow10(exp));
-        fp_err += (u64)ERR_CACHED_POW + (fp_err != 0) + (u64)ERR_MUL_FIXED;
-        
-        /* normalize */
-        bits = u64_lz_bits(fp.sig);
-        fp.sig <<= bits;
-        fp.exp -= (i32)bits;
-        fp_err <<= bits;
-        
-        /* effective significand */
-        order_of_magnitude = DIY_SIG_BITS + fp.exp;
-        if (likely(order_of_magnitude >= EXP_SUBNORMAL + F64_SIG_FULL_BITS)) {
-            effective_significand_size = F64_SIG_FULL_BITS;
-        } else if (order_of_magnitude <= EXP_SUBNORMAL) {
-            effective_significand_size = 0;
-        } else {
-            effective_significand_size = order_of_magnitude - EXP_SUBNORMAL;
-        }
-        
-        /* precision digits count */
-        precision_digits_count = DIY_SIG_BITS - effective_significand_size;
-        if (unlikely(precision_digits_count + ERR_ULP_LOG >= DIY_SIG_BITS)) {
-            i32 shr = (precision_digits_count + ERR_ULP_LOG) - DIY_SIG_BITS + 1;
-            fp.sig >>= shr;
-            fp.exp += shr;
-            fp_err = (fp_err >> shr) + 1 + (u32)ERR_ULP;
-            precision_digits_count -= shr;
-        }
-        
-        /* half way */
-        precision_bits = fp.sig & (((u64)1 << precision_digits_count) - 1);
-        precision_bits *= (u32)ERR_ULP;
-        half_way = (u64)1 << (precision_digits_count - 1);
-        half_way *= (u32)ERR_ULP;
-        
-        /* rounding */
-        fp.sig >>= precision_digits_count;
-        fp.sig += (precision_bits >= half_way + fp_err);
-        fp.exp += precision_digits_count;
-        
-        /* get IEEE double raw value */
-        raw = diy_fp_to_ieee_raw(fp);
-        if (unlikely(raw == F64_RAW_INF)) return_inf();
-        if (likely(precision_bits <= half_way - fp_err ||
-                   precision_bits >= half_way + fp_err)) {
-            return_f64_raw(raw); /* number is accurate */
-        }
-        /* now the number is the correct value, or the next lower value */
-        
-        /* upper boundary */
-        if (raw & F64_EXP_MASK) {
-            fp_upper.sig = (raw & F64_SIG_MASK) + ((u64)1 << F64_SIG_BITS);
-            fp_upper.exp = (i32)((raw & F64_EXP_MASK) >> F64_SIG_BITS);
-        } else {
-            fp_upper.sig = (raw & F64_SIG_MASK);
-            fp_upper.exp = 1;
-        }
-        fp_upper.exp -= F64_EXP_BIAS + F64_SIG_BITS;
-        fp_upper.sig <<= 1;
-        fp_upper.exp -= 1;
-        fp_upper.sig += 1; /* add half ulp */
-        
-        /* compare with bigint */
-        bigint_set_buf(&big_full, sig, &exp, sig_cut, sig_end, dot_pos);
-        bigint_set_u64(&big_comp, fp_upper.sig);
-        if (exp >= 0) {
-            bigint_mul_pow10(&big_full, +exp);
-        } else {
-            bigint_mul_pow10(&big_comp, -exp);
-        }
-        if (fp_upper.exp > 0) {
-            bigint_mul_pow2(&big_comp, (u32)+fp_upper.exp);
-        } else {
-            bigint_mul_pow2(&big_full, (u32)-fp_upper.exp);
-        }
-        cmp = bigint_cmp(&big_full, &big_comp);
-        if (likely(cmp != 0)) {
-            /* round down or round up */
-            raw += (cmp > 0);
-        } else {
-            /* falls midway, round to even */
-            raw += (raw & 1);
-        }
-        
-        if (unlikely(raw == F64_RAW_INF)) return_inf();
-        return_f64_raw(raw);
+      return_f64_raw (0); /* underflow */
     }
-    
+    else
+    {
+      return_inf (); /* overflow */
+    }
+  }
+  exp_sig += exp_sign ? -exp_lit : exp_lit;
+
+  /* validate exponent value */
+digi_exp_finish:
+  if (unlikely (exp_sig < F64_MIN_DEC_EXP - 19))
+  {
+    return_f64_raw (0); /* underflow */
+  }
+  if (unlikely (exp_sig > F64_MAX_DEC_EXP))
+  {
+    return_inf (); /* overflow */
+  }
+  exp = (i32)exp_sig;
+
+  /* all digit read finished */
+digi_finish:
+
+  /*
+   Fast path 1:
+
+   1. The floating-point number calculation should be accurate, see the
+      comments of macro `YYJSON_DOUBLE_MATH_CORRECT`.
+   2. Correct rounding should be performed (fegetround() == FE_TONEAREST).
+   3. The input of floating point number calculation does not lose precision,
+      which means: 64 - leading_zero(input) - trailing_zero(input) < 53.
+
+   We don't check all available inputs here, because that would make the code
+   more complicated, and not friendly to branch predictor.
+   */
+#if YYJSON_DOUBLE_MATH_CORRECT
+  if (sig < ((u64)1 << 53) &&
+      exp >= -F64_POW10_EXP_MAX_EXACT &&
+      exp <= +F64_POW10_EXP_MAX_EXACT)
+  {
+    f64 dbl = (f64)sig;
+    if (exp < 0)
+    {
+      dbl /= f64_pow10_table[-exp];
+    }
+    else
+    {
+      dbl *= f64_pow10_table[+exp];
+    }
+    return_f64 (dbl);
+  }
+#endif
+
+  /*
+   Fast path 2:
+
+   To keep it simple, we only accept normal number here,
+   let the slow path to handle subnormal and infinity number.
+   */
+  if (likely (!sig_cut &&
+              exp > -F64_MAX_DEC_EXP + 1 &&
+              exp < +F64_MAX_DEC_EXP - 20))
+  {
+    /*
+     The result value is exactly equal to (sig * 10^exp),
+     the exponent part (10^exp) can be converted to (sig2 * 2^exp2).
+
+     The sig2 can be an infinite length number, only the highest 128 bits
+     is cached in the pow10_sig_table.
+
+     Now we have these bits:
+     sig1 (normalized 64bit)        : aaaaaaaa
+     sig2 (higher 64bit)            : bbbbbbbb
+     sig2_ext (lower 64bit)         : cccccccc
+     sig2_cut (extra unknown bits)  : dddddddddddd....
+
+     And the calculation process is:
+     ----------------------------------------
+             aaaaaaaa *
+             bbbbbbbbccccccccdddddddddddd....
+     ----------------------------------------
+     abababababababab +
+             acacacacacacacac +
+                     adadadadadadadadadad....
+     ----------------------------------------
+     [hi____][lo____] +
+             [hi2___][lo2___] +
+                     [unknown___________....]
+     ----------------------------------------
+
+     The addition with carry may affect higher bits, but if there is a 0
+     in higher bits, the bits higher than 0 will not be affected.
+
+     `lo2` + `unknown` may get a carry bit and may affect `hi2`, the max
+     value of `hi2` is 0xFFFFFFFFFFFFFFFE, so `hi2` will not overflow.
+
+     `lo` + `hi2` may also get a carry bit and may affect `hi`, but only
+     the highest significant 53 bits of `hi` is needed. If there is a 0
+     in the lower bits of `hi`, then all the following bits can be dropped.
+
+     To convert the result to IEEE-754 double number, we need to perform
+     correct rounding:
+     1. if bit 54 is 0, round down,
+     2. if bit 54 is 1 and any bit beyond bit 54 is 1, round up,
+     3. if bit 54 is 1 and all bits beyond bit 54 are 0, round to even,
+        as the extra bits is unknown, this case will not be handled here.
+     */
+
+    u64 raw;
+    u64 sig1, sig2, sig2_ext, hi, lo, hi2, lo2, add, bits;
+    i32 exp2;
+    u32 lz;
+    bool exact = false, carry, round_up;
+
+    /* convert (10^exp) to (sig2 * 2^exp2) */
+    pow10_table_get_sig (exp, &sig2, &sig2_ext);
+    pow10_table_get_exp (exp, &exp2);
+
+    /* normalize and multiply */
+    lz   = u64_lz_bits (sig);
+    sig1 = sig << lz;
+    exp2 -= (i32)lz;
+    u128_mul (sig1, sig2, &hi, &lo);
+
+    /*
+     The `hi` is in range [0x4000000000000000, 0xFFFFFFFFFFFFFFFE],
+     To get normalized value, `hi` should be shifted to the left by 0 or 1.
+
+     The highest significant 53 bits is used by IEEE-754 double number,
+     and the bit 54 is used to detect rounding direction.
+
+     The lowest (64 - 54 - 1) bits is used to check whether it contains 0.
+     */
+    bits = hi & (((u64)1 << (64 - 54 - 1)) - 1);
+    if (bits - 1 < (((u64)1 << (64 - 54 - 1)) - 2))
+    {
+      /*
+       (bits != 0 && bits != 0x1FF) => (bits - 1 < 0x1FF - 1)
+       The `bits` is not zero, so we don't need to check `round to even`
+       case. The `bits` contains bit `0`, so we can drop the extra bits
+       after `0`.
+       */
+      exact = true;
+    }
+    else
+    {
+      /*
+       (bits == 0 || bits == 0x1FF)
+       The `bits` is filled with all `0` or all `1`, so we need to check
+       lower bits with another 64-bit multiplication.
+       */
+      u128_mul (sig1, sig2_ext, &hi2, &lo2);
+
+      add = lo + hi2;
+      if (add + 1 > (u64)1)
+      {
+        /*
+         (add != 0 && add != U64_MAX) => (add + 1 > 1)
+         The `add` is not zero, so we don't need to check `round to
+         even` case. The `add` contains bit `0`, so we can drop the
+         extra bits after `0`. The `hi` cannot be U64_MAX, so it will
+         not overflow.
+         */
+        carry = add < lo || add < hi2;
+        hi += carry;
+        exact = true;
+      }
+    }
+
+    if (exact)
+    {
+      /* normalize */
+      lz = hi < ((u64)1 << 63);
+      hi <<= lz;
+      exp2 -= (i32)lz;
+      exp2 += 64;
+
+      /* test the bit 54 and get rounding direction */
+      round_up = (hi & ((u64)1 << (64 - 54))) > (u64)0;
+      hi += (round_up ? ((u64)1 << (64 - 54)) : (u64)0);
+
+      /* test overflow */
+      if (hi < ((u64)1 << (64 - 54)))
+      {
+        hi = ((u64)1 << 63);
+        exp2 += 1;
+      }
+
+      /* This is a normal number, convert it to IEEE-754 format. */
+      hi >>= F64_BITS - F64_SIG_FULL_BITS;
+      exp2 += F64_BITS - F64_SIG_FULL_BITS + F64_SIG_BITS;
+      exp2 += F64_EXP_BIAS;
+      raw = ((u64)exp2 << F64_SIG_BITS) | (hi & F64_SIG_MASK);
+      return_f64_raw (raw);
+    }
+  }
+
+  /*
+   Slow path: read double number exactly with diyfp.
+   1. Use cached diyfp to get an approximation value.
+   2. Use bigcomp to check the approximation value if needed.
+
+   This algorithm refers to google's double-conversion project:
+   https://github.com/google/double-conversion
+   */
+  {
+    const i32 ERR_ULP_LOG    = 3;
+    const i32 ERR_ULP        = 1 << ERR_ULP_LOG;
+    const i32 ERR_CACHED_POW = ERR_ULP / 2;
+    const i32 ERR_MUL_FIXED  = ERR_ULP / 2;
+    const i32 DIY_SIG_BITS   = 64;
+    const i32 EXP_BIAS       = F64_EXP_BIAS + F64_SIG_BITS;
+    const i32 EXP_SUBNORMAL  = -EXP_BIAS + 1;
+
+    u64 fp_err;
+    u32 bits;
+    i32 order_of_magnitude;
+    i32 effective_significand_size;
+    i32 precision_digits_count;
+    u64 precision_bits;
+    u64 half_way;
+
+    u64 raw;
+    diy_fp fp, fp_upper;
+    bigint big_full, big_comp;
+    i32 cmp;
+
+    fp.sig = sig;
+    fp.exp = 0;
+    fp_err = sig_cut ? (u64)(ERR_ULP / 2) : (u64)0;
+
+    /* normalize */
+    bits = u64_lz_bits (fp.sig);
+    fp.sig <<= bits;
+    fp.exp -= (i32)bits;
+    fp_err <<= bits;
+
+    /* multiply and add error */
+    fp = diy_fp_mul (fp, diy_fp_get_cached_pow10 (exp));
+    fp_err += (u64)ERR_CACHED_POW + (fp_err != 0) + (u64)ERR_MUL_FIXED;
+
+    /* normalize */
+    bits = u64_lz_bits (fp.sig);
+    fp.sig <<= bits;
+    fp.exp -= (i32)bits;
+    fp_err <<= bits;
+
+    /* effective significand */
+    order_of_magnitude = DIY_SIG_BITS + fp.exp;
+    if (likely (order_of_magnitude >= EXP_SUBNORMAL + F64_SIG_FULL_BITS))
+    {
+      effective_significand_size = F64_SIG_FULL_BITS;
+    }
+    else if (order_of_magnitude <= EXP_SUBNORMAL)
+    {
+      effective_significand_size = 0;
+    }
+    else
+    {
+      effective_significand_size = order_of_magnitude - EXP_SUBNORMAL;
+    }
+
+    /* precision digits count */
+    precision_digits_count = DIY_SIG_BITS - effective_significand_size;
+    if (unlikely (precision_digits_count + ERR_ULP_LOG >= DIY_SIG_BITS))
+    {
+      i32 shr = (precision_digits_count + ERR_ULP_LOG) - DIY_SIG_BITS + 1;
+      fp.sig >>= shr;
+      fp.exp += shr;
+      fp_err = (fp_err >> shr) + 1 + (u32)ERR_ULP;
+      precision_digits_count -= shr;
+    }
+
+    /* half way */
+    precision_bits = fp.sig & (((u64)1 << precision_digits_count) - 1);
+    precision_bits *= (u32)ERR_ULP;
+    half_way = (u64)1 << (precision_digits_count - 1);
+    half_way *= (u32)ERR_ULP;
+
+    /* rounding */
+    fp.sig >>= precision_digits_count;
+    fp.sig += (precision_bits >= half_way + fp_err);
+    fp.exp += precision_digits_count;
+
+    /* get IEEE double raw value */
+    raw = diy_fp_to_ieee_raw (fp);
+    if (unlikely (raw == F64_RAW_INF))
+      return_inf ();
+    if (likely (precision_bits <= half_way - fp_err ||
+                precision_bits >= half_way + fp_err))
+    {
+      return_f64_raw (raw); /* number is accurate */
+    }
+    /* now the number is the correct value, or the next lower value */
+
+    /* upper boundary */
+    if (raw & F64_EXP_MASK)
+    {
+      fp_upper.sig = (raw & F64_SIG_MASK) + ((u64)1 << F64_SIG_BITS);
+      fp_upper.exp = (i32)((raw & F64_EXP_MASK) >> F64_SIG_BITS);
+    }
+    else
+    {
+      fp_upper.sig = (raw & F64_SIG_MASK);
+      fp_upper.exp = 1;
+    }
+    fp_upper.exp -= F64_EXP_BIAS + F64_SIG_BITS;
+    fp_upper.sig <<= 1;
+    fp_upper.exp -= 1;
+    fp_upper.sig += 1; /* add half ulp */
+
+    /* compare with bigint */
+    bigint_set_buf (&big_full, sig, &exp, sig_cut, sig_end, dot_pos);
+    bigint_set_u64 (&big_comp, fp_upper.sig);
+    if (exp >= 0)
+    {
+      bigint_mul_pow10 (&big_full, +exp);
+    }
+    else
+    {
+      bigint_mul_pow10 (&big_comp, -exp);
+    }
+    if (fp_upper.exp > 0)
+    {
+      bigint_mul_pow2 (&big_comp, (u32) + fp_upper.exp);
+    }
+    else
+    {
+      bigint_mul_pow2 (&big_full, (u32)-fp_upper.exp);
+    }
+    cmp = bigint_cmp (&big_full, &big_comp);
+    if (likely (cmp != 0))
+    {
+      /* round down or round up */
+      raw += (cmp > 0);
+    }
+    else
+    {
+      /* falls midway, round to even */
+      raw += (raw & 1);
+    }
+
+    if (unlikely (raw == F64_RAW_INF))
+      return_inf ();
+    return_f64_raw (raw);
+  }
+
 #undef has_flag
 #undef return_err
 #undef return_inf
@@ -4140,8 +4748,6 @@ digi_finish:
 #undef return_f64_raw
 }
 
-
-
 #else /* FP_READER */
 
 /**
@@ -4149,164 +4755,211 @@ digi_finish:
  This is a fallback function if the custom number reader is disabled.
  This function use libc's strtod() to read floating-point number.
  */
-static_noinline bool read_number(u8 **ptr,
-                                 u8 **pre,
-                                 bool ext,
-                                 yyjson_val *val,
-                                 const char **msg) {
-    
-#define return_err(_pos, _msg) do { \
-    *msg = _msg; \
-    *end = _pos; \
-    return false; \
-} while (false)
-    
-#define return_0() do { \
-    val->tag = YYJSON_TYPE_NUM | (u64)((u8)sign << 3); \
-    val->uni.u64 = 0; \
-    *end = cur; return true; \
-} while (false)
+static_noinline bool
+read_number (u8 **ptr,
+             u8 **pre,
+             bool ext,
+             yyjson_val *val,
+             const char **msg)
+{
 
-#define return_i64(_v) do { \
-    val->tag = YYJSON_TYPE_NUM | (u64)((u8)sign << 3); \
+#define return_err(_pos, _msg) \
+  do                           \
+  {                            \
+    *msg = _msg;               \
+    *end = _pos;               \
+    return false;              \
+  } while (false)
+
+#define return_0()                                         \
+  do                                                       \
+  {                                                        \
+    val->tag     = YYJSON_TYPE_NUM | (u64)((u8)sign << 3); \
+    val->uni.u64 = 0;                                      \
+    *end         = cur;                                    \
+    return true;                                           \
+  } while (false)
+
+#define return_i64(_v)                                         \
+  do                                                           \
+  {                                                            \
+    val->tag     = YYJSON_TYPE_NUM | (u64)((u8)sign << 3);     \
     val->uni.u64 = (u64)(sign ? (u64)(~(_v) + 1) : (u64)(_v)); \
-    *end = cur; return true; \
-} while (false)
-    
-#define return_f64(_v) do { \
-    val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL; \
-    val->uni.f64 = sign ? -(f64)(_v) : (f64)(_v); \
-    *end = cur; return true; \
-} while (false)
-    
-#define return_f64_raw(_v) do { \
-    val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL; \
-    val->uni.u64 = ((u64)sign << 63) | (u64)(_v); \
-    *end = cur; return true; \
-} while (false)
-    
-    u64 sig, num;
-    u8 *hdr = *ptr;
-    u8 *cur = *ptr;
-    u8 **end = ptr;
-    u8 *dot = NULL;
-    u8 *f64_end = NULL;
-    bool sign;
-    
-    /* read number as raw string if has flag */
-    if (unlikely(pre)) {
-        return read_number_raw(ptr, pre, ext, val, msg);
+    *end         = cur;                                        \
+    return true;                                               \
+  } while (false)
+
+#define return_f64(_v)                                    \
+  do                                                      \
+  {                                                       \
+    val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL; \
+    val->uni.f64 = sign ? -(f64)(_v) : (f64)(_v);         \
+    *end         = cur;                                   \
+    return true;                                          \
+  } while (false)
+
+#define return_f64_raw(_v)                                \
+  do                                                      \
+  {                                                       \
+    val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL; \
+    val->uni.u64 = ((u64)sign << 63) | (u64)(_v);         \
+    *end         = cur;                                   \
+    return true;                                          \
+  } while (false)
+
+  u64 sig, num;
+  u8 *hdr     = *ptr;
+  u8 *cur     = *ptr;
+  u8 **end    = ptr;
+  u8 *dot     = NULL;
+  u8 *f64_end = NULL;
+  bool sign;
+
+  /* read number as raw string if has flag */
+  if (unlikely (pre))
+  {
+    return read_number_raw (ptr, pre, ext, val, msg);
+  }
+
+  sign = (*hdr == '-');
+  cur += sign;
+  sig = (u8)(*cur - '0');
+
+  /* read first digit, check leading zero */
+  if (unlikely (!digi_is_digit (*cur)))
+  {
+    if (unlikely (ext))
+    {
+      if (read_inf_or_nan (sign, &cur, pre, val))
+      {
+        *end = cur;
+        return true;
+      }
     }
-    
-    sign = (*hdr == '-');
-    cur += sign;
-    sig = (u8)(*cur - '0');
-    
-    /* read first digit, check leading zero */
-    if (unlikely(!digi_is_digit(*cur))) {
-        if (unlikely(ext)) {
-            if (read_inf_or_nan(sign, &cur, pre, val)) {
-                *end = cur;
-                return true;
-            }
-        }
-        return_err(cur, "no digit after minus sign");
+    return_err (cur, "no digit after minus sign");
+  }
+  if (*cur == '0')
+  {
+    cur++;
+    if (unlikely (digi_is_digit (*cur)))
+    {
+      return_err (cur - 1, "number with leading zero is not allowed");
     }
-    if (*cur == '0') {
-        cur++;
-        if (unlikely(digi_is_digit(*cur))) {
-            return_err(cur - 1, "number with leading zero is not allowed");
-        }
-        if (!digi_is_fp(*cur)) return_0();
-        goto read_double;
-    }
-    
-    /* read continuous digits, up to 19 characters */
-#define expr_intg(i) \
-    if (likely((num = (u64)(cur[i] - (u8)'0')) <= 9)) sig = num + sig * 10; \
-    else { cur += i; goto intg_end; }
-    repeat_in_1_18(expr_intg)
+    if (!digi_is_fp (*cur))
+      return_0 ();
+    goto read_double;
+  }
+
+  /* read continuous digits, up to 19 characters */
+#define expr_intg(i)                                 \
+  if (likely ((num = (u64)(cur[i] - (u8)'0')) <= 9)) \
+    sig = num + sig * 10;                            \
+  else                                               \
+  {                                                  \
+    cur += i;                                        \
+    goto intg_end;                                   \
+  }
+  repeat_in_1_18 (expr_intg)
 #undef expr_intg
-    
-    /* here are 19 continuous digits, skip them */
-    cur += 19;
-    if (digi_is_digit(cur[0]) && !digi_is_digit_or_fp(cur[1])) {
-        /* this number is an integer consisting of 20 digits */
-        num = (u8)(*cur - '0');
-        if ((sig < (U64_MAX / 10)) ||
-            (sig == (U64_MAX / 10) && num <= (U64_MAX % 10))) {
-            sig = num + sig * 10;
-            cur++;
-            if (sign) return_f64(normalized_u64_to_f64(sig));
-            return_i64(sig);
-        }
+
+      /* here are 19 continuous digits, skip them */
+      cur += 19;
+  if (digi_is_digit (cur[0]) && !digi_is_digit_or_fp (cur[1]))
+  {
+    /* this number is an integer consisting of 20 digits */
+    num = (u8)(*cur - '0');
+    if ((sig < (U64_MAX / 10)) ||
+        (sig == (U64_MAX / 10) && num <= (U64_MAX % 10)))
+    {
+      sig = num + sig * 10;
+      cur++;
+      if (sign)
+        return_f64 (normalized_u64_to_f64 (sig));
+      return_i64 (sig);
     }
-    
+  }
+
 intg_end:
-    /* continuous digits ended */
-    if (!digi_is_digit_or_fp(*cur)) {
-        /* this number is an integer consisting of 1 to 19 digits */
-        if (sign && (sig > ((u64)1 << 63))) {
-            return_f64(normalized_u64_to_f64(sig));
-        }
-        return_i64(sig);
+  /* continuous digits ended */
+  if (!digi_is_digit_or_fp (*cur))
+  {
+    /* this number is an integer consisting of 1 to 19 digits */
+    if (sign && (sig > ((u64)1 << 63)))
+    {
+      return_f64 (normalized_u64_to_f64 (sig));
     }
-    
+    return_i64 (sig);
+  }
+
 read_double:
-    /* this number should be read as double */
-    while (digi_is_digit(*cur)) cur++;
-    if (*cur == '.') {
-        /* skip fraction part */
-        dot = cur;
-        cur++;
-        if (!digi_is_digit(*cur)) {
-            return_err(cur, "no digit after decimal point");
-        }
-        cur++;
-        while (digi_is_digit(*cur)) cur++;
+  /* this number should be read as double */
+  while (digi_is_digit (*cur))
+    cur++;
+  if (*cur == '.')
+  {
+    /* skip fraction part */
+    dot = cur;
+    cur++;
+    if (!digi_is_digit (*cur))
+    {
+      return_err (cur, "no digit after decimal point");
     }
-    if (digi_is_exp(*cur)) {
-        /* skip exponent part */
-        cur += 1 + digi_is_sign(cur[1]);
-        if (!digi_is_digit(*cur)) {
-            return_err(cur, "no digit after exponent sign");
-        }
-        cur++;
-        while (digi_is_digit(*cur)) cur++;
+    cur++;
+    while (digi_is_digit (*cur))
+      cur++;
+  }
+  if (digi_is_exp (*cur))
+  {
+    /* skip exponent part */
+    cur += 1 + digi_is_sign (cur[1]);
+    if (!digi_is_digit (*cur))
+    {
+      return_err (cur, "no digit after exponent sign");
     }
-    
-    /*
-     libc's strtod() is used to parse the floating-point number.
-     
-     Note that the decimal point character used by strtod() is locale-dependent,
-     and the rounding direction may affected by fesetround().
-     
-     For currently known locales, (en, zh, ja, ko, am, he, hi) use '.' as the
-     decimal point, while other locales use ',' as the decimal point.
-     
-     Here strtod() is called twice for different locales, but if another thread
-     happens calls setlocale() between two strtod(), parsing may still fail.
-     */
-    val->uni.f64 = strtod((const char *)hdr, (char **)&f64_end);
-    if (unlikely(f64_end != cur)) {
-        bool cut = (*cur == ',');
-        if (dot) *dot = ',';
-        if (cut) *cur = ' ';
-        val->uni.f64 = strtod((const char *)hdr, (char **)&f64_end);
-        if (cut) *cur = ',';
-        if (unlikely(f64_end != cur)) {
-            return_err(hdr, "strtod() failed to parse the number");
-        }
+    cur++;
+    while (digi_is_digit (*cur))
+      cur++;
+  }
+
+  /*
+   libc's strtod() is used to parse the floating-point number.
+
+   Note that the decimal point character used by strtod() is locale-dependent,
+   and the rounding direction may affected by fesetround().
+
+   For currently known locales, (en, zh, ja, ko, am, he, hi) use '.' as the
+   decimal point, while other locales use ',' as the decimal point.
+
+   Here strtod() is called twice for different locales, but if another thread
+   happens calls setlocale() between two strtod(), parsing may still fail.
+   */
+  val->uni.f64 = strtod ((const char *)hdr, (char **)&f64_end);
+  if (unlikely (f64_end != cur))
+  {
+    bool cut = (*cur == ',');
+    if (dot)
+      *dot = ',';
+    if (cut)
+      *cur = ' ';
+    val->uni.f64 = strtod ((const char *)hdr, (char **)&f64_end);
+    if (cut)
+      *cur = ',';
+    if (unlikely (f64_end != cur))
+    {
+      return_err (hdr, "strtod() failed to parse the number");
     }
-    if (unlikely(val->uni.f64 >= HUGE_VAL || val->uni.f64 <= -HUGE_VAL)) {
-        if (!ext) {
-            return_err(hdr, "number is infinity when parsed as double");
-        }
+  }
+  if (unlikely (val->uni.f64 >= HUGE_VAL || val->uni.f64 <= -HUGE_VAL))
+  {
+    if (!ext)
+    {
+      return_err (hdr, "number is infinity when parsed as double");
     }
-    val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
-    *end = cur;
-    return true;
-    
+  }
+  val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
+  *end     = cur;
+  return true;
+
 #undef has_flag
 #undef return_err
 #undef return_0
@@ -4315,8 +4968,6 @@ read_double:
 }
 
 #endif /* FP_READER */
-
-
 
 /*==============================================================================
  * JSON String Reader
@@ -4331,452 +4982,527 @@ read_double:
  @param msg The error message pointer.
  @return Whether success.
  */
-static_inline bool read_string(u8 **ptr,
-                               u8 *lst,
-                               bool inv,
-                               yyjson_val *val,
-                               const char **msg) {
-    /*
-     Each unicode code point is encoded as 1 to 4 bytes in UTF-8 encoding,
-     we use 4-byte mask and pattern value to validate UTF-8 byte sequence,
-     this requires the input data to have 4-byte zero padding.
-     ---------------------------------------------------
-     1 byte
-     unicode range [U+0000, U+007F]
-     unicode min   [.......0]
-     unicode max   [.1111111]
-     bit pattern   [0.......]
-     ---------------------------------------------------
-     2 byte
-     unicode range [U+0080, U+07FF]
-     unicode min   [......10 ..000000]
-     unicode max   [...11111 ..111111]
-     bit require   [...xxxx. ........] (1E 00)
-     bit mask      [xxx..... xx......] (E0 C0)
-     bit pattern   [110..... 10......] (C0 80)
-     ---------------------------------------------------
-     3 byte
-     unicode range [U+0800, U+FFFF]
-     unicode min   [........ ..100000 ..000000]
-     unicode max   [....1111 ..111111 ..111111]
-     bit require   [....xxxx ..x..... ........] (0F 20 00)
-     bit mask      [xxxx.... xx...... xx......] (F0 C0 C0)
-     bit pattern   [1110.... 10...... 10......] (E0 80 80)
-     ---------------------------------------------------
-     3 byte invalid (reserved for surrogate halves)
-     unicode range [U+D800, U+DFFF]
-     unicode min   [....1101 ..100000 ..000000]
-     unicode max   [....1101 ..111111 ..111111]
-     bit mask      [....xxxx ..x..... ........] (0F 20 00)
-     bit pattern   [....1101 ..1..... ........] (0D 20 00)
-     ---------------------------------------------------
-     4 byte
-     unicode range [U+10000, U+10FFFF]
-     unicode min   [........ ...10000 ..000000 ..000000]
-     unicode max   [.....100 ..001111 ..111111 ..111111]
-     bit require   [.....xxx ..xx.... ........ ........] (07 30 00 00)
-     bit mask      [xxxxx... xx...... xx...... xx......] (F8 C0 C0 C0)
-     bit pattern   [11110... 10...... 10...... 10......] (F0 80 80 80)
-     ---------------------------------------------------
-     */
+static_inline bool
+read_string (u8 **ptr,
+             u8 *lst,
+             bool inv,
+             yyjson_val *val,
+             const char **msg)
+{
+  /*
+   Each unicode code point is encoded as 1 to 4 bytes in UTF-8 encoding,
+   we use 4-byte mask and pattern value to validate UTF-8 byte sequence,
+   this requires the input data to have 4-byte zero padding.
+   ---------------------------------------------------
+   1 byte
+   unicode range [U+0000, U+007F]
+   unicode min   [.......0]
+   unicode max   [.1111111]
+   bit pattern   [0.......]
+   ---------------------------------------------------
+   2 byte
+   unicode range [U+0080, U+07FF]
+   unicode min   [......10 ..000000]
+   unicode max   [...11111 ..111111]
+   bit require   [...xxxx. ........] (1E 00)
+   bit mask      [xxx..... xx......] (E0 C0)
+   bit pattern   [110..... 10......] (C0 80)
+   ---------------------------------------------------
+   3 byte
+   unicode range [U+0800, U+FFFF]
+   unicode min   [........ ..100000 ..000000]
+   unicode max   [....1111 ..111111 ..111111]
+   bit require   [....xxxx ..x..... ........] (0F 20 00)
+   bit mask      [xxxx.... xx...... xx......] (F0 C0 C0)
+   bit pattern   [1110.... 10...... 10......] (E0 80 80)
+   ---------------------------------------------------
+   3 byte invalid (reserved for surrogate halves)
+   unicode range [U+D800, U+DFFF]
+   unicode min   [....1101 ..100000 ..000000]
+   unicode max   [....1101 ..111111 ..111111]
+   bit mask      [....xxxx ..x..... ........] (0F 20 00)
+   bit pattern   [....1101 ..1..... ........] (0D 20 00)
+   ---------------------------------------------------
+   4 byte
+   unicode range [U+10000, U+10FFFF]
+   unicode min   [........ ...10000 ..000000 ..000000]
+   unicode max   [.....100 ..001111 ..111111 ..111111]
+   bit require   [.....xxx ..xx.... ........ ........] (07 30 00 00)
+   bit mask      [xxxxx... xx...... xx...... xx......] (F8 C0 C0 C0)
+   bit pattern   [11110... 10...... 10...... 10......] (F0 80 80 80)
+   ---------------------------------------------------
+   */
 #if YYJSON_ENDIAN == YYJSON_BIG_ENDIAN
-    const u32 b1_mask = 0x80000000UL;
-    const u32 b1_patt = 0x00000000UL;
-    const u32 b2_mask = 0xE0C00000UL;
-    const u32 b2_patt = 0xC0800000UL;
-    const u32 b2_requ = 0x1E000000UL;
-    const u32 b3_mask = 0xF0C0C000UL;
-    const u32 b3_patt = 0xE0808000UL;
-    const u32 b3_requ = 0x0F200000UL;
-    const u32 b3_erro = 0x0D200000UL;
-    const u32 b4_mask = 0xF8C0C0C0UL;
-    const u32 b4_patt = 0xF0808080UL;
-    const u32 b4_requ = 0x07300000UL;
-    const u32 b4_err0 = 0x04000000UL;
-    const u32 b4_err1 = 0x03300000UL;
+  const u32 b1_mask = 0x80000000UL;
+  const u32 b1_patt = 0x00000000UL;
+  const u32 b2_mask = 0xE0C00000UL;
+  const u32 b2_patt = 0xC0800000UL;
+  const u32 b2_requ = 0x1E000000UL;
+  const u32 b3_mask = 0xF0C0C000UL;
+  const u32 b3_patt = 0xE0808000UL;
+  const u32 b3_requ = 0x0F200000UL;
+  const u32 b3_erro = 0x0D200000UL;
+  const u32 b4_mask = 0xF8C0C0C0UL;
+  const u32 b4_patt = 0xF0808080UL;
+  const u32 b4_requ = 0x07300000UL;
+  const u32 b4_err0 = 0x04000000UL;
+  const u32 b4_err1 = 0x03300000UL;
 #elif YYJSON_ENDIAN == YYJSON_LITTLE_ENDIAN
-    const u32 b1_mask = 0x00000080UL;
-    const u32 b1_patt = 0x00000000UL;
-    const u32 b2_mask = 0x0000C0E0UL;
-    const u32 b2_patt = 0x000080C0UL;
-    const u32 b2_requ = 0x0000001EUL;
-    const u32 b3_mask = 0x00C0C0F0UL;
-    const u32 b3_patt = 0x008080E0UL;
-    const u32 b3_requ = 0x0000200FUL;
-    const u32 b3_erro = 0x0000200DUL;
-    const u32 b4_mask = 0xC0C0C0F8UL;
-    const u32 b4_patt = 0x808080F0UL;
-    const u32 b4_requ = 0x00003007UL;
-    const u32 b4_err0 = 0x00000004UL;
-    const u32 b4_err1 = 0x00003003UL;
+  const u32 b1_mask = 0x00000080UL;
+  const u32 b1_patt = 0x00000000UL;
+  const u32 b2_mask = 0x0000C0E0UL;
+  const u32 b2_patt = 0x000080C0UL;
+  const u32 b2_requ = 0x0000001EUL;
+  const u32 b3_mask = 0x00C0C0F0UL;
+  const u32 b3_patt = 0x008080E0UL;
+  const u32 b3_requ = 0x0000200FUL;
+  const u32 b3_erro = 0x0000200DUL;
+  const u32 b4_mask = 0xC0C0C0F8UL;
+  const u32 b4_patt = 0x808080F0UL;
+  const u32 b4_requ = 0x00003007UL;
+  const u32 b4_err0 = 0x00000004UL;
+  const u32 b4_err1 = 0x00003003UL;
 #else
-    v32_uni b1_mask_uni = {{ 0x80, 0x00, 0x00, 0x00 }};
-    v32_uni b1_patt_uni = {{ 0x00, 0x00, 0x00, 0x00 }};
-    v32_uni b2_mask_uni = {{ 0xE0, 0xC0, 0x00, 0x00 }};
-    v32_uni b2_patt_uni = {{ 0xC0, 0x80, 0x00, 0x00 }};
-    v32_uni b2_requ_uni = {{ 0x1E, 0x00, 0x00, 0x00 }};
-    v32_uni b3_mask_uni = {{ 0xF0, 0xC0, 0xC0, 0x00 }};
-    v32_uni b3_patt_uni = {{ 0xE0, 0x80, 0x80, 0x00 }};
-    v32_uni b3_requ_uni = {{ 0x0F, 0x20, 0x00, 0x00 }};
-    v32_uni b3_erro_uni = {{ 0x0D, 0x20, 0x00, 0x00 }};
-    v32_uni b4_mask_uni = {{ 0xF8, 0xC0, 0xC0, 0xC0 }};
-    v32_uni b4_patt_uni = {{ 0xF0, 0x80, 0x80, 0x80 }};
-    v32_uni b4_requ_uni = {{ 0x07, 0x30, 0x00, 0x00 }};
-    v32_uni b4_err0_uni = {{ 0x04, 0x00, 0x00, 0x00 }};
-    v32_uni b4_err1_uni = {{ 0x03, 0x30, 0x00, 0x00 }};
-    u32 b1_mask = b1_mask_uni.u;
-    u32 b1_patt = b1_patt_uni.u;
-    u32 b2_mask = b2_mask_uni.u;
-    u32 b2_patt = b2_patt_uni.u;
-    u32 b2_requ = b2_requ_uni.u;
-    u32 b3_mask = b3_mask_uni.u;
-    u32 b3_patt = b3_patt_uni.u;
-    u32 b3_requ = b3_requ_uni.u;
-    u32 b3_erro = b3_erro_uni.u;
-    u32 b4_mask = b4_mask_uni.u;
-    u32 b4_patt = b4_patt_uni.u;
-    u32 b4_requ = b4_requ_uni.u;
-    u32 b4_err0 = b4_err0_uni.u;
-    u32 b4_err1 = b4_err1_uni.u;
+  v32_uni b1_mask_uni = {{0x80, 0x00, 0x00, 0x00}};
+  v32_uni b1_patt_uni = {{0x00, 0x00, 0x00, 0x00}};
+  v32_uni b2_mask_uni = {{0xE0, 0xC0, 0x00, 0x00}};
+  v32_uni b2_patt_uni = {{0xC0, 0x80, 0x00, 0x00}};
+  v32_uni b2_requ_uni = {{0x1E, 0x00, 0x00, 0x00}};
+  v32_uni b3_mask_uni = {{0xF0, 0xC0, 0xC0, 0x00}};
+  v32_uni b3_patt_uni = {{0xE0, 0x80, 0x80, 0x00}};
+  v32_uni b3_requ_uni = {{0x0F, 0x20, 0x00, 0x00}};
+  v32_uni b3_erro_uni = {{0x0D, 0x20, 0x00, 0x00}};
+  v32_uni b4_mask_uni = {{0xF8, 0xC0, 0xC0, 0xC0}};
+  v32_uni b4_patt_uni = {{0xF0, 0x80, 0x80, 0x80}};
+  v32_uni b4_requ_uni = {{0x07, 0x30, 0x00, 0x00}};
+  v32_uni b4_err0_uni = {{0x04, 0x00, 0x00, 0x00}};
+  v32_uni b4_err1_uni = {{0x03, 0x30, 0x00, 0x00}};
+  u32 b1_mask         = b1_mask_uni.u;
+  u32 b1_patt         = b1_patt_uni.u;
+  u32 b2_mask         = b2_mask_uni.u;
+  u32 b2_patt         = b2_patt_uni.u;
+  u32 b2_requ         = b2_requ_uni.u;
+  u32 b3_mask         = b3_mask_uni.u;
+  u32 b3_patt         = b3_patt_uni.u;
+  u32 b3_requ         = b3_requ_uni.u;
+  u32 b3_erro         = b3_erro_uni.u;
+  u32 b4_mask         = b4_mask_uni.u;
+  u32 b4_patt         = b4_patt_uni.u;
+  u32 b4_requ         = b4_requ_uni.u;
+  u32 b4_err0         = b4_err0_uni.u;
+  u32 b4_err1         = b4_err1_uni.u;
 #endif
-    
-#define is_valid_seq_1(uni) ( \
-    ((uni & b1_mask) == b1_patt) \
-)
 
-#define is_valid_seq_2(uni) ( \
+#define is_valid_seq_1(uni) ( \
+    ((uni & b1_mask) == b1_patt))
+
+#define is_valid_seq_2(uni) (       \
     ((uni & b2_mask) == b2_patt) && \
-    ((uni & b2_requ)) \
-)
-    
-#define is_valid_seq_3(uni) ( \
+    ((uni & b2_requ)))
+
+#define is_valid_seq_3(uni) (       \
     ((uni & b3_mask) == b3_patt) && \
-    ((tmp = (uni & b3_requ))) && \
-    ((tmp != b3_erro)) \
-)
-    
-#define is_valid_seq_4(uni) ( \
+    ((tmp = (uni & b3_requ))) &&    \
+    ((tmp != b3_erro)))
+
+#define is_valid_seq_4(uni) (       \
     ((uni & b4_mask) == b4_patt) && \
-    ((tmp = (uni & b4_requ))) && \
-    ((tmp & b4_err0) == 0 || (tmp & b4_err1) == 0) \
-)
-    
-#define return_err(_end, _msg) do { \
-    *msg = _msg; \
-    *end = _end; \
-    return false; \
-} while (false)
-    
-    u8 *cur = *ptr;
-    u8 **end = ptr;
-    u8 *src = ++cur, *dst, *pos;
-    u16 hi, lo;
-    u32 uni, tmp;
-    
+    ((tmp = (uni & b4_requ))) &&    \
+    ((tmp & b4_err0) == 0 || (tmp & b4_err1) == 0))
+
+#define return_err(_end, _msg) \
+  do                           \
+  {                            \
+    *msg = _msg;               \
+    *end = _end;               \
+    return false;              \
+  } while (false)
+
+  u8 *cur  = *ptr;
+  u8 **end = ptr;
+  u8 *src  = ++cur, *dst, *pos;
+  u16 hi, lo;
+  u32 uni, tmp;
+
 skip_ascii:
-    /* Most strings have no escaped characters, so we can jump them quickly. */
-    
+  /* Most strings have no escaped characters, so we can jump them quickly. */
+
 skip_ascii_begin:
-    /*
-     We want to make loop unrolling, as shown in the following code. Some
-     compiler may not generate instructions as expected, so we rewrite it with
-     explicit goto statements. We hope the compiler can generate instructions
-     like this: https://godbolt.org/z/8vjsYq
-     
-         while (true) repeat16({
-            if (likely(!(char_is_ascii_stop(*src)))) src++;
-            else break;
-         })
-     */
-#define expr_jump(i) \
-    if (likely(!char_is_ascii_stop(src[i]))) {} \
-    else goto skip_ascii_stop##i;
-    
-#define expr_stop(i) \
-    skip_ascii_stop##i: \
-    src += i; \
-    goto skip_ascii_end;
-    
-    repeat16_incr(expr_jump)
-    src += 16;
-    goto skip_ascii_begin;
-    repeat16_incr(expr_stop)
-    
+  /*
+   We want to make loop unrolling, as shown in the following code. Some
+   compiler may not generate instructions as expected, so we rewrite it with
+   explicit goto statements. We hope the compiler can generate instructions
+   like this: https://godbolt.org/z/8vjsYq
+
+       while (true) repeat16({
+          if (likely(!(char_is_ascii_stop(*src)))) src++;
+          else break;
+       })
+   */
+#define expr_jump(i)                         \
+  if (likely (!char_is_ascii_stop (src[i]))) \
+  {                                          \
+  }                                          \
+  else                                       \
+    goto skip_ascii_stop##i;
+
+#define expr_stop(i)             \
+  skip_ascii_stop##i : src += i; \
+  goto skip_ascii_end;
+
+  repeat16_incr (expr_jump)
+      src += 16;
+  goto skip_ascii_begin;
+  repeat16_incr (expr_stop)
+
 #undef expr_jump
 #undef expr_stop
-    
-skip_ascii_end:
-    
-    /*
-     GCC may store src[i] in a register at each line of expr_jump(i) above.
-     These instructions are useless and will degrade performance.
-     This inline asm is a hint for gcc: "the memory has been modified,
-     do not cache it".
-     
-     MSVC, Clang, ICC can generate expected instructions without this hint.
-     */
+
+      skip_ascii_end :
+
+  /*
+   GCC may store src[i] in a register at each line of expr_jump(i) above.
+   These instructions are useless and will degrade performance.
+   This inline asm is a hint for gcc: "the memory has been modified,
+   do not cache it".
+
+   MSVC, Clang, ICC can generate expected instructions without this hint.
+   */
 #if YYJSON_IS_REAL_GCC
-    __asm__ volatile("":"=m"(*src));
+      __asm__ volatile(""
+                       : "=m"(*src));
 #endif
-    if (likely(*src == '"')) {
-        val->tag = ((u64)(src - cur) << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-        val->uni.str = (const char *)cur;
-        *src = '\0';
-        *end = src + 1;
-        return true;
-    }
-    
+  if (likely (*src == '"'))
+  {
+    val->tag     = ((u64)(src - cur) << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+    val->uni.str = (const char *)cur;
+    *src         = '\0';
+    *end         = src + 1;
+    return true;
+  }
+
 skip_utf8:
-    if (*src & 0x80) { /* non-ASCII character */
-        /*
-         Non-ASCII character appears here, which means that the text is likely
-         to be written in non-English or emoticons. According to some common
-         data set statistics, byte sequences of the same length may appear
-         consecutively. We process the byte sequences of the same length in each
-         loop, which is more friendly to branch prediction.
-         */
-        pos = src;
-        uni = byte_load_4(src);
-        while (is_valid_seq_3(uni)) {
-            src += 3;
-            uni = byte_load_4(src);
-        }
-        if (is_valid_seq_1(uni)) goto skip_ascii;
-        while (is_valid_seq_2(uni)) {
-            src += 2;
-            uni = byte_load_4(src);
-        }
-        while (is_valid_seq_4(uni)) {
-            src += 4;
-            uni = byte_load_4(src);
-        }
-        if (unlikely(pos == src)) {
-            if (!inv) return_err(src, "invalid UTF-8 encoding in string");
-            ++src;
-        }
-        goto skip_ascii;
-    }
-    
-    /* The escape character appears, we need to copy it. */
-    dst = src;
-copy_escape:
-    if (likely(*src == '\\')) {
-        switch (*++src) {
-            case '"':  *dst++ = '"';  src++; break;
-            case '\\': *dst++ = '\\'; src++; break;
-            case '/':  *dst++ = '/';  src++; break;
-            case 'b':  *dst++ = '\b'; src++; break;
-            case 'f':  *dst++ = '\f'; src++; break;
-            case 'n':  *dst++ = '\n'; src++; break;
-            case 'r':  *dst++ = '\r'; src++; break;
-            case 't':  *dst++ = '\t'; src++; break;
-            case 'u':
-                if (unlikely(!read_hex_u16(++src, &hi))) {
-                    return_err(src - 2, "invalid escaped sequence in string");
-                }
-                src += 4;
-                if (likely((hi & 0xF800) != 0xD800)) {
-                    /* a BMP character */
-                    if (hi >= 0x800) {
-                        *dst++ = (u8)(0xE0 | (hi >> 12));
-                        *dst++ = (u8)(0x80 | ((hi >> 6) & 0x3F));
-                        *dst++ = (u8)(0x80 | (hi & 0x3F));
-                    } else if (hi >= 0x80) {
-                        *dst++ = (u8)(0xC0 | (hi >> 6));
-                        *dst++ = (u8)(0x80 | (hi & 0x3F));
-                    } else {
-                        *dst++ = (u8)hi;
-                    }
-                } else {
-                    /* a non-BMP character, represented as a surrogate pair */
-                    if (unlikely((hi & 0xFC00) != 0xD800)) {
-                        return_err(src - 6, "invalid high surrogate in string");
-                    }
-                    if (unlikely(!byte_match_2(src, "\\u"))) {
-                        return_err(src, "no low surrogate in string");
-                    }
-                    if (unlikely(!read_hex_u16(src + 2, &lo))) {
-                        return_err(src, "invalid escaped sequence in string");
-                    }
-                    if (unlikely((lo & 0xFC00) != 0xDC00)) {
-                        return_err(src, "invalid low surrogate in string");
-                    }
-                    uni = ((((u32)hi - 0xD800) << 10) |
-                            ((u32)lo - 0xDC00)) + 0x10000;
-                    *dst++ = (u8)(0xF0 | (uni >> 18));
-                    *dst++ = (u8)(0x80 | ((uni >> 12) & 0x3F));
-                    *dst++ = (u8)(0x80 | ((uni >> 6) & 0x3F));
-                    *dst++ = (u8)(0x80 | (uni & 0x3F));
-                    src += 6;
-                }
-                break;
-            default: return_err(src, "invalid escaped character in string");
-        }
-    } else if (likely(*src == '"')) {
-        val->tag = ((u64)(dst - cur) << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-        val->uni.str = (const char *)cur;
-        *dst = '\0';
-        *end = src + 1;
-        return true;
-    } else {
-        if (!inv) return_err(src, "unexpected control character in string");
-        if (src >= lst) return_err(src, "unclosed string");
-        *dst++ = *src++;
-    }
-    
-copy_ascii:
+  if (*src & 0x80)
+  { /* non-ASCII character */
     /*
-     Copy continuous ASCII, loop unrolling, same as the following code:
-     
-         while (true) repeat16({
-            if (unlikely(char_is_ascii_stop(*src))) break;
-            *dst++ = *src++;
-         })
+     Non-ASCII character appears here, which means that the text is likely
+     to be written in non-English or emoticons. According to some common
+     data set statistics, byte sequences of the same length may appear
+     consecutively. We process the byte sequences of the same length in each
+     loop, which is more friendly to branch prediction.
      */
-#if YYJSON_IS_REAL_GCC
-#   define expr_jump(i) \
-    if (likely(!(char_is_ascii_stop(src[i])))) {} \
-    else { __asm__ volatile("":"=m"(src[i])); goto copy_ascii_stop_##i; }
-#else
-#   define expr_jump(i) \
-    if (likely(!(char_is_ascii_stop(src[i])))) {} \
-    else { goto copy_ascii_stop_##i; }
-#endif
-    repeat16_incr(expr_jump)
-#undef expr_jump
-    
-    byte_move_16(dst, src);
-    src += 16;
-    dst += 16;
-    goto copy_ascii;
-    
-copy_ascii_stop_0:
-    goto copy_utf8;
-copy_ascii_stop_1:
-    byte_move_2(dst, src);
-    src += 1;
-    dst += 1;
-    goto copy_utf8;
-copy_ascii_stop_2:
-    byte_move_2(dst, src);
-    src += 2;
-    dst += 2;
-    goto copy_utf8;
-copy_ascii_stop_3:
-    byte_move_4(dst, src);
-    src += 3;
-    dst += 3;
-    goto copy_utf8;
-copy_ascii_stop_4:
-    byte_move_4(dst, src);
-    src += 4;
-    dst += 4;
-    goto copy_utf8;
-copy_ascii_stop_5:
-    byte_move_4(dst, src);
-    byte_move_2(dst + 4, src + 4);
-    src += 5;
-    dst += 5;
-    goto copy_utf8;
-copy_ascii_stop_6:
-    byte_move_4(dst, src);
-    byte_move_2(dst + 4, src + 4);
-    src += 6;
-    dst += 6;
-    goto copy_utf8;
-copy_ascii_stop_7:
-    byte_move_8(dst, src);
-    src += 7;
-    dst += 7;
-    goto copy_utf8;
-copy_ascii_stop_8:
-    byte_move_8(dst, src);
-    src += 8;
-    dst += 8;
-    goto copy_utf8;
-copy_ascii_stop_9:
-    byte_move_8(dst, src);
-    byte_move_2(dst + 8, src + 8);
-    src += 9;
-    dst += 9;
-    goto copy_utf8;
-copy_ascii_stop_10:
-    byte_move_8(dst, src);
-    byte_move_2(dst + 8, src + 8);
-    src += 10;
-    dst += 10;
-    goto copy_utf8;
-copy_ascii_stop_11:
-    byte_move_8(dst, src);
-    byte_move_4(dst + 8, src + 8);
-    src += 11;
-    dst += 11;
-    goto copy_utf8;
-copy_ascii_stop_12:
-    byte_move_8(dst, src);
-    byte_move_4(dst + 8, src + 8);
-    src += 12;
-    dst += 12;
-    goto copy_utf8;
-copy_ascii_stop_13:
-    byte_move_8(dst, src);
-    byte_move_4(dst + 8, src + 8);
-    byte_move_2(dst + 12, src + 12);
-    src += 13;
-    dst += 13;
-    goto copy_utf8;
-copy_ascii_stop_14:
-    byte_move_8(dst, src);
-    byte_move_4(dst + 8, src + 8);
-    byte_move_2(dst + 12, src + 12);
-    src += 14;
-    dst += 14;
-    goto copy_utf8;
-copy_ascii_stop_15:
-    byte_move_16(dst, src);
-    src += 15;
-    dst += 15;
-    goto copy_utf8;
-    
-copy_utf8:
-    if (*src & 0x80) { /* non-ASCII character */
-        pos = src;
-        uni = byte_load_4(src);
-        while (is_valid_seq_3(uni)) {
-            byte_move_4(dst, &uni);
-            dst += 3;
-            src += 3;
-            uni = byte_load_4(src);
-        }
-        if (is_valid_seq_1(uni)) goto copy_ascii;
-        while (is_valid_seq_2(uni)) {
-            byte_move_2(dst, &uni);
-            dst += 2;
-            src += 2;
-            uni = byte_load_4(src);
-        }
-        while (is_valid_seq_4(uni)) {
-            byte_move_4(dst, &uni);
-            dst += 4;
-            src += 4;
-            uni = byte_load_4(src);
-        }
-        if (unlikely(pos == src)) {
-            if (!inv) return_err(src, "invalid UTF-8 encoding in string");
-            goto copy_ascii_stop_1;
-        }
-        goto copy_ascii;
+    pos = src;
+    uni = byte_load_4 (src);
+    while (is_valid_seq_3 (uni))
+    {
+      src += 3;
+      uni = byte_load_4 (src);
     }
-    goto copy_escape;
-    
+    if (is_valid_seq_1 (uni))
+      goto skip_ascii;
+    while (is_valid_seq_2 (uni))
+    {
+      src += 2;
+      uni = byte_load_4 (src);
+    }
+    while (is_valid_seq_4 (uni))
+    {
+      src += 4;
+      uni = byte_load_4 (src);
+    }
+    if (unlikely (pos == src))
+    {
+      if (!inv)
+        return_err (src, "invalid UTF-8 encoding in string");
+      ++src;
+    }
+    goto skip_ascii;
+  }
+
+  /* The escape character appears, we need to copy it. */
+  dst = src;
+copy_escape:
+  if (likely (*src == '\\'))
+  {
+    switch (*++src)
+    {
+    case '"':
+      *dst++ = '"';
+      src++;
+      break;
+    case '\\':
+      *dst++ = '\\';
+      src++;
+      break;
+    case '/':
+      *dst++ = '/';
+      src++;
+      break;
+    case 'b':
+      *dst++ = '\b';
+      src++;
+      break;
+    case 'f':
+      *dst++ = '\f';
+      src++;
+      break;
+    case 'n':
+      *dst++ = '\n';
+      src++;
+      break;
+    case 'r':
+      *dst++ = '\r';
+      src++;
+      break;
+    case 't':
+      *dst++ = '\t';
+      src++;
+      break;
+    case 'u':
+      if (unlikely (!read_hex_u16 (++src, &hi)))
+      {
+        return_err (src - 2, "invalid escaped sequence in string");
+      }
+      src += 4;
+      if (likely ((hi & 0xF800) != 0xD800))
+      {
+        /* a BMP character */
+        if (hi >= 0x800)
+        {
+          *dst++ = (u8)(0xE0 | (hi >> 12));
+          *dst++ = (u8)(0x80 | ((hi >> 6) & 0x3F));
+          *dst++ = (u8)(0x80 | (hi & 0x3F));
+        }
+        else if (hi >= 0x80)
+        {
+          *dst++ = (u8)(0xC0 | (hi >> 6));
+          *dst++ = (u8)(0x80 | (hi & 0x3F));
+        }
+        else
+        {
+          *dst++ = (u8)hi;
+        }
+      }
+      else
+      {
+        /* a non-BMP character, represented as a surrogate pair */
+        if (unlikely ((hi & 0xFC00) != 0xD800))
+        {
+          return_err (src - 6, "invalid high surrogate in string");
+        }
+        if (unlikely (!byte_match_2 (src, "\\u")))
+        {
+          return_err (src, "no low surrogate in string");
+        }
+        if (unlikely (!read_hex_u16 (src + 2, &lo)))
+        {
+          return_err (src, "invalid escaped sequence in string");
+        }
+        if (unlikely ((lo & 0xFC00) != 0xDC00))
+        {
+          return_err (src, "invalid low surrogate in string");
+        }
+        uni = ((((u32)hi - 0xD800) << 10) |
+               ((u32)lo - 0xDC00)) +
+              0x10000;
+        *dst++ = (u8)(0xF0 | (uni >> 18));
+        *dst++ = (u8)(0x80 | ((uni >> 12) & 0x3F));
+        *dst++ = (u8)(0x80 | ((uni >> 6) & 0x3F));
+        *dst++ = (u8)(0x80 | (uni & 0x3F));
+        src += 6;
+      }
+      break;
+    default:
+      return_err (src, "invalid escaped character in string");
+    }
+  }
+  else if (likely (*src == '"'))
+  {
+    val->tag     = ((u64)(dst - cur) << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+    val->uni.str = (const char *)cur;
+    *dst         = '\0';
+    *end         = src + 1;
+    return true;
+  }
+  else
+  {
+    if (!inv)
+      return_err (src, "unexpected control character in string");
+    if (src >= lst)
+      return_err (src, "unclosed string");
+    *dst++ = *src++;
+  }
+
+copy_ascii:
+  /*
+   Copy continuous ASCII, loop unrolling, same as the following code:
+
+       while (true) repeat16({
+          if (unlikely(char_is_ascii_stop(*src))) break;
+          *dst++ = *src++;
+       })
+   */
+#if YYJSON_IS_REAL_GCC
+#define expr_jump(i)                           \
+  if (likely (!(char_is_ascii_stop (src[i])))) \
+  {                                            \
+  }                                            \
+  else                                         \
+  {                                            \
+    __asm__ volatile(""                        \
+                     : "=m"(src[i]));          \
+    goto copy_ascii_stop_##i;                  \
+  }
+#else
+#define expr_jump(i)                           \
+  if (likely (!(char_is_ascii_stop (src[i])))) \
+  {                                            \
+  }                                            \
+  else                                         \
+  {                                            \
+    goto copy_ascii_stop_##i;                  \
+  }
+#endif
+  repeat16_incr (expr_jump)
+#undef expr_jump
+
+      byte_move_16 (dst, src);
+  src += 16;
+  dst += 16;
+  goto copy_ascii;
+
+copy_ascii_stop_0:
+  goto copy_utf8;
+copy_ascii_stop_1:
+  byte_move_2 (dst, src);
+  src += 1;
+  dst += 1;
+  goto copy_utf8;
+copy_ascii_stop_2:
+  byte_move_2 (dst, src);
+  src += 2;
+  dst += 2;
+  goto copy_utf8;
+copy_ascii_stop_3:
+  byte_move_4 (dst, src);
+  src += 3;
+  dst += 3;
+  goto copy_utf8;
+copy_ascii_stop_4:
+  byte_move_4 (dst, src);
+  src += 4;
+  dst += 4;
+  goto copy_utf8;
+copy_ascii_stop_5:
+  byte_move_4 (dst, src);
+  byte_move_2 (dst + 4, src + 4);
+  src += 5;
+  dst += 5;
+  goto copy_utf8;
+copy_ascii_stop_6:
+  byte_move_4 (dst, src);
+  byte_move_2 (dst + 4, src + 4);
+  src += 6;
+  dst += 6;
+  goto copy_utf8;
+copy_ascii_stop_7:
+  byte_move_8 (dst, src);
+  src += 7;
+  dst += 7;
+  goto copy_utf8;
+copy_ascii_stop_8:
+  byte_move_8 (dst, src);
+  src += 8;
+  dst += 8;
+  goto copy_utf8;
+copy_ascii_stop_9:
+  byte_move_8 (dst, src);
+  byte_move_2 (dst + 8, src + 8);
+  src += 9;
+  dst += 9;
+  goto copy_utf8;
+copy_ascii_stop_10:
+  byte_move_8 (dst, src);
+  byte_move_2 (dst + 8, src + 8);
+  src += 10;
+  dst += 10;
+  goto copy_utf8;
+copy_ascii_stop_11:
+  byte_move_8 (dst, src);
+  byte_move_4 (dst + 8, src + 8);
+  src += 11;
+  dst += 11;
+  goto copy_utf8;
+copy_ascii_stop_12:
+  byte_move_8 (dst, src);
+  byte_move_4 (dst + 8, src + 8);
+  src += 12;
+  dst += 12;
+  goto copy_utf8;
+copy_ascii_stop_13:
+  byte_move_8 (dst, src);
+  byte_move_4 (dst + 8, src + 8);
+  byte_move_2 (dst + 12, src + 12);
+  src += 13;
+  dst += 13;
+  goto copy_utf8;
+copy_ascii_stop_14:
+  byte_move_8 (dst, src);
+  byte_move_4 (dst + 8, src + 8);
+  byte_move_2 (dst + 12, src + 12);
+  src += 14;
+  dst += 14;
+  goto copy_utf8;
+copy_ascii_stop_15:
+  byte_move_16 (dst, src);
+  src += 15;
+  dst += 15;
+  goto copy_utf8;
+
+copy_utf8:
+  if (*src & 0x80)
+  { /* non-ASCII character */
+    pos = src;
+    uni = byte_load_4 (src);
+    while (is_valid_seq_3 (uni))
+    {
+      byte_move_4 (dst, &uni);
+      dst += 3;
+      src += 3;
+      uni = byte_load_4 (src);
+    }
+    if (is_valid_seq_1 (uni))
+      goto copy_ascii;
+    while (is_valid_seq_2 (uni))
+    {
+      byte_move_2 (dst, &uni);
+      dst += 2;
+      src += 2;
+      uni = byte_load_4 (src);
+    }
+    while (is_valid_seq_4 (uni))
+    {
+      byte_move_4 (dst, &uni);
+      dst += 4;
+      src += 4;
+      uni = byte_load_4 (src);
+    }
+    if (unlikely (pos == src))
+    {
+      if (!inv)
+        return_err (src, "invalid UTF-8 encoding in string");
+      goto copy_ascii_stop_1;
+    }
+    goto copy_ascii;
+  }
+  goto copy_escape;
+
 #undef return_err
 #undef is_valid_seq_1
 #undef is_valid_seq_2
 #undef is_valid_seq_3
 #undef is_valid_seq_4
 }
-
-
 
 /*==============================================================================
  * JSON Reader Implementation
@@ -4787,1243 +5513,1594 @@ copy_utf8:
  *============================================================================*/
 
 /** Read single value JSON document. */
-static_noinline yyjson_doc *read_root_single(u8 *hdr,
-                                             u8 *cur,
-                                             u8 *end,
-                                             yyjson_alc alc,
-                                             yyjson_read_flag flg,
-                                             yyjson_read_err *err) {
-    
-#define has_flag(_flag) unlikely((flg & YYJSON_READ_##_flag) != 0)
-    
-#define return_err(_pos, _code, _msg) do { \
-    if (is_truncated_end(hdr, _pos, end, YYJSON_READ_ERROR_##_code, flg)) { \
-        err->pos = (usize)(end - hdr); \
-        err->code = YYJSON_READ_ERROR_UNEXPECTED_END; \
-        err->msg = "unexpected end of data"; \
-    } else { \
-        err->pos = (usize)(_pos - hdr); \
-        err->code = YYJSON_READ_ERROR_##_code; \
-        err->msg = _msg; \
-    } \
-    if (val_hdr) alc.free(alc.ctx, (void *)val_hdr); \
-    return NULL; \
-} while (false)
-    
-    usize hdr_len; /* value count used by doc */
-    usize alc_num; /* value count capacity */
-    yyjson_val *val_hdr; /* the head of allocated values */
-    yyjson_val *val; /* current value */
-    yyjson_doc *doc; /* the JSON document, equals to val_hdr */
-    const char *msg; /* error message */
-    
-    bool raw; /* read number as raw */
-    bool ext; /* allow inf and nan */
-    bool inv; /* allow invalid unicode */
-    u8 *raw_end; /* raw end for null-terminator */
-    u8 **pre; /* previous raw end pointer */
-    
-    hdr_len = sizeof(yyjson_doc) / sizeof(yyjson_val);
-    hdr_len += (sizeof(yyjson_doc) % sizeof(yyjson_val)) > 0;
-    alc_num = hdr_len + 1; /* single value */
-    
-    val_hdr = (yyjson_val *)alc.malloc(alc.ctx, alc_num * sizeof(yyjson_val));
-    if (unlikely(!val_hdr)) goto fail_alloc;
-    val = val_hdr + hdr_len;
-    raw = (flg & YYJSON_READ_NUMBER_AS_RAW) != 0;
-    ext = (flg & YYJSON_READ_ALLOW_INF_AND_NAN) != 0;
-    inv = (flg & YYJSON_READ_ALLOW_INVALID_UNICODE) != 0;
-    raw_end = NULL;
-    pre = raw ? &raw_end : NULL;
-    
-    if (char_is_number(*cur)) {
-        if (likely(read_number(&cur, pre, ext, val, &msg))) goto doc_end;
-        goto fail_number;
+static_noinline yyjson_doc *
+read_root_single (u8 *hdr,
+                  u8 *cur,
+                  u8 *end,
+                  yyjson_alc alc,
+                  yyjson_read_flag flg,
+                  yyjson_read_err *err)
+{
+
+#define has_flag(_flag) unlikely ((flg & YYJSON_READ_##_flag) != 0)
+
+#define return_err(_pos, _code, _msg)                                      \
+  do                                                                       \
+  {                                                                        \
+    if (is_truncated_end (hdr, _pos, end, YYJSON_READ_ERROR_##_code, flg)) \
+    {                                                                      \
+      err->pos  = (usize)(end - hdr);                                      \
+      err->code = YYJSON_READ_ERROR_UNEXPECTED_END;                        \
+      err->msg  = "unexpected end of data";                                \
+    }                                                                      \
+    else                                                                   \
+    {                                                                      \
+      err->pos  = (usize)(_pos - hdr);                                     \
+      err->code = YYJSON_READ_ERROR_##_code;                               \
+      err->msg  = _msg;                                                    \
+    }                                                                      \
+    if (val_hdr)                                                           \
+      alc.free (alc.ctx, (void *)val_hdr);                                 \
+    return NULL;                                                           \
+  } while (false)
+
+  usize hdr_len;       /* value count used by doc */
+  usize alc_num;       /* value count capacity */
+  yyjson_val *val_hdr; /* the head of allocated values */
+  yyjson_val *val;     /* current value */
+  yyjson_doc *doc;     /* the JSON document, equals to val_hdr */
+  const char *msg;     /* error message */
+
+  bool raw;    /* read number as raw */
+  bool ext;    /* allow inf and nan */
+  bool inv;    /* allow invalid unicode */
+  u8 *raw_end; /* raw end for null-terminator */
+  u8 **pre;    /* previous raw end pointer */
+
+  hdr_len = sizeof (yyjson_doc) / sizeof (yyjson_val);
+  hdr_len += (sizeof (yyjson_doc) % sizeof (yyjson_val)) > 0;
+  alc_num = hdr_len + 1; /* single value */
+
+  val_hdr = (yyjson_val *)alc.malloc (alc.ctx, alc_num * sizeof (yyjson_val));
+  if (unlikely (!val_hdr))
+    goto fail_alloc;
+  val     = val_hdr + hdr_len;
+  raw     = (flg & YYJSON_READ_NUMBER_AS_RAW) != 0;
+  ext     = (flg & YYJSON_READ_ALLOW_INF_AND_NAN) != 0;
+  inv     = (flg & YYJSON_READ_ALLOW_INVALID_UNICODE) != 0;
+  raw_end = NULL;
+  pre     = raw ? &raw_end : NULL;
+
+  if (char_is_number (*cur))
+  {
+    if (likely (read_number (&cur, pre, ext, val, &msg)))
+      goto doc_end;
+    goto fail_number;
+  }
+  if (*cur == '"')
+  {
+    if (likely (read_string (&cur, end, inv, val, &msg)))
+      goto doc_end;
+    goto fail_string;
+  }
+  if (*cur == 't')
+  {
+    if (likely (read_true (&cur, val)))
+      goto doc_end;
+    goto fail_literal;
+  }
+  if (*cur == 'f')
+  {
+    if (likely (read_false (&cur, val)))
+      goto doc_end;
+    goto fail_literal;
+  }
+  if (*cur == 'n')
+  {
+    if (likely (read_null (&cur, val)))
+      goto doc_end;
+    if (unlikely (ext))
+    {
+      if (read_nan (false, &cur, pre, val))
+        goto doc_end;
     }
-    if (*cur == '"') {
-        if (likely(read_string(&cur, end, inv, val, &msg))) goto doc_end;
-        goto fail_string;
-    }
-    if (*cur == 't') {
-        if (likely(read_true(&cur, val))) goto doc_end;
-        goto fail_literal;
-    }
-    if (*cur == 'f') {
-        if (likely(read_false(&cur, val))) goto doc_end;
-        goto fail_literal;
-    }
-    if (*cur == 'n') {
-        if (likely(read_null(&cur, val))) goto doc_end;
-        if (unlikely(ext)) {
-            if (read_nan(false, &cur, pre, val)) goto doc_end;
-        }
-        goto fail_literal;
-    }
-    if (unlikely(ext)) {
-        if (read_inf_or_nan(false, &cur, pre, val)) goto doc_end;
-    }
-    goto fail_character;
-    
+    goto fail_literal;
+  }
+  if (unlikely (ext))
+  {
+    if (read_inf_or_nan (false, &cur, pre, val))
+      goto doc_end;
+  }
+  goto fail_character;
+
 doc_end:
-    /* check invalid contents after json document */
-    if (unlikely(cur < end) && !has_flag(STOP_WHEN_DONE)) {
-        if (has_flag(ALLOW_COMMENTS)) {
-            if (!skip_spaces_and_comments(&cur)) {
-                if (byte_match_2(cur, "/*")) goto fail_comment;
-            }
-        } else {
-            while (char_is_space(*cur)) cur++;
-        }
-        if (unlikely(cur < end)) goto fail_garbage;
+  /* check invalid contents after json document */
+  if (unlikely (cur < end) && !has_flag (STOP_WHEN_DONE))
+  {
+    if (has_flag (ALLOW_COMMENTS))
+    {
+      if (!skip_spaces_and_comments (&cur))
+      {
+        if (byte_match_2 (cur, "/*"))
+          goto fail_comment;
+      }
     }
-    
-    if (pre && *pre) **pre = '\0';
-    doc = (yyjson_doc *)val_hdr;
-    doc->root = val_hdr + hdr_len;
-    doc->alc = alc;
-    doc->dat_read = (usize)(cur - hdr);
-    doc->val_read = 1;
-    doc->str_pool = has_flag(INSITU) ? NULL : (char *)hdr;
-    return doc;
-    
+    else
+    {
+      while (char_is_space (*cur))
+        cur++;
+    }
+    if (unlikely (cur < end))
+      goto fail_garbage;
+  }
+
+  if (pre && *pre)
+    **pre = '\0';
+  doc           = (yyjson_doc *)val_hdr;
+  doc->root     = val_hdr + hdr_len;
+  doc->alc      = alc;
+  doc->dat_read = (usize)(cur - hdr);
+  doc->val_read = 1;
+  doc->str_pool = has_flag (INSITU) ? NULL : (char *)hdr;
+  return doc;
+
 fail_string:
-    return_err(cur, INVALID_STRING, msg);
+  return_err (cur, INVALID_STRING, msg);
 fail_number:
-    return_err(cur, INVALID_NUMBER, msg);
+  return_err (cur, INVALID_NUMBER, msg);
 fail_alloc:
-    return_err(cur, MEMORY_ALLOCATION, "memory allocation failed");
+  return_err (cur, MEMORY_ALLOCATION, "memory allocation failed");
 fail_literal:
-    return_err(cur, LITERAL, "invalid literal");
+  return_err (cur, LITERAL, "invalid literal");
 fail_comment:
-    return_err(cur, INVALID_COMMENT, "unclosed multiline comment");
+  return_err (cur, INVALID_COMMENT, "unclosed multiline comment");
 fail_character:
-    return_err(cur, UNEXPECTED_CHARACTER, "unexpected character");
+  return_err (cur, UNEXPECTED_CHARACTER, "unexpected character");
 fail_garbage:
-    return_err(cur, UNEXPECTED_CONTENT, "unexpected content after document");
-    
+  return_err (cur, UNEXPECTED_CONTENT, "unexpected content after document");
+
 #undef has_flag
 #undef return_err
 }
 
 /** Read JSON document (accept all style, but optimized for minify). */
-static_inline yyjson_doc *read_root_minify(u8 *hdr,
-                                           u8 *cur,
-                                           u8 *end,
-                                           yyjson_alc alc,
-                                           yyjson_read_flag flg,
-                                           yyjson_read_err *err) {
-    
-#define has_flag(_flag) unlikely((flg & YYJSON_READ_##_flag) != 0)
-    
-#define return_err(_pos, _code, _msg) do { \
-    if (is_truncated_end(hdr, _pos, end, YYJSON_READ_ERROR_##_code, flg)) { \
-        err->pos = (usize)(end - hdr); \
-        err->code = YYJSON_READ_ERROR_UNEXPECTED_END; \
-        err->msg = "unexpected end of data"; \
-    } else { \
-        err->pos = (usize)(_pos - hdr); \
-        err->code = YYJSON_READ_ERROR_##_code; \
-        err->msg = _msg; \
-    } \
-    if (val_hdr) alc.free(alc.ctx, (void *)val_hdr); \
-    return NULL; \
-} while (false)
-    
-#define val_incr() do { \
-    val++; \
-    if (unlikely(val >= val_end)) { \
-        usize alc_old = alc_len; \
-        alc_len += alc_len / 2; \
-        if ((alc_len >= alc_max)) goto fail_alloc; \
-        val_tmp = (yyjson_val *)alc.realloc(alc.ctx, (void *)val_hdr, \
-            alc_old * sizeof(yyjson_val), \
-            alc_len * sizeof(yyjson_val)); \
-        if ((!val_tmp)) goto fail_alloc; \
-        val = val_tmp + (usize)(val - val_hdr); \
-        ctn = val_tmp + (usize)(ctn - val_hdr); \
-        val_hdr = val_tmp; \
-        val_end = val_tmp + (alc_len - 2); \
-    } \
-} while (false)
-    
-    usize dat_len; /* data length in bytes, hint for allocator */
-    usize hdr_len; /* value count used by yyjson_doc */
-    usize alc_len; /* value count allocated */
-    usize alc_max; /* maximum value count for allocator */
-    usize ctn_len; /* the number of elements in current container */
-    yyjson_val *val_hdr; /* the head of allocated values */
-    yyjson_val *val_end; /* the end of allocated values */
-    yyjson_val *val_tmp; /* temporary pointer for realloc */
-    yyjson_val *val; /* current JSON value */
-    yyjson_val *ctn; /* current container */
-    yyjson_val *ctn_parent; /* parent of current container */
-    yyjson_doc *doc; /* the JSON document, equals to val_hdr */
-    const char *msg; /* error message */
-    
-    bool raw; /* read number as raw */
-    bool ext; /* allow inf and nan */
-    bool inv; /* allow invalid unicode */
-    u8 *raw_end; /* raw end for null-terminator */
-    u8 **pre; /* previous raw end pointer */
-    
-    dat_len = has_flag(STOP_WHEN_DONE) ? 256 : (usize)(end - cur);
-    hdr_len = sizeof(yyjson_doc) / sizeof(yyjson_val);
-    hdr_len += (sizeof(yyjson_doc) % sizeof(yyjson_val)) > 0;
-    alc_max = USIZE_MAX / sizeof(yyjson_val);
-    alc_len = hdr_len + (dat_len / YYJSON_READER_ESTIMATED_MINIFY_RATIO) + 4;
-    alc_len = yyjson_min(alc_len, alc_max);
-    
-    val_hdr = (yyjson_val *)alc.malloc(alc.ctx, alc_len * sizeof(yyjson_val));
-    if (unlikely(!val_hdr)) goto fail_alloc;
-    val_end = val_hdr + (alc_len - 2); /* padding for key-value pair reading */
-    val = val_hdr + hdr_len;
-    ctn = val;
-    ctn_len = 0;
-    raw = (flg & YYJSON_READ_NUMBER_AS_RAW) != 0;
-    ext = (flg & YYJSON_READ_ALLOW_INF_AND_NAN) != 0;
-    inv = (flg & YYJSON_READ_ALLOW_INVALID_UNICODE) != 0;
-    raw_end = NULL;
-    pre = raw ? &raw_end : NULL;
-    
-    if (*cur++ == '{') {
-        ctn->tag = YYJSON_TYPE_OBJ;
-        ctn->uni.ofs = 0;
-        goto obj_key_begin;
-    } else {
-        ctn->tag = YYJSON_TYPE_ARR;
-        ctn->uni.ofs = 0;
-        goto arr_val_begin;
-    }
-    
+static_inline yyjson_doc *
+read_root_minify (u8 *hdr,
+                  u8 *cur,
+                  u8 *end,
+                  yyjson_alc alc,
+                  yyjson_read_flag flg,
+                  yyjson_read_err *err)
+{
+
+#define has_flag(_flag) unlikely ((flg & YYJSON_READ_##_flag) != 0)
+
+#define return_err(_pos, _code, _msg)                                      \
+  do                                                                       \
+  {                                                                        \
+    if (is_truncated_end (hdr, _pos, end, YYJSON_READ_ERROR_##_code, flg)) \
+    {                                                                      \
+      err->pos  = (usize)(end - hdr);                                      \
+      err->code = YYJSON_READ_ERROR_UNEXPECTED_END;                        \
+      err->msg  = "unexpected end of data";                                \
+    }                                                                      \
+    else                                                                   \
+    {                                                                      \
+      err->pos  = (usize)(_pos - hdr);                                     \
+      err->code = YYJSON_READ_ERROR_##_code;                               \
+      err->msg  = _msg;                                                    \
+    }                                                                      \
+    if (val_hdr)                                                           \
+      alc.free (alc.ctx, (void *)val_hdr);                                 \
+    return NULL;                                                           \
+  } while (false)
+
+#define val_incr()                                                         \
+  do                                                                       \
+  {                                                                        \
+    val++;                                                                 \
+    if (unlikely (val >= val_end))                                         \
+    {                                                                      \
+      usize alc_old = alc_len;                                             \
+      alc_len += alc_len / 2;                                              \
+      if ((alc_len >= alc_max))                                            \
+        goto fail_alloc;                                                   \
+      val_tmp = (yyjson_val *)alc.realloc (alc.ctx, (void *)val_hdr,       \
+                                           alc_old * sizeof (yyjson_val),  \
+                                           alc_len * sizeof (yyjson_val)); \
+      if ((!val_tmp))                                                      \
+        goto fail_alloc;                                                   \
+      val     = val_tmp + (usize)(val - val_hdr);                          \
+      ctn     = val_tmp + (usize)(ctn - val_hdr);                          \
+      val_hdr = val_tmp;                                                   \
+      val_end = val_tmp + (alc_len - 2);                                   \
+    }                                                                      \
+  } while (false)
+
+  usize dat_len;          /* data length in bytes, hint for allocator */
+  usize hdr_len;          /* value count used by yyjson_doc */
+  usize alc_len;          /* value count allocated */
+  usize alc_max;          /* maximum value count for allocator */
+  usize ctn_len;          /* the number of elements in current container */
+  yyjson_val *val_hdr;    /* the head of allocated values */
+  yyjson_val *val_end;    /* the end of allocated values */
+  yyjson_val *val_tmp;    /* temporary pointer for realloc */
+  yyjson_val *val;        /* current JSON value */
+  yyjson_val *ctn;        /* current container */
+  yyjson_val *ctn_parent; /* parent of current container */
+  yyjson_doc *doc;        /* the JSON document, equals to val_hdr */
+  const char *msg;        /* error message */
+
+  bool raw;    /* read number as raw */
+  bool ext;    /* allow inf and nan */
+  bool inv;    /* allow invalid unicode */
+  u8 *raw_end; /* raw end for null-terminator */
+  u8 **pre;    /* previous raw end pointer */
+
+  dat_len = has_flag (STOP_WHEN_DONE) ? 256 : (usize)(end - cur);
+  hdr_len = sizeof (yyjson_doc) / sizeof (yyjson_val);
+  hdr_len += (sizeof (yyjson_doc) % sizeof (yyjson_val)) > 0;
+  alc_max = USIZE_MAX / sizeof (yyjson_val);
+  alc_len = hdr_len + (dat_len / YYJSON_READER_ESTIMATED_MINIFY_RATIO) + 4;
+  alc_len = yyjson_min (alc_len, alc_max);
+
+  val_hdr = (yyjson_val *)alc.malloc (alc.ctx, alc_len * sizeof (yyjson_val));
+  if (unlikely (!val_hdr))
+    goto fail_alloc;
+  val_end = val_hdr + (alc_len - 2); /* padding for key-value pair reading */
+  val     = val_hdr + hdr_len;
+  ctn     = val;
+  ctn_len = 0;
+  raw     = (flg & YYJSON_READ_NUMBER_AS_RAW) != 0;
+  ext     = (flg & YYJSON_READ_ALLOW_INF_AND_NAN) != 0;
+  inv     = (flg & YYJSON_READ_ALLOW_INVALID_UNICODE) != 0;
+  raw_end = NULL;
+  pre     = raw ? &raw_end : NULL;
+
+  if (*cur++ == '{')
+  {
+    ctn->tag     = YYJSON_TYPE_OBJ;
+    ctn->uni.ofs = 0;
+    goto obj_key_begin;
+  }
+  else
+  {
+    ctn->tag     = YYJSON_TYPE_ARR;
+    ctn->uni.ofs = 0;
+    goto arr_val_begin;
+  }
+
 arr_begin:
-    /* save current container */
-    ctn->tag = (((u64)ctn_len + 1) << YYJSON_TAG_BIT) |
-               (ctn->tag & YYJSON_TAG_MASK);
-    
-    /* create a new array value, save parent container offset */
-    val_incr();
-    val->tag = YYJSON_TYPE_ARR;
-    val->uni.ofs = (usize)((u8 *)val - (u8 *)ctn);
-    
-    /* push the new array value as current container */
-    ctn = val;
-    ctn_len = 0;
-    
+  /* save current container */
+  ctn->tag = (((u64)ctn_len + 1) << YYJSON_TAG_BIT) |
+             (ctn->tag & YYJSON_TAG_MASK);
+
+  /* create a new array value, save parent container offset */
+  val_incr ();
+  val->tag     = YYJSON_TYPE_ARR;
+  val->uni.ofs = (usize)((u8 *)val - (u8 *)ctn);
+
+  /* push the new array value as current container */
+  ctn     = val;
+  ctn_len = 0;
+
 arr_val_begin:
-    if (*cur == '{') {
-        cur++;
-        goto obj_begin;
+  if (*cur == '{')
+  {
+    cur++;
+    goto obj_begin;
+  }
+  if (*cur == '[')
+  {
+    cur++;
+    goto arr_begin;
+  }
+  if (char_is_number (*cur))
+  {
+    val_incr ();
+    ctn_len++;
+    if (likely (read_number (&cur, pre, ext, val, &msg)))
+      goto arr_val_end;
+    goto fail_number;
+  }
+  if (*cur == '"')
+  {
+    val_incr ();
+    ctn_len++;
+    if (likely (read_string (&cur, end, inv, val, &msg)))
+      goto arr_val_end;
+    goto fail_string;
+  }
+  if (*cur == 't')
+  {
+    val_incr ();
+    ctn_len++;
+    if (likely (read_true (&cur, val)))
+      goto arr_val_end;
+    goto fail_literal;
+  }
+  if (*cur == 'f')
+  {
+    val_incr ();
+    ctn_len++;
+    if (likely (read_false (&cur, val)))
+      goto arr_val_end;
+    goto fail_literal;
+  }
+  if (*cur == 'n')
+  {
+    val_incr ();
+    ctn_len++;
+    if (likely (read_null (&cur, val)))
+      goto arr_val_end;
+    if (unlikely (ext))
+    {
+      if (read_nan (false, &cur, pre, val))
+        goto arr_val_end;
     }
-    if (*cur == '[') {
-        cur++;
-        goto arr_begin;
-    }
-    if (char_is_number(*cur)) {
-        val_incr();
-        ctn_len++;
-        if (likely(read_number(&cur, pre, ext, val, &msg))) goto arr_val_end;
-        goto fail_number;
-    }
-    if (*cur == '"') {
-        val_incr();
-        ctn_len++;
-        if (likely(read_string(&cur, end, inv, val, &msg))) goto arr_val_end;
-        goto fail_string;
-    }
-    if (*cur == 't') {
-        val_incr();
-        ctn_len++;
-        if (likely(read_true(&cur, val))) goto arr_val_end;
-        goto fail_literal;
-    }
-    if (*cur == 'f') {
-        val_incr();
-        ctn_len++;
-        if (likely(read_false(&cur, val))) goto arr_val_end;
-        goto fail_literal;
-    }
-    if (*cur == 'n') {
-        val_incr();
-        ctn_len++;
-        if (likely(read_null(&cur, val))) goto arr_val_end;
-        if (unlikely(ext)) {
-            if (read_nan(false, &cur, pre, val)) goto arr_val_end;
-        }
-        goto fail_literal;
-    }
-    if (*cur == ']') {
-        cur++;
-        if (likely(ctn_len == 0)) goto arr_end;
-        if (has_flag(ALLOW_TRAILING_COMMAS)) goto arr_end;
-        while (*cur != ',') cur--;
-        goto fail_trailing_comma;
-    }
-    if (char_is_space(*cur)) {
-        while (char_is_space(*++cur));
-        goto arr_val_begin;
-    }
-    if (unlikely(ext) && (*cur == 'i' || *cur == 'I' || *cur == 'N')) {
-        val_incr();
-        ctn_len++;
-        if (read_inf_or_nan(false, &cur, pre, val)) goto arr_val_end;
-        goto fail_character;
-    }
-    if (has_flag(ALLOW_COMMENTS)) {
-        if (skip_spaces_and_comments(&cur)) goto arr_val_begin;
-        if (byte_match_2(cur, "/*")) goto fail_comment;
-    }
+    goto fail_literal;
+  }
+  if (*cur == ']')
+  {
+    cur++;
+    if (likely (ctn_len == 0))
+      goto arr_end;
+    if (has_flag (ALLOW_TRAILING_COMMAS))
+      goto arr_end;
+    while (*cur != ',')
+      cur--;
+    goto fail_trailing_comma;
+  }
+  if (char_is_space (*cur))
+  {
+    while (char_is_space (*++cur))
+      ;
+    goto arr_val_begin;
+  }
+  if (unlikely (ext) && (*cur == 'i' || *cur == 'I' || *cur == 'N'))
+  {
+    val_incr ();
+    ctn_len++;
+    if (read_inf_or_nan (false, &cur, pre, val))
+      goto arr_val_end;
     goto fail_character;
-    
+  }
+  if (has_flag (ALLOW_COMMENTS))
+  {
+    if (skip_spaces_and_comments (&cur))
+      goto arr_val_begin;
+    if (byte_match_2 (cur, "/*"))
+      goto fail_comment;
+  }
+  goto fail_character;
+
 arr_val_end:
-    if (*cur == ',') {
-        cur++;
-        goto arr_val_begin;
-    }
-    if (*cur == ']') {
-        cur++;
-        goto arr_end;
-    }
-    if (char_is_space(*cur)) {
-        while (char_is_space(*++cur));
-        goto arr_val_end;
-    }
-    if (has_flag(ALLOW_COMMENTS)) {
-        if (skip_spaces_and_comments(&cur)) goto arr_val_end;
-        if (byte_match_2(cur, "/*")) goto fail_comment;
-    }
-    goto fail_character;
-    
+  if (*cur == ',')
+  {
+    cur++;
+    goto arr_val_begin;
+  }
+  if (*cur == ']')
+  {
+    cur++;
+    goto arr_end;
+  }
+  if (char_is_space (*cur))
+  {
+    while (char_is_space (*++cur))
+      ;
+    goto arr_val_end;
+  }
+  if (has_flag (ALLOW_COMMENTS))
+  {
+    if (skip_spaces_and_comments (&cur))
+      goto arr_val_end;
+    if (byte_match_2 (cur, "/*"))
+      goto fail_comment;
+  }
+  goto fail_character;
+
 arr_end:
-    /* get parent container */
-    ctn_parent = (yyjson_val *)(void *)((u8 *)ctn - ctn->uni.ofs);
-    
-    /* save the next sibling value offset */
-    ctn->uni.ofs = (usize)((u8 *)val - (u8 *)ctn) + sizeof(yyjson_val);
-    ctn->tag = ((ctn_len) << YYJSON_TAG_BIT) | YYJSON_TYPE_ARR;
-    if (unlikely(ctn == ctn_parent)) goto doc_end;
-    
-    /* pop parent as current container */
-    ctn = ctn_parent;
-    ctn_len = (usize)(ctn->tag >> YYJSON_TAG_BIT);
-    if ((ctn->tag & YYJSON_TYPE_MASK) == YYJSON_TYPE_OBJ) {
-        goto obj_val_end;
-    } else {
-        goto arr_val_end;
-    }
-    
+  /* get parent container */
+  ctn_parent = (yyjson_val *)(void *)((u8 *)ctn - ctn->uni.ofs);
+
+  /* save the next sibling value offset */
+  ctn->uni.ofs = (usize)((u8 *)val - (u8 *)ctn) + sizeof (yyjson_val);
+  ctn->tag     = ((ctn_len) << YYJSON_TAG_BIT) | YYJSON_TYPE_ARR;
+  if (unlikely (ctn == ctn_parent))
+    goto doc_end;
+
+  /* pop parent as current container */
+  ctn     = ctn_parent;
+  ctn_len = (usize)(ctn->tag >> YYJSON_TAG_BIT);
+  if ((ctn->tag & YYJSON_TYPE_MASK) == YYJSON_TYPE_OBJ)
+  {
+    goto obj_val_end;
+  }
+  else
+  {
+    goto arr_val_end;
+  }
+
 obj_begin:
-    /* push container */
-    ctn->tag = (((u64)ctn_len + 1) << YYJSON_TAG_BIT) |
-               (ctn->tag & YYJSON_TAG_MASK);
-    val_incr();
-    val->tag = YYJSON_TYPE_OBJ;
-    /* offset to the parent */
-    val->uni.ofs = (usize)((u8 *)val - (u8 *)ctn);
-    ctn = val;
-    ctn_len = 0;
-    
+  /* push container */
+  ctn->tag = (((u64)ctn_len + 1) << YYJSON_TAG_BIT) |
+             (ctn->tag & YYJSON_TAG_MASK);
+  val_incr ();
+  val->tag = YYJSON_TYPE_OBJ;
+  /* offset to the parent */
+  val->uni.ofs = (usize)((u8 *)val - (u8 *)ctn);
+  ctn          = val;
+  ctn_len      = 0;
+
 obj_key_begin:
-    if (likely(*cur == '"')) {
-        val_incr();
-        ctn_len++;
-        if (likely(read_string(&cur, end, inv, val, &msg))) goto obj_key_end;
-        goto fail_string;
-    }
-    if (likely(*cur == '}')) {
-        cur++;
-        if (likely(ctn_len == 0)) goto obj_end;
-        if (has_flag(ALLOW_TRAILING_COMMAS)) goto obj_end;
-        while (*cur != ',') cur--;
-        goto fail_trailing_comma;
-    }
-    if (char_is_space(*cur)) {
-        while (char_is_space(*++cur));
-        goto obj_key_begin;
-    }
-    if (has_flag(ALLOW_COMMENTS)) {
-        if (skip_spaces_and_comments(&cur)) goto obj_key_begin;
-        if (byte_match_2(cur, "/*")) goto fail_comment;
-    }
-    goto fail_character;
-    
+  if (likely (*cur == '"'))
+  {
+    val_incr ();
+    ctn_len++;
+    if (likely (read_string (&cur, end, inv, val, &msg)))
+      goto obj_key_end;
+    goto fail_string;
+  }
+  if (likely (*cur == '}'))
+  {
+    cur++;
+    if (likely (ctn_len == 0))
+      goto obj_end;
+    if (has_flag (ALLOW_TRAILING_COMMAS))
+      goto obj_end;
+    while (*cur != ',')
+      cur--;
+    goto fail_trailing_comma;
+  }
+  if (char_is_space (*cur))
+  {
+    while (char_is_space (*++cur))
+      ;
+    goto obj_key_begin;
+  }
+  if (has_flag (ALLOW_COMMENTS))
+  {
+    if (skip_spaces_and_comments (&cur))
+      goto obj_key_begin;
+    if (byte_match_2 (cur, "/*"))
+      goto fail_comment;
+  }
+  goto fail_character;
+
 obj_key_end:
-    if (*cur == ':') {
-        cur++;
-        goto obj_val_begin;
-    }
-    if (char_is_space(*cur)) {
-        while (char_is_space(*++cur));
-        goto obj_key_end;
-    }
-    if (has_flag(ALLOW_COMMENTS)) {
-        if (skip_spaces_and_comments(&cur)) goto obj_key_end;
-        if (byte_match_2(cur, "/*")) goto fail_comment;
-    }
-    goto fail_character;
-    
+  if (*cur == ':')
+  {
+    cur++;
+    goto obj_val_begin;
+  }
+  if (char_is_space (*cur))
+  {
+    while (char_is_space (*++cur))
+      ;
+    goto obj_key_end;
+  }
+  if (has_flag (ALLOW_COMMENTS))
+  {
+    if (skip_spaces_and_comments (&cur))
+      goto obj_key_end;
+    if (byte_match_2 (cur, "/*"))
+      goto fail_comment;
+  }
+  goto fail_character;
+
 obj_val_begin:
-    if (*cur == '"') {
-        val++;
-        ctn_len++;
-        if (likely(read_string(&cur, end, inv, val, &msg))) goto obj_val_end;
-        goto fail_string;
+  if (*cur == '"')
+  {
+    val++;
+    ctn_len++;
+    if (likely (read_string (&cur, end, inv, val, &msg)))
+      goto obj_val_end;
+    goto fail_string;
+  }
+  if (char_is_number (*cur))
+  {
+    val++;
+    ctn_len++;
+    if (likely (read_number (&cur, pre, ext, val, &msg)))
+      goto obj_val_end;
+    goto fail_number;
+  }
+  if (*cur == '{')
+  {
+    cur++;
+    goto obj_begin;
+  }
+  if (*cur == '[')
+  {
+    cur++;
+    goto arr_begin;
+  }
+  if (*cur == 't')
+  {
+    val++;
+    ctn_len++;
+    if (likely (read_true (&cur, val)))
+      goto obj_val_end;
+    goto fail_literal;
+  }
+  if (*cur == 'f')
+  {
+    val++;
+    ctn_len++;
+    if (likely (read_false (&cur, val)))
+      goto obj_val_end;
+    goto fail_literal;
+  }
+  if (*cur == 'n')
+  {
+    val++;
+    ctn_len++;
+    if (likely (read_null (&cur, val)))
+      goto obj_val_end;
+    if (unlikely (ext))
+    {
+      if (read_nan (false, &cur, pre, val))
+        goto obj_val_end;
     }
-    if (char_is_number(*cur)) {
-        val++;
-        ctn_len++;
-        if (likely(read_number(&cur, pre, ext, val, &msg))) goto obj_val_end;
-        goto fail_number;
-    }
-    if (*cur == '{') {
-        cur++;
-        goto obj_begin;
-    }
-    if (*cur == '[') {
-        cur++;
-        goto arr_begin;
-    }
-    if (*cur == 't') {
-        val++;
-        ctn_len++;
-        if (likely(read_true(&cur, val))) goto obj_val_end;
-        goto fail_literal;
-    }
-    if (*cur == 'f') {
-        val++;
-        ctn_len++;
-        if (likely(read_false(&cur, val))) goto obj_val_end;
-        goto fail_literal;
-    }
-    if (*cur == 'n') {
-        val++;
-        ctn_len++;
-        if (likely(read_null(&cur, val))) goto obj_val_end;
-        if (unlikely(ext)) {
-            if (read_nan(false, &cur, pre, val)) goto obj_val_end;
-        }
-        goto fail_literal;
-    }
-    if (char_is_space(*cur)) {
-        while (char_is_space(*++cur));
-        goto obj_val_begin;
-    }
-    if (unlikely(ext) && (*cur == 'i' || *cur == 'I' || *cur == 'N')) {
-        val++;
-        ctn_len++;
-        if (read_inf_or_nan(false, &cur, pre, val)) goto obj_val_end;
-        goto fail_character;
-    }
-    if (has_flag(ALLOW_COMMENTS)) {
-        if (skip_spaces_and_comments(&cur)) goto obj_val_begin;
-        if (byte_match_2(cur, "/*")) goto fail_comment;
-    }
+    goto fail_literal;
+  }
+  if (char_is_space (*cur))
+  {
+    while (char_is_space (*++cur))
+      ;
+    goto obj_val_begin;
+  }
+  if (unlikely (ext) && (*cur == 'i' || *cur == 'I' || *cur == 'N'))
+  {
+    val++;
+    ctn_len++;
+    if (read_inf_or_nan (false, &cur, pre, val))
+      goto obj_val_end;
     goto fail_character;
-    
+  }
+  if (has_flag (ALLOW_COMMENTS))
+  {
+    if (skip_spaces_and_comments (&cur))
+      goto obj_val_begin;
+    if (byte_match_2 (cur, "/*"))
+      goto fail_comment;
+  }
+  goto fail_character;
+
 obj_val_end:
-    if (likely(*cur == ',')) {
-        cur++;
-        goto obj_key_begin;
-    }
-    if (likely(*cur == '}')) {
-        cur++;
-        goto obj_end;
-    }
-    if (char_is_space(*cur)) {
-        while (char_is_space(*++cur));
-        goto obj_val_end;
-    }
-    if (has_flag(ALLOW_COMMENTS)) {
-        if (skip_spaces_and_comments(&cur)) goto obj_val_end;
-        if (byte_match_2(cur, "/*")) goto fail_comment;
-    }
-    goto fail_character;
-    
+  if (likely (*cur == ','))
+  {
+    cur++;
+    goto obj_key_begin;
+  }
+  if (likely (*cur == '}'))
+  {
+    cur++;
+    goto obj_end;
+  }
+  if (char_is_space (*cur))
+  {
+    while (char_is_space (*++cur))
+      ;
+    goto obj_val_end;
+  }
+  if (has_flag (ALLOW_COMMENTS))
+  {
+    if (skip_spaces_and_comments (&cur))
+      goto obj_val_end;
+    if (byte_match_2 (cur, "/*"))
+      goto fail_comment;
+  }
+  goto fail_character;
+
 obj_end:
-    /* pop container */
-    ctn_parent = (yyjson_val *)(void *)((u8 *)ctn - ctn->uni.ofs);
-    /* point to the next value */
-    ctn->uni.ofs = (usize)((u8 *)val - (u8 *)ctn) + sizeof(yyjson_val);
-    ctn->tag = (ctn_len << (YYJSON_TAG_BIT - 1)) | YYJSON_TYPE_OBJ;
-    if (unlikely(ctn == ctn_parent)) goto doc_end;
-    ctn = ctn_parent;
-    ctn_len = (usize)(ctn->tag >> YYJSON_TAG_BIT);
-    if ((ctn->tag & YYJSON_TYPE_MASK) == YYJSON_TYPE_OBJ) {
-        goto obj_val_end;
-    } else {
-        goto arr_val_end;
-    }
-    
+  /* pop container */
+  ctn_parent = (yyjson_val *)(void *)((u8 *)ctn - ctn->uni.ofs);
+  /* point to the next value */
+  ctn->uni.ofs = (usize)((u8 *)val - (u8 *)ctn) + sizeof (yyjson_val);
+  ctn->tag     = (ctn_len << (YYJSON_TAG_BIT - 1)) | YYJSON_TYPE_OBJ;
+  if (unlikely (ctn == ctn_parent))
+    goto doc_end;
+  ctn     = ctn_parent;
+  ctn_len = (usize)(ctn->tag >> YYJSON_TAG_BIT);
+  if ((ctn->tag & YYJSON_TYPE_MASK) == YYJSON_TYPE_OBJ)
+  {
+    goto obj_val_end;
+  }
+  else
+  {
+    goto arr_val_end;
+  }
+
 doc_end:
-    /* check invalid contents after json document */
-    if (unlikely(cur < end) && !has_flag(STOP_WHEN_DONE)) {
-        if (has_flag(ALLOW_COMMENTS)) {
-            skip_spaces_and_comments(&cur);
-            if (byte_match_2(cur, "/*")) goto fail_comment;
-        }
-        else while (char_is_space(*cur)) cur++;
-        if (unlikely(cur < end)) goto fail_garbage;
+  /* check invalid contents after json document */
+  if (unlikely (cur < end) && !has_flag (STOP_WHEN_DONE))
+  {
+    if (has_flag (ALLOW_COMMENTS))
+    {
+      skip_spaces_and_comments (&cur);
+      if (byte_match_2 (cur, "/*"))
+        goto fail_comment;
     }
-    
-    if (pre && *pre) **pre = '\0';
-    doc = (yyjson_doc *)val_hdr;
-    doc->root = val_hdr + hdr_len;
-    doc->alc = alc;
-    doc->dat_read = (usize)(cur - hdr);
-    doc->val_read = (usize)((val - doc->root) + 1);
-    doc->str_pool = has_flag(INSITU) ? NULL : (char *)hdr;
-    return doc;
-    
+    else
+      while (char_is_space (*cur))
+        cur++;
+    if (unlikely (cur < end))
+      goto fail_garbage;
+  }
+
+  if (pre && *pre)
+    **pre = '\0';
+  doc           = (yyjson_doc *)val_hdr;
+  doc->root     = val_hdr + hdr_len;
+  doc->alc      = alc;
+  doc->dat_read = (usize)(cur - hdr);
+  doc->val_read = (usize)((val - doc->root) + 1);
+  doc->str_pool = has_flag (INSITU) ? NULL : (char *)hdr;
+  return doc;
+
 fail_string:
-    return_err(cur, INVALID_STRING, msg);
+  return_err (cur, INVALID_STRING, msg);
 fail_number:
-    return_err(cur, INVALID_NUMBER, msg);
+  return_err (cur, INVALID_NUMBER, msg);
 fail_alloc:
-    return_err(cur, MEMORY_ALLOCATION, "memory allocation failed");
+  return_err (cur, MEMORY_ALLOCATION, "memory allocation failed");
 fail_trailing_comma:
-    return_err(cur, JSON_STRUCTURE, "trailing comma is not allowed");
+  return_err (cur, JSON_STRUCTURE, "trailing comma is not allowed");
 fail_literal:
-    return_err(cur, LITERAL, "invalid literal");
+  return_err (cur, LITERAL, "invalid literal");
 fail_comment:
-    return_err(cur, INVALID_COMMENT, "unclosed multiline comment");
+  return_err (cur, INVALID_COMMENT, "unclosed multiline comment");
 fail_character:
-    return_err(cur, UNEXPECTED_CHARACTER, "unexpected character");
+  return_err (cur, UNEXPECTED_CHARACTER, "unexpected character");
 fail_garbage:
-    return_err(cur, UNEXPECTED_CONTENT, "unexpected content after document");
-    
+  return_err (cur, UNEXPECTED_CONTENT, "unexpected content after document");
+
 #undef has_flag
 #undef val_incr
 #undef return_err
 }
 
 /** Read JSON document (accept all style, but optimized for pretty). */
-static_inline yyjson_doc *read_root_pretty(u8 *hdr,
-                                           u8 *cur,
-                                           u8 *end,
-                                           yyjson_alc alc,
-                                           yyjson_read_flag flg,
-                                           yyjson_read_err *err) {
-    
-#define has_flag(_flag) unlikely((flg & YYJSON_READ_##_flag) != 0)
-    
-#define return_err(_pos, _code, _msg) do { \
-    if (is_truncated_end(hdr, _pos, end, YYJSON_READ_ERROR_##_code, flg)) { \
-        err->pos = (usize)(end - hdr); \
-        err->code = YYJSON_READ_ERROR_UNEXPECTED_END; \
-        err->msg = "unexpected end of data"; \
-    } else { \
-        err->pos = (usize)(_pos - hdr); \
-        err->code = YYJSON_READ_ERROR_##_code; \
-        err->msg = _msg; \
-    } \
-    if (val_hdr) alc.free(alc.ctx, (void *)val_hdr); \
-    return NULL; \
-} while (false)
-    
-#define val_incr() do { \
-    val++; \
-    if (unlikely(val >= val_end)) { \
-        usize alc_old = alc_len; \
-        alc_len += alc_len / 2; \
-        if ((alc_len >= alc_max)) goto fail_alloc; \
-        val_tmp = (yyjson_val *)alc.realloc(alc.ctx, (void *)val_hdr, \
-            alc_old * sizeof(yyjson_val), \
-            alc_len * sizeof(yyjson_val)); \
-        if ((!val_tmp)) goto fail_alloc; \
-        val = val_tmp + (usize)(val - val_hdr); \
-        ctn = val_tmp + (usize)(ctn - val_hdr); \
-        val_hdr = val_tmp; \
-        val_end = val_tmp + (alc_len - 2); \
-    } \
-} while (false)
-    
-    usize dat_len; /* data length in bytes, hint for allocator */
-    usize hdr_len; /* value count used by yyjson_doc */
-    usize alc_len; /* value count allocated */
-    usize alc_max; /* maximum value count for allocator */
-    usize ctn_len; /* the number of elements in current container */
-    yyjson_val *val_hdr; /* the head of allocated values */
-    yyjson_val *val_end; /* the end of allocated values */
-    yyjson_val *val_tmp; /* temporary pointer for realloc */
-    yyjson_val *val; /* current JSON value */
-    yyjson_val *ctn; /* current container */
-    yyjson_val *ctn_parent; /* parent of current container */
-    yyjson_doc *doc; /* the JSON document, equals to val_hdr */
-    const char *msg; /* error message */
-    
-    bool raw; /* read number as raw */
-    bool ext; /* allow inf and nan */
-    bool inv; /* allow invalid unicode */
-    u8 *raw_end; /* raw end for null-terminator */
-    u8 **pre; /* previous raw end pointer */
-    
-    dat_len = has_flag(STOP_WHEN_DONE) ? 256 : (usize)(end - cur);
-    hdr_len = sizeof(yyjson_doc) / sizeof(yyjson_val);
-    hdr_len += (sizeof(yyjson_doc) % sizeof(yyjson_val)) > 0;
-    alc_max = USIZE_MAX / sizeof(yyjson_val);
-    alc_len = hdr_len + (dat_len / YYJSON_READER_ESTIMATED_PRETTY_RATIO) + 4;
-    alc_len = yyjson_min(alc_len, alc_max);
-    
-    val_hdr = (yyjson_val *)alc.malloc(alc.ctx, alc_len * sizeof(yyjson_val));
-    if (unlikely(!val_hdr)) goto fail_alloc;
-    val_end = val_hdr + (alc_len - 2); /* padding for key-value pair reading */
-    val = val_hdr + hdr_len;
-    ctn = val;
-    ctn_len = 0;
-    raw = (flg & YYJSON_READ_NUMBER_AS_RAW) != 0;
-    ext = (flg & YYJSON_READ_ALLOW_INF_AND_NAN) != 0;
-    inv = (flg & YYJSON_READ_ALLOW_INVALID_UNICODE) != 0;
-    raw_end = NULL;
-    pre = raw ? &raw_end : NULL;
-    
-    if (*cur++ == '{') {
-        ctn->tag = YYJSON_TYPE_OBJ;
-        ctn->uni.ofs = 0;
-        if (*cur == '\n') cur++;
-        goto obj_key_begin;
-    } else {
-        ctn->tag = YYJSON_TYPE_ARR;
-        ctn->uni.ofs = 0;
-        if (*cur == '\n') cur++;
-        goto arr_val_begin;
-    }
-    
+static_inline yyjson_doc *
+read_root_pretty (u8 *hdr,
+                  u8 *cur,
+                  u8 *end,
+                  yyjson_alc alc,
+                  yyjson_read_flag flg,
+                  yyjson_read_err *err)
+{
+
+#define has_flag(_flag) unlikely ((flg & YYJSON_READ_##_flag) != 0)
+
+#define return_err(_pos, _code, _msg)                                      \
+  do                                                                       \
+  {                                                                        \
+    if (is_truncated_end (hdr, _pos, end, YYJSON_READ_ERROR_##_code, flg)) \
+    {                                                                      \
+      err->pos  = (usize)(end - hdr);                                      \
+      err->code = YYJSON_READ_ERROR_UNEXPECTED_END;                        \
+      err->msg  = "unexpected end of data";                                \
+    }                                                                      \
+    else                                                                   \
+    {                                                                      \
+      err->pos  = (usize)(_pos - hdr);                                     \
+      err->code = YYJSON_READ_ERROR_##_code;                               \
+      err->msg  = _msg;                                                    \
+    }                                                                      \
+    if (val_hdr)                                                           \
+      alc.free (alc.ctx, (void *)val_hdr);                                 \
+    return NULL;                                                           \
+  } while (false)
+
+#define val_incr()                                                         \
+  do                                                                       \
+  {                                                                        \
+    val++;                                                                 \
+    if (unlikely (val >= val_end))                                         \
+    {                                                                      \
+      usize alc_old = alc_len;                                             \
+      alc_len += alc_len / 2;                                              \
+      if ((alc_len >= alc_max))                                            \
+        goto fail_alloc;                                                   \
+      val_tmp = (yyjson_val *)alc.realloc (alc.ctx, (void *)val_hdr,       \
+                                           alc_old * sizeof (yyjson_val),  \
+                                           alc_len * sizeof (yyjson_val)); \
+      if ((!val_tmp))                                                      \
+        goto fail_alloc;                                                   \
+      val     = val_tmp + (usize)(val - val_hdr);                          \
+      ctn     = val_tmp + (usize)(ctn - val_hdr);                          \
+      val_hdr = val_tmp;                                                   \
+      val_end = val_tmp + (alc_len - 2);                                   \
+    }                                                                      \
+  } while (false)
+
+  usize dat_len;          /* data length in bytes, hint for allocator */
+  usize hdr_len;          /* value count used by yyjson_doc */
+  usize alc_len;          /* value count allocated */
+  usize alc_max;          /* maximum value count for allocator */
+  usize ctn_len;          /* the number of elements in current container */
+  yyjson_val *val_hdr;    /* the head of allocated values */
+  yyjson_val *val_end;    /* the end of allocated values */
+  yyjson_val *val_tmp;    /* temporary pointer for realloc */
+  yyjson_val *val;        /* current JSON value */
+  yyjson_val *ctn;        /* current container */
+  yyjson_val *ctn_parent; /* parent of current container */
+  yyjson_doc *doc;        /* the JSON document, equals to val_hdr */
+  const char *msg;        /* error message */
+
+  bool raw;    /* read number as raw */
+  bool ext;    /* allow inf and nan */
+  bool inv;    /* allow invalid unicode */
+  u8 *raw_end; /* raw end for null-terminator */
+  u8 **pre;    /* previous raw end pointer */
+
+  dat_len = has_flag (STOP_WHEN_DONE) ? 256 : (usize)(end - cur);
+  hdr_len = sizeof (yyjson_doc) / sizeof (yyjson_val);
+  hdr_len += (sizeof (yyjson_doc) % sizeof (yyjson_val)) > 0;
+  alc_max = USIZE_MAX / sizeof (yyjson_val);
+  alc_len = hdr_len + (dat_len / YYJSON_READER_ESTIMATED_PRETTY_RATIO) + 4;
+  alc_len = yyjson_min (alc_len, alc_max);
+
+  val_hdr = (yyjson_val *)alc.malloc (alc.ctx, alc_len * sizeof (yyjson_val));
+  if (unlikely (!val_hdr))
+    goto fail_alloc;
+  val_end = val_hdr + (alc_len - 2); /* padding for key-value pair reading */
+  val     = val_hdr + hdr_len;
+  ctn     = val;
+  ctn_len = 0;
+  raw     = (flg & YYJSON_READ_NUMBER_AS_RAW) != 0;
+  ext     = (flg & YYJSON_READ_ALLOW_INF_AND_NAN) != 0;
+  inv     = (flg & YYJSON_READ_ALLOW_INVALID_UNICODE) != 0;
+  raw_end = NULL;
+  pre     = raw ? &raw_end : NULL;
+
+  if (*cur++ == '{')
+  {
+    ctn->tag     = YYJSON_TYPE_OBJ;
+    ctn->uni.ofs = 0;
+    if (*cur == '\n')
+      cur++;
+    goto obj_key_begin;
+  }
+  else
+  {
+    ctn->tag     = YYJSON_TYPE_ARR;
+    ctn->uni.ofs = 0;
+    if (*cur == '\n')
+      cur++;
+    goto arr_val_begin;
+  }
+
 arr_begin:
-    /* save current container */
-    ctn->tag = (((u64)ctn_len + 1) << YYJSON_TAG_BIT) |
-               (ctn->tag & YYJSON_TAG_MASK);
-    
-    /* create a new array value, save parent container offset */
-    val_incr();
-    val->tag = YYJSON_TYPE_ARR;
-    val->uni.ofs = (usize)((u8 *)val - (u8 *)ctn);
-    
-    /* push the new array value as current container */
-    ctn = val;
-    ctn_len = 0;
-    if (*cur == '\n') cur++;
-    
+  /* save current container */
+  ctn->tag = (((u64)ctn_len + 1) << YYJSON_TAG_BIT) |
+             (ctn->tag & YYJSON_TAG_MASK);
+
+  /* create a new array value, save parent container offset */
+  val_incr ();
+  val->tag     = YYJSON_TYPE_ARR;
+  val->uni.ofs = (usize)((u8 *)val - (u8 *)ctn);
+
+  /* push the new array value as current container */
+  ctn     = val;
+  ctn_len = 0;
+  if (*cur == '\n')
+    cur++;
+
 arr_val_begin:
 #if YYJSON_IS_REAL_GCC
-    while (true) repeat16({
-        if (byte_match_2(cur, "  ")) cur += 2;
-        else break;
+  while (true)
+    repeat16 ({
+      if (byte_match_2 (cur, "  "))
+        cur += 2;
+      else
+        break;
     })
 #else
-    while (true) repeat16({
-        if (likely(byte_match_2(cur, "  "))) cur += 2;
-        else break;
+  while (true)
+    repeat16 ({
+      if (likely (byte_match_2 (cur, "  ")))
+        cur += 2;
+      else
+        break;
     })
 #endif
-    
-    if (*cur == '{') {
-        cur++;
-        goto obj_begin;
+
+        if (*cur == '{')
+    {
+      cur++;
+      goto obj_begin;
     }
-    if (*cur == '[') {
-        cur++;
-        goto arr_begin;
+  if (*cur == '[')
+  {
+    cur++;
+    goto arr_begin;
+  }
+  if (char_is_number (*cur))
+  {
+    val_incr ();
+    ctn_len++;
+    if (likely (read_number (&cur, pre, ext, val, &msg)))
+      goto arr_val_end;
+    goto fail_number;
+  }
+  if (*cur == '"')
+  {
+    val_incr ();
+    ctn_len++;
+    if (likely (read_string (&cur, end, inv, val, &msg)))
+      goto arr_val_end;
+    goto fail_string;
+  }
+  if (*cur == 't')
+  {
+    val_incr ();
+    ctn_len++;
+    if (likely (read_true (&cur, val)))
+      goto arr_val_end;
+    goto fail_literal;
+  }
+  if (*cur == 'f')
+  {
+    val_incr ();
+    ctn_len++;
+    if (likely (read_false (&cur, val)))
+      goto arr_val_end;
+    goto fail_literal;
+  }
+  if (*cur == 'n')
+  {
+    val_incr ();
+    ctn_len++;
+    if (likely (read_null (&cur, val)))
+      goto arr_val_end;
+    if (unlikely (ext))
+    {
+      if (read_nan (false, &cur, pre, val))
+        goto arr_val_end;
     }
-    if (char_is_number(*cur)) {
-        val_incr();
-        ctn_len++;
-        if (likely(read_number(&cur, pre, ext, val, &msg))) goto arr_val_end;
-        goto fail_number;
-    }
-    if (*cur == '"') {
-        val_incr();
-        ctn_len++;
-        if (likely(read_string(&cur, end, inv, val, &msg))) goto arr_val_end;
-        goto fail_string;
-    }
-    if (*cur == 't') {
-        val_incr();
-        ctn_len++;
-        if (likely(read_true(&cur, val))) goto arr_val_end;
-        goto fail_literal;
-    }
-    if (*cur == 'f') {
-        val_incr();
-        ctn_len++;
-        if (likely(read_false(&cur, val))) goto arr_val_end;
-        goto fail_literal;
-    }
-    if (*cur == 'n') {
-        val_incr();
-        ctn_len++;
-        if (likely(read_null(&cur, val))) goto arr_val_end;
-        if (unlikely(ext)) {
-            if (read_nan(false, &cur, pre, val)) goto arr_val_end;
-        }
-        goto fail_literal;
-    }
-    if (*cur == ']') {
-        cur++;
-        if (likely(ctn_len == 0)) goto arr_end;
-        if (has_flag(ALLOW_TRAILING_COMMAS)) goto arr_end;
-        while (*cur != ',') cur--;
-        goto fail_trailing_comma;
-    }
-    if (char_is_space(*cur)) {
-        while (char_is_space(*++cur));
-        goto arr_val_begin;
-    }
-    if (unlikely(ext) && (*cur == 'i' || *cur == 'I' || *cur == 'N')) {
-        val_incr();
-        ctn_len++;
-        if (read_inf_or_nan(false, &cur, pre, val)) goto arr_val_end;
-        goto fail_character;
-    }
-    if (has_flag(ALLOW_COMMENTS)) {
-        if (skip_spaces_and_comments(&cur)) goto arr_val_begin;
-        if (byte_match_2(cur, "/*")) goto fail_comment;
-    }
+    goto fail_literal;
+  }
+  if (*cur == ']')
+  {
+    cur++;
+    if (likely (ctn_len == 0))
+      goto arr_end;
+    if (has_flag (ALLOW_TRAILING_COMMAS))
+      goto arr_end;
+    while (*cur != ',')
+      cur--;
+    goto fail_trailing_comma;
+  }
+  if (char_is_space (*cur))
+  {
+    while (char_is_space (*++cur))
+      ;
+    goto arr_val_begin;
+  }
+  if (unlikely (ext) && (*cur == 'i' || *cur == 'I' || *cur == 'N'))
+  {
+    val_incr ();
+    ctn_len++;
+    if (read_inf_or_nan (false, &cur, pre, val))
+      goto arr_val_end;
     goto fail_character;
-    
+  }
+  if (has_flag (ALLOW_COMMENTS))
+  {
+    if (skip_spaces_and_comments (&cur))
+      goto arr_val_begin;
+    if (byte_match_2 (cur, "/*"))
+      goto fail_comment;
+  }
+  goto fail_character;
+
 arr_val_end:
-    if (byte_match_2(cur, ",\n")) {
-        cur += 2;
-        goto arr_val_begin;
-    }
-    if (*cur == ',') {
-        cur++;
-        goto arr_val_begin;
-    }
-    if (*cur == ']') {
-        cur++;
-        goto arr_end;
-    }
-    if (char_is_space(*cur)) {
-        while (char_is_space(*++cur));
-        goto arr_val_end;
-    }
-    if (has_flag(ALLOW_COMMENTS)) {
-        if (skip_spaces_and_comments(&cur)) goto arr_val_end;
-        if (byte_match_2(cur, "/*")) goto fail_comment;
-    }
-    goto fail_character;
-    
+  if (byte_match_2 (cur, ",\n"))
+  {
+    cur += 2;
+    goto arr_val_begin;
+  }
+  if (*cur == ',')
+  {
+    cur++;
+    goto arr_val_begin;
+  }
+  if (*cur == ']')
+  {
+    cur++;
+    goto arr_end;
+  }
+  if (char_is_space (*cur))
+  {
+    while (char_is_space (*++cur))
+      ;
+    goto arr_val_end;
+  }
+  if (has_flag (ALLOW_COMMENTS))
+  {
+    if (skip_spaces_and_comments (&cur))
+      goto arr_val_end;
+    if (byte_match_2 (cur, "/*"))
+      goto fail_comment;
+  }
+  goto fail_character;
+
 arr_end:
-    /* get parent container */
-    ctn_parent = (yyjson_val *)(void *)((u8 *)ctn - ctn->uni.ofs);
-    
-    /* save the next sibling value offset */
-    ctn->uni.ofs = (usize)((u8 *)val - (u8 *)ctn) + sizeof(yyjson_val);
-    ctn->tag = ((ctn_len) << YYJSON_TAG_BIT) | YYJSON_TYPE_ARR;
-    if (unlikely(ctn == ctn_parent)) goto doc_end;
-    
-    /* pop parent as current container */
-    ctn = ctn_parent;
-    ctn_len = (usize)(ctn->tag >> YYJSON_TAG_BIT);
-    if (*cur == '\n') cur++;
-    if ((ctn->tag & YYJSON_TYPE_MASK) == YYJSON_TYPE_OBJ) {
-        goto obj_val_end;
-    } else {
-        goto arr_val_end;
-    }
-    
+  /* get parent container */
+  ctn_parent = (yyjson_val *)(void *)((u8 *)ctn - ctn->uni.ofs);
+
+  /* save the next sibling value offset */
+  ctn->uni.ofs = (usize)((u8 *)val - (u8 *)ctn) + sizeof (yyjson_val);
+  ctn->tag     = ((ctn_len) << YYJSON_TAG_BIT) | YYJSON_TYPE_ARR;
+  if (unlikely (ctn == ctn_parent))
+    goto doc_end;
+
+  /* pop parent as current container */
+  ctn     = ctn_parent;
+  ctn_len = (usize)(ctn->tag >> YYJSON_TAG_BIT);
+  if (*cur == '\n')
+    cur++;
+  if ((ctn->tag & YYJSON_TYPE_MASK) == YYJSON_TYPE_OBJ)
+  {
+    goto obj_val_end;
+  }
+  else
+  {
+    goto arr_val_end;
+  }
+
 obj_begin:
-    /* push container */
-    ctn->tag = (((u64)ctn_len + 1) << YYJSON_TAG_BIT) |
-               (ctn->tag & YYJSON_TAG_MASK);
-    val_incr();
-    val->tag = YYJSON_TYPE_OBJ;
-    /* offset to the parent */
-    val->uni.ofs = (usize)((u8 *)val - (u8 *)ctn);
-    ctn = val;
-    ctn_len = 0;
-    if (*cur == '\n') cur++;
-    
+  /* push container */
+  ctn->tag = (((u64)ctn_len + 1) << YYJSON_TAG_BIT) |
+             (ctn->tag & YYJSON_TAG_MASK);
+  val_incr ();
+  val->tag = YYJSON_TYPE_OBJ;
+  /* offset to the parent */
+  val->uni.ofs = (usize)((u8 *)val - (u8 *)ctn);
+  ctn          = val;
+  ctn_len      = 0;
+  if (*cur == '\n')
+    cur++;
+
 obj_key_begin:
 #if YYJSON_IS_REAL_GCC
-    while (true) repeat16({
-        if (byte_match_2(cur, "  ")) cur += 2;
-        else break;
+  while (true)
+    repeat16 ({
+      if (byte_match_2 (cur, "  "))
+        cur += 2;
+      else
+        break;
     })
 #else
-    while (true) repeat16({
-        if (likely(byte_match_2(cur, "  "))) cur += 2;
-        else break;
+  while (true)
+    repeat16 ({
+      if (likely (byte_match_2 (cur, "  ")))
+        cur += 2;
+      else
+        break;
     })
 #endif
-    if (likely(*cur == '"')) {
-        val_incr();
-        ctn_len++;
-        if (likely(read_string(&cur, end, inv, val, &msg))) goto obj_key_end;
-        goto fail_string;
-    }
-    if (likely(*cur == '}')) {
-        cur++;
-        if (likely(ctn_len == 0)) goto obj_end;
-        if (has_flag(ALLOW_TRAILING_COMMAS)) goto obj_end;
-        while (*cur != ',') cur--;
-        goto fail_trailing_comma;
-    }
-    if (char_is_space(*cur)) {
-        while (char_is_space(*++cur));
-        goto obj_key_begin;
-    }
-    if (has_flag(ALLOW_COMMENTS)) {
-        if (skip_spaces_and_comments(&cur)) goto obj_key_begin;
-        if (byte_match_2(cur, "/*")) goto fail_comment;
-    }
-    goto fail_character;
-    
-obj_key_end:
-    if (byte_match_2(cur, ": ")) {
-        cur += 2;
-        goto obj_val_begin;
-    }
-    if (*cur == ':') {
-        cur++;
-        goto obj_val_begin;
-    }
-    if (char_is_space(*cur)) {
-        while (char_is_space(*++cur));
+        if (likely (*cur == '"'))
+    {
+      val_incr ();
+      ctn_len++;
+      if (likely (read_string (&cur, end, inv, val, &msg)))
         goto obj_key_end;
+      goto fail_string;
     }
-    if (has_flag(ALLOW_COMMENTS)) {
-        if (skip_spaces_and_comments(&cur)) goto obj_key_end;
-        if (byte_match_2(cur, "/*")) goto fail_comment;
-    }
-    goto fail_character;
-    
+  if (likely (*cur == '}'))
+  {
+    cur++;
+    if (likely (ctn_len == 0))
+      goto obj_end;
+    if (has_flag (ALLOW_TRAILING_COMMAS))
+      goto obj_end;
+    while (*cur != ',')
+      cur--;
+    goto fail_trailing_comma;
+  }
+  if (char_is_space (*cur))
+  {
+    while (char_is_space (*++cur))
+      ;
+    goto obj_key_begin;
+  }
+  if (has_flag (ALLOW_COMMENTS))
+  {
+    if (skip_spaces_and_comments (&cur))
+      goto obj_key_begin;
+    if (byte_match_2 (cur, "/*"))
+      goto fail_comment;
+  }
+  goto fail_character;
+
+obj_key_end:
+  if (byte_match_2 (cur, ": "))
+  {
+    cur += 2;
+    goto obj_val_begin;
+  }
+  if (*cur == ':')
+  {
+    cur++;
+    goto obj_val_begin;
+  }
+  if (char_is_space (*cur))
+  {
+    while (char_is_space (*++cur))
+      ;
+    goto obj_key_end;
+  }
+  if (has_flag (ALLOW_COMMENTS))
+  {
+    if (skip_spaces_and_comments (&cur))
+      goto obj_key_end;
+    if (byte_match_2 (cur, "/*"))
+      goto fail_comment;
+  }
+  goto fail_character;
+
 obj_val_begin:
-    if (*cur == '"') {
-        val++;
-        ctn_len++;
-        if (likely(read_string(&cur, end, inv, val, &msg))) goto obj_val_end;
-        goto fail_string;
+  if (*cur == '"')
+  {
+    val++;
+    ctn_len++;
+    if (likely (read_string (&cur, end, inv, val, &msg)))
+      goto obj_val_end;
+    goto fail_string;
+  }
+  if (char_is_number (*cur))
+  {
+    val++;
+    ctn_len++;
+    if (likely (read_number (&cur, pre, ext, val, &msg)))
+      goto obj_val_end;
+    goto fail_number;
+  }
+  if (*cur == '{')
+  {
+    cur++;
+    goto obj_begin;
+  }
+  if (*cur == '[')
+  {
+    cur++;
+    goto arr_begin;
+  }
+  if (*cur == 't')
+  {
+    val++;
+    ctn_len++;
+    if (likely (read_true (&cur, val)))
+      goto obj_val_end;
+    goto fail_literal;
+  }
+  if (*cur == 'f')
+  {
+    val++;
+    ctn_len++;
+    if (likely (read_false (&cur, val)))
+      goto obj_val_end;
+    goto fail_literal;
+  }
+  if (*cur == 'n')
+  {
+    val++;
+    ctn_len++;
+    if (likely (read_null (&cur, val)))
+      goto obj_val_end;
+    if (unlikely (ext))
+    {
+      if (read_nan (false, &cur, pre, val))
+        goto obj_val_end;
     }
-    if (char_is_number(*cur)) {
-        val++;
-        ctn_len++;
-        if (likely(read_number(&cur, pre, ext, val, &msg))) goto obj_val_end;
-        goto fail_number;
-    }
-    if (*cur == '{') {
-        cur++;
-        goto obj_begin;
-    }
-    if (*cur == '[') {
-        cur++;
-        goto arr_begin;
-    }
-    if (*cur == 't') {
-        val++;
-        ctn_len++;
-        if (likely(read_true(&cur, val))) goto obj_val_end;
-        goto fail_literal;
-    }
-    if (*cur == 'f') {
-        val++;
-        ctn_len++;
-        if (likely(read_false(&cur, val))) goto obj_val_end;
-        goto fail_literal;
-    }
-    if (*cur == 'n') {
-        val++;
-        ctn_len++;
-        if (likely(read_null(&cur, val))) goto obj_val_end;
-        if (unlikely(ext)) {
-            if (read_nan(false, &cur, pre, val)) goto obj_val_end;
-        }
-        goto fail_literal;
-    }
-    if (char_is_space(*cur)) {
-        while (char_is_space(*++cur));
-        goto obj_val_begin;
-    }
-    if (unlikely(ext) && (*cur == 'i' || *cur == 'I' || *cur == 'N')) {
-        val++;
-        ctn_len++;
-        if (read_inf_or_nan(false, &cur, pre, val)) goto obj_val_end;
-        goto fail_character;
-    }
-    if (has_flag(ALLOW_COMMENTS)) {
-        if (skip_spaces_and_comments(&cur)) goto obj_val_begin;
-        if (byte_match_2(cur, "/*")) goto fail_comment;
-    }
+    goto fail_literal;
+  }
+  if (char_is_space (*cur))
+  {
+    while (char_is_space (*++cur))
+      ;
+    goto obj_val_begin;
+  }
+  if (unlikely (ext) && (*cur == 'i' || *cur == 'I' || *cur == 'N'))
+  {
+    val++;
+    ctn_len++;
+    if (read_inf_or_nan (false, &cur, pre, val))
+      goto obj_val_end;
     goto fail_character;
-    
+  }
+  if (has_flag (ALLOW_COMMENTS))
+  {
+    if (skip_spaces_and_comments (&cur))
+      goto obj_val_begin;
+    if (byte_match_2 (cur, "/*"))
+      goto fail_comment;
+  }
+  goto fail_character;
+
 obj_val_end:
-    if (byte_match_2(cur, ",\n")) {
-        cur += 2;
-        goto obj_key_begin;
-    }
-    if (likely(*cur == ',')) {
-        cur++;
-        goto obj_key_begin;
-    }
-    if (likely(*cur == '}')) {
-        cur++;
-        goto obj_end;
-    }
-    if (char_is_space(*cur)) {
-        while (char_is_space(*++cur));
-        goto obj_val_end;
-    }
-    if (has_flag(ALLOW_COMMENTS)) {
-        if (skip_spaces_and_comments(&cur)) goto obj_val_end;
-        if (byte_match_2(cur, "/*")) goto fail_comment;
-    }
-    goto fail_character;
-    
+  if (byte_match_2 (cur, ",\n"))
+  {
+    cur += 2;
+    goto obj_key_begin;
+  }
+  if (likely (*cur == ','))
+  {
+    cur++;
+    goto obj_key_begin;
+  }
+  if (likely (*cur == '}'))
+  {
+    cur++;
+    goto obj_end;
+  }
+  if (char_is_space (*cur))
+  {
+    while (char_is_space (*++cur))
+      ;
+    goto obj_val_end;
+  }
+  if (has_flag (ALLOW_COMMENTS))
+  {
+    if (skip_spaces_and_comments (&cur))
+      goto obj_val_end;
+    if (byte_match_2 (cur, "/*"))
+      goto fail_comment;
+  }
+  goto fail_character;
+
 obj_end:
-    /* pop container */
-    ctn_parent = (yyjson_val *)(void *)((u8 *)ctn - ctn->uni.ofs);
-    /* point to the next value */
-    ctn->uni.ofs = (usize)((u8 *)val - (u8 *)ctn) + sizeof(yyjson_val);
-    ctn->tag = (ctn_len << (YYJSON_TAG_BIT - 1)) | YYJSON_TYPE_OBJ;
-    if (unlikely(ctn == ctn_parent)) goto doc_end;
-    ctn = ctn_parent;
-    ctn_len = (usize)(ctn->tag >> YYJSON_TAG_BIT);
-    if (*cur == '\n') cur++;
-    if ((ctn->tag & YYJSON_TYPE_MASK) == YYJSON_TYPE_OBJ) {
-        goto obj_val_end;
-    } else {
-        goto arr_val_end;
-    }
-    
+  /* pop container */
+  ctn_parent = (yyjson_val *)(void *)((u8 *)ctn - ctn->uni.ofs);
+  /* point to the next value */
+  ctn->uni.ofs = (usize)((u8 *)val - (u8 *)ctn) + sizeof (yyjson_val);
+  ctn->tag     = (ctn_len << (YYJSON_TAG_BIT - 1)) | YYJSON_TYPE_OBJ;
+  if (unlikely (ctn == ctn_parent))
+    goto doc_end;
+  ctn     = ctn_parent;
+  ctn_len = (usize)(ctn->tag >> YYJSON_TAG_BIT);
+  if (*cur == '\n')
+    cur++;
+  if ((ctn->tag & YYJSON_TYPE_MASK) == YYJSON_TYPE_OBJ)
+  {
+    goto obj_val_end;
+  }
+  else
+  {
+    goto arr_val_end;
+  }
+
 doc_end:
-    /* check invalid contents after json document */
-    if (unlikely(cur < end) && !has_flag(STOP_WHEN_DONE)) {
-        if (has_flag(ALLOW_COMMENTS)) {
-            skip_spaces_and_comments(&cur);
-            if (byte_match_2(cur, "/*")) goto fail_comment;
-        }
-        else while (char_is_space(*cur)) cur++;
-        if (unlikely(cur < end)) goto fail_garbage;
+  /* check invalid contents after json document */
+  if (unlikely (cur < end) && !has_flag (STOP_WHEN_DONE))
+  {
+    if (has_flag (ALLOW_COMMENTS))
+    {
+      skip_spaces_and_comments (&cur);
+      if (byte_match_2 (cur, "/*"))
+        goto fail_comment;
     }
-    
-    if (pre && *pre) **pre = '\0';
-    doc = (yyjson_doc *)val_hdr;
-    doc->root = val_hdr + hdr_len;
-    doc->alc = alc;
-    doc->dat_read = (usize)(cur - hdr);
-    doc->val_read = (usize)((val - val_hdr)) - hdr_len + 1;
-    doc->str_pool = has_flag(INSITU) ? NULL : (char *)hdr;
-    return doc;
-    
+    else
+      while (char_is_space (*cur))
+        cur++;
+    if (unlikely (cur < end))
+      goto fail_garbage;
+  }
+
+  if (pre && *pre)
+    **pre = '\0';
+  doc           = (yyjson_doc *)val_hdr;
+  doc->root     = val_hdr + hdr_len;
+  doc->alc      = alc;
+  doc->dat_read = (usize)(cur - hdr);
+  doc->val_read = (usize)((val - val_hdr)) - hdr_len + 1;
+  doc->str_pool = has_flag (INSITU) ? NULL : (char *)hdr;
+  return doc;
+
 fail_string:
-    return_err(cur, INVALID_STRING, msg);
+  return_err (cur, INVALID_STRING, msg);
 fail_number:
-    return_err(cur, INVALID_NUMBER, msg);
+  return_err (cur, INVALID_NUMBER, msg);
 fail_alloc:
-    return_err(cur, MEMORY_ALLOCATION, "memory allocation failed");
+  return_err (cur, MEMORY_ALLOCATION, "memory allocation failed");
 fail_trailing_comma:
-    return_err(cur, JSON_STRUCTURE, "trailing comma is not allowed");
+  return_err (cur, JSON_STRUCTURE, "trailing comma is not allowed");
 fail_literal:
-    return_err(cur, LITERAL, "invalid literal");
+  return_err (cur, LITERAL, "invalid literal");
 fail_comment:
-    return_err(cur, INVALID_COMMENT, "unclosed multiline comment");
+  return_err (cur, INVALID_COMMENT, "unclosed multiline comment");
 fail_character:
-    return_err(cur, UNEXPECTED_CHARACTER, "unexpected character");
+  return_err (cur, UNEXPECTED_CHARACTER, "unexpected character");
 fail_garbage:
-    return_err(cur, UNEXPECTED_CONTENT, "unexpected content after document");
-    
+  return_err (cur, UNEXPECTED_CONTENT, "unexpected content after document");
+
 #undef has_flag
 #undef val_incr
 #undef return_err
 }
 
-
-
 /*==============================================================================
  * JSON Reader Entrance
  *============================================================================*/
 
-yyjson_doc *yyjson_read_opts(char *dat,
-                             usize len,
-                             yyjson_read_flag flg,
-                             const yyjson_alc *alc_ptr,
-                             yyjson_read_err *err) {
-    
-#define has_flag(_flag) unlikely((flg & YYJSON_READ_##_flag) != 0)
-    
-#define return_err(_pos, _code, _msg) do { \
-    err->pos = (usize)(_pos); \
-    err->msg = _msg; \
+yyjson_doc *
+yyjson_read_opts (char *dat,
+                  usize len,
+                  yyjson_read_flag flg,
+                  const yyjson_alc *alc_ptr,
+                  yyjson_read_err *err)
+{
+
+#define has_flag(_flag) unlikely ((flg & YYJSON_READ_##_flag) != 0)
+
+#define return_err(_pos, _code, _msg)      \
+  do                                       \
+  {                                        \
+    err->pos  = (usize)(_pos);             \
+    err->msg  = _msg;                      \
     err->code = YYJSON_READ_ERROR_##_code; \
-    if (!has_flag(INSITU) && hdr) alc.free(alc.ctx, (void *)hdr); \
-    return NULL; \
-} while (false)
-    
-    yyjson_read_err dummy_err;
-    yyjson_alc alc;
-    yyjson_doc *doc;
-    u8 *hdr = NULL, *end, *cur;
-    
+    if (!has_flag (INSITU) && hdr)         \
+      alc.free (alc.ctx, (void *)hdr);     \
+    return NULL;                           \
+  } while (false)
+
+  yyjson_read_err dummy_err;
+  yyjson_alc alc;
+  yyjson_doc *doc;
+  u8 *hdr = NULL, *end, *cur;
+
 #if YYJSON_DISABLE_NON_STANDARD
-    flg &= ~YYJSON_READ_ALLOW_TRAILING_COMMAS;
-    flg &= ~YYJSON_READ_ALLOW_COMMENTS;
-    flg &= ~YYJSON_READ_ALLOW_INF_AND_NAN;
-    flg &= ~YYJSON_READ_ALLOW_INVALID_UNICODE;
+  flg &= ~YYJSON_READ_ALLOW_TRAILING_COMMAS;
+  flg &= ~YYJSON_READ_ALLOW_COMMENTS;
+  flg &= ~YYJSON_READ_ALLOW_INF_AND_NAN;
+  flg &= ~YYJSON_READ_ALLOW_INVALID_UNICODE;
 #endif
-    
-    /* validate input parameters */
-    if (!err) err = &dummy_err;
-    if (likely(!alc_ptr)) {
-        alc = YYJSON_DEFAULT_ALC;
-    } else {
-        alc = *alc_ptr;
+
+  /* validate input parameters */
+  if (!err)
+    err = &dummy_err;
+  if (likely (!alc_ptr))
+  {
+    alc = YYJSON_DEFAULT_ALC;
+  }
+  else
+  {
+    alc = *alc_ptr;
+  }
+  if (unlikely (!dat))
+  {
+    return_err (0, INVALID_PARAMETER, "input data is NULL");
+  }
+  if (unlikely (!len))
+  {
+    return_err (0, INVALID_PARAMETER, "input length is 0");
+  }
+
+  /* add 4-byte zero padding for input data if necessary */
+  if (has_flag (INSITU))
+  {
+    hdr = (u8 *)dat;
+    end = (u8 *)dat + len;
+    cur = (u8 *)dat;
+  }
+  else
+  {
+    if (unlikely (len >= USIZE_MAX - YYJSON_PADDING_SIZE))
+    {
+      return_err (0, MEMORY_ALLOCATION, "memory allocation failed");
     }
-    if (unlikely(!dat)) {
-        return_err(0, INVALID_PARAMETER, "input data is NULL");
+    hdr = (u8 *)alc.malloc (alc.ctx, len + YYJSON_PADDING_SIZE);
+    if (unlikely (!hdr))
+    {
+      return_err (0, MEMORY_ALLOCATION, "memory allocation failed");
     }
-    if (unlikely(!len)) {
-        return_err(0, INVALID_PARAMETER, "input length is 0");
+    end = hdr + len;
+    cur = hdr;
+    memcpy (hdr, dat, len);
+    memset (end, 0, YYJSON_PADDING_SIZE);
+  }
+
+  /* skip empty contents before json document */
+  if (unlikely (char_is_space_or_comment (*cur)))
+  {
+    if (has_flag (ALLOW_COMMENTS))
+    {
+      if (!skip_spaces_and_comments (&cur))
+      {
+        return_err (cur - hdr, INVALID_COMMENT,
+                    "unclosed multiline comment");
+      }
     }
-    
-    /* add 4-byte zero padding for input data if necessary */
-    if (has_flag(INSITU)) {
-        hdr = (u8 *)dat;
-        end = (u8 *)dat + len;
-        cur = (u8 *)dat;
-    } else {
-        if (unlikely(len >= USIZE_MAX - YYJSON_PADDING_SIZE)) {
-            return_err(0, MEMORY_ALLOCATION, "memory allocation failed");
-        }
-        hdr = (u8 *)alc.malloc(alc.ctx, len + YYJSON_PADDING_SIZE);
-        if (unlikely(!hdr)) {
-            return_err(0, MEMORY_ALLOCATION, "memory allocation failed");
-        }
-        end = hdr + len;
-        cur = hdr;
-        memcpy(hdr, dat, len);
-        memset(end, 0, YYJSON_PADDING_SIZE);
+    else
+    {
+      if (likely (char_is_space (*cur)))
+      {
+        while (char_is_space (*++cur))
+          ;
+      }
     }
-    
-    /* skip empty contents before json document */
-    if (unlikely(char_is_space_or_comment(*cur))) {
-        if (has_flag(ALLOW_COMMENTS)) {
-            if (!skip_spaces_and_comments(&cur)) {
-                return_err(cur - hdr, INVALID_COMMENT,
-                           "unclosed multiline comment");
-            }
-        } else {
-            if (likely(char_is_space(*cur))) {
-                while (char_is_space(*++cur));
-            }
-        }
-        if (unlikely(cur >= end)) {
-            return_err(0, EMPTY_CONTENT, "input data is empty");
-        }
+    if (unlikely (cur >= end))
+    {
+      return_err (0, EMPTY_CONTENT, "input data is empty");
     }
-    
-    /* read json document */
-    if (likely(char_is_container(*cur))) {
-        if (char_is_space(cur[1]) && char_is_space(cur[2])) {
-            doc = read_root_pretty(hdr, cur, end, alc, flg, err);
-        } else {
-            doc = read_root_minify(hdr, cur, end, alc, flg, err);
-        }
-    } else {
-        doc = read_root_single(hdr, cur, end, alc, flg, err);
+  }
+
+  /* read json document */
+  if (likely (char_is_container (*cur)))
+  {
+    if (char_is_space (cur[1]) && char_is_space (cur[2]))
+    {
+      doc = read_root_pretty (hdr, cur, end, alc, flg, err);
     }
-    
-    /* check result */
-    if (likely(doc)) {
-        memset(err, 0, sizeof(yyjson_read_err));
-    } else {
-        /* RFC 8259: JSON text MUST be encoded using UTF-8 */
-        if (err->pos == 0 && err->code != YYJSON_READ_ERROR_MEMORY_ALLOCATION) {
-            if ((hdr[0] == 0xEF && hdr[1] == 0xBB && hdr[2] == 0xBF)) {
-                err->msg = "byte order mark (BOM) is not supported";
-            } else if (len >= 4 &&
-                       ((hdr[0] == 0x00 && hdr[1] == 0x00 &&
-                         hdr[2] == 0xFE && hdr[3] == 0xFF) ||
-                        (hdr[0] == 0xFF && hdr[1] == 0xFE &&
-                         hdr[2] == 0x00 && hdr[3] == 0x00))) {
-                err->msg = "UTF-32 encoding is not supported";
-            } else if (len >= 2 &&
-                       ((hdr[0] == 0xFE && hdr[1] == 0xFF) ||
-                        (hdr[0] == 0xFF && hdr[1] == 0xFE))) {
-                err->msg = "UTF-16 encoding is not supported";
-            }
-        }
-        if (!has_flag(INSITU)) alc.free(alc.ctx, (void *)hdr);
+    else
+    {
+      doc = read_root_minify (hdr, cur, end, alc, flg, err);
     }
-    return doc;
-    
+  }
+  else
+  {
+    doc = read_root_single (hdr, cur, end, alc, flg, err);
+  }
+
+  /* check result */
+  if (likely (doc))
+  {
+    memset (err, 0, sizeof (yyjson_read_err));
+  }
+  else
+  {
+    /* RFC 8259: JSON text MUST be encoded using UTF-8 */
+    if (err->pos == 0 && err->code != YYJSON_READ_ERROR_MEMORY_ALLOCATION)
+    {
+      if ((hdr[0] == 0xEF && hdr[1] == 0xBB && hdr[2] == 0xBF))
+      {
+        err->msg = "byte order mark (BOM) is not supported";
+      }
+      else if (len >= 4 &&
+               ((hdr[0] == 0x00 && hdr[1] == 0x00 &&
+                 hdr[2] == 0xFE && hdr[3] == 0xFF) ||
+                (hdr[0] == 0xFF && hdr[1] == 0xFE &&
+                 hdr[2] == 0x00 && hdr[3] == 0x00)))
+      {
+        err->msg = "UTF-32 encoding is not supported";
+      }
+      else if (len >= 2 &&
+               ((hdr[0] == 0xFE && hdr[1] == 0xFF) ||
+                (hdr[0] == 0xFF && hdr[1] == 0xFE)))
+      {
+        err->msg = "UTF-16 encoding is not supported";
+      }
+    }
+    if (!has_flag (INSITU))
+      alc.free (alc.ctx, (void *)hdr);
+  }
+  return doc;
+
 #undef has_flag
 #undef return_err
 }
 
-yyjson_doc *yyjson_read_file(const char *path,
-                             yyjson_read_flag flg,
-                             const yyjson_alc *alc_ptr,
-                             yyjson_read_err *err) {
-    
-#define return_err(_code, _msg) do { \
-    err->pos = 0; \
-    err->msg = _msg; \
+yyjson_doc *
+yyjson_read_file (const char *path,
+                  yyjson_read_flag flg,
+                  const yyjson_alc *alc_ptr,
+                  yyjson_read_err *err)
+{
+
+#define return_err(_code, _msg)            \
+  do                                       \
+  {                                        \
+    err->pos  = 0;                         \
+    err->msg  = _msg;                      \
     err->code = YYJSON_READ_ERROR_##_code; \
-    if (file) fclose(file); \
-    if (buf) alc.free(alc.ctx, buf); \
-    return NULL; \
-} while (false)
-    
-    yyjson_read_err dummy_err;
-    yyjson_alc alc = alc_ptr ? *alc_ptr : YYJSON_DEFAULT_ALC;
-    yyjson_doc *doc;
-    
-    FILE *file = NULL;
-    long file_size = 0;
-    void *buf = NULL;
-    usize buf_size = 0;
-    
-    /* validate input parameters */
-    if (!err) err = &dummy_err;
-    if (unlikely(!path)) return_err(INVALID_PARAMETER, "input path is NULL");
-    
-    /* open file */
-    file = fopen_readonly(path);
-    if (file == NULL) return_err(FILE_OPEN, "file opening failed");
-    
-    /* get file size */
-    if (fseek(file, 0, SEEK_END) == 0) file_size = ftell(file);
-    rewind(file);
-    
-    /* read file */
-    if (file_size > 0) {
-        /* read the entire file in one call */
-        buf_size = (usize)file_size + YYJSON_PADDING_SIZE;
-        buf = alc.malloc(alc.ctx, buf_size);
-        if (buf == NULL) {
-            return_err(MEMORY_ALLOCATION, "fail to alloc memory");
-        }
-        if (fread_safe(buf, (usize)file_size, file) != (usize)file_size) {
-            return_err(FILE_READ, "file reading failed");
-        }
-    } else {
-        /* failed to get file size, read it as a stream */
-        usize chunk_min = (usize)64;
-        usize chunk_max = (usize)512 * 1024 * 1024;
-        usize chunk_now = chunk_min;
-        usize read_size;
-        void *tmp;
-        
-        buf_size = YYJSON_PADDING_SIZE;
-        while (true) {
-            if (buf_size + chunk_now < buf_size) { /* overflow */
-                return_err(MEMORY_ALLOCATION, "fail to alloc memory");
-            }
-            buf_size += chunk_now;
-            if (!buf) {
-                buf = alc.malloc(alc.ctx, buf_size);
-                if (!buf) return_err(MEMORY_ALLOCATION, "fail to alloc memory");
-            } else {
-                tmp = alc.realloc(alc.ctx, buf, buf_size - chunk_now, buf_size);
-                if (!tmp) return_err(MEMORY_ALLOCATION, "fail to alloc memory");
-                buf = tmp;
-            }
-            tmp = ((u8 *)buf) + buf_size - YYJSON_PADDING_SIZE - chunk_now;
-            read_size = fread_safe(tmp, chunk_now, file);
-            file_size += (long)read_size;
-            if (read_size != chunk_now) break;
-            
-            chunk_now *= 2;
-            if (chunk_now > chunk_max) chunk_now = chunk_max;
-        }
+    if (file)                              \
+      fclose (file);                       \
+    if (buf)                               \
+      alc.free (alc.ctx, buf);             \
+    return NULL;                           \
+  } while (false)
+
+  yyjson_read_err dummy_err;
+  yyjson_alc alc = alc_ptr ? *alc_ptr : YYJSON_DEFAULT_ALC;
+  yyjson_doc *doc;
+
+  FILE *file     = NULL;
+  long file_size = 0;
+  void *buf      = NULL;
+  usize buf_size = 0;
+
+  /* validate input parameters */
+  if (!err)
+    err = &dummy_err;
+  if (unlikely (!path))
+    return_err (INVALID_PARAMETER, "input path is NULL");
+
+  /* open file */
+  file = fopen_readonly (path);
+  if (file == NULL)
+    return_err (FILE_OPEN, "file opening failed");
+
+  /* get file size */
+  if (fseek (file, 0, SEEK_END) == 0)
+    file_size = ftell (file);
+  rewind (file);
+
+  /* read file */
+  if (file_size > 0)
+  {
+    /* read the entire file in one call */
+    buf_size = (usize)file_size + YYJSON_PADDING_SIZE;
+    buf      = alc.malloc (alc.ctx, buf_size);
+    if (buf == NULL)
+    {
+      return_err (MEMORY_ALLOCATION, "fail to alloc memory");
     }
-    fclose(file);
-    
-    /* read JSON */
-    memset((u8 *)buf + file_size, 0, YYJSON_PADDING_SIZE);
-    flg |= YYJSON_READ_INSITU;
-    doc = yyjson_read_opts((char *)buf, (usize)file_size, flg, &alc, err);
-    if (doc) {
-        doc->str_pool = (char *)buf;
-        return doc;
-    } else {
-        alc.free(alc.ctx, buf);
-        return NULL;
+    if (fread_safe (buf, (usize)file_size, file) != (usize)file_size)
+    {
+      return_err (FILE_READ, "file reading failed");
     }
-    
+  }
+  else
+  {
+    /* failed to get file size, read it as a stream */
+    usize chunk_min = (usize)64;
+    usize chunk_max = (usize)512 * 1024 * 1024;
+    usize chunk_now = chunk_min;
+    usize read_size;
+    void *tmp;
+
+    buf_size = YYJSON_PADDING_SIZE;
+    while (true)
+    {
+      if (buf_size + chunk_now < buf_size)
+      { /* overflow */
+        return_err (MEMORY_ALLOCATION, "fail to alloc memory");
+      }
+      buf_size += chunk_now;
+      if (!buf)
+      {
+        buf = alc.malloc (alc.ctx, buf_size);
+        if (!buf)
+          return_err (MEMORY_ALLOCATION, "fail to alloc memory");
+      }
+      else
+      {
+        tmp = alc.realloc (alc.ctx, buf, buf_size - chunk_now, buf_size);
+        if (!tmp)
+          return_err (MEMORY_ALLOCATION, "fail to alloc memory");
+        buf = tmp;
+      }
+      tmp       = ((u8 *)buf) + buf_size - YYJSON_PADDING_SIZE - chunk_now;
+      read_size = fread_safe (tmp, chunk_now, file);
+      file_size += (long)read_size;
+      if (read_size != chunk_now)
+        break;
+
+      chunk_now *= 2;
+      if (chunk_now > chunk_max)
+        chunk_now = chunk_max;
+    }
+  }
+  fclose (file);
+
+  /* read JSON */
+  memset ((u8 *)buf + file_size, 0, YYJSON_PADDING_SIZE);
+  flg |= YYJSON_READ_INSITU;
+  doc = yyjson_read_opts ((char *)buf, (usize)file_size, flg, &alc, err);
+  if (doc)
+  {
+    doc->str_pool = (char *)buf;
+    return doc;
+  }
+  else
+  {
+    alc.free (alc.ctx, buf);
+    return NULL;
+  }
+
 #undef return_err
 }
 
-const char *yyjson_read_number(const char *dat,
-                               yyjson_val *val,
-                               yyjson_read_flag flg,
-                               const yyjson_alc *alc,
-                               yyjson_read_err *err) {
-#define return_err(_pos, _code, _msg) do { \
-    err->pos = _pos > hdr ? (usize)(_pos - hdr) : 0; \
-    err->msg = _msg; \
-    err->code = YYJSON_READ_ERROR_##_code; \
-    return NULL; \
-} while (false)
-    
-    u8 *hdr = constcast(u8 *)dat, *cur = hdr;
-    bool raw; /* read number as raw */
-    bool ext; /* allow inf and nan */
-    u8 *raw_end; /* raw end for null-terminator */
-    u8 **pre; /* previous raw end pointer */
-    const char *msg;
-    yyjson_read_err dummy_err;
-    
+const char *
+yyjson_read_number (const char *dat,
+                    yyjson_val *val,
+                    yyjson_read_flag flg,
+                    const yyjson_alc *alc,
+                    yyjson_read_err *err)
+{
+#define return_err(_pos, _code, _msg)                 \
+  do                                                  \
+  {                                                   \
+    err->pos  = _pos > hdr ? (usize)(_pos - hdr) : 0; \
+    err->msg  = _msg;                                 \
+    err->code = YYJSON_READ_ERROR_##_code;            \
+    return NULL;                                      \
+  } while (false)
+
+  u8 *hdr = constcast (u8 *) dat, *cur = hdr;
+  bool raw;    /* read number as raw */
+  bool ext;    /* allow inf and nan */
+  u8 *raw_end; /* raw end for null-terminator */
+  u8 **pre;    /* previous raw end pointer */
+  const char *msg;
+  yyjson_read_err dummy_err;
+
 #if !YYJSON_HAS_IEEE_754 || YYJSON_DISABLE_FAST_FP_CONV
-    u8 buf[128];
-    usize dat_len;
+  u8 buf[128];
+  usize dat_len;
 #endif
-    
-    if (!err) err = &dummy_err;
-    if (unlikely(!dat)) {
-        return_err(cur, INVALID_PARAMETER, "input data is NULL");
-    }
-    if (unlikely(!val)) {
-        return_err(cur, INVALID_PARAMETER, "output value is NULL");
-    }
-    
+
+  if (!err)
+    err = &dummy_err;
+  if (unlikely (!dat))
+  {
+    return_err (cur, INVALID_PARAMETER, "input data is NULL");
+  }
+  if (unlikely (!val))
+  {
+    return_err (cur, INVALID_PARAMETER, "output value is NULL");
+  }
+
 #if !YYJSON_HAS_IEEE_754 || YYJSON_DISABLE_FAST_FP_CONV
-    if (!alc) alc = &YYJSON_DEFAULT_ALC;
-    dat_len = strlen(dat);
-    if (dat_len < sizeof(buf)) {
-        memcpy(buf, dat, dat_len + 1);
-        hdr = buf;
-        cur = hdr;
-    } else {
-        hdr = (u8 *)alc->malloc(alc->ctx, dat_len + 1);
-        cur = hdr;
-        if (unlikely(!hdr)) {
-            return_err(cur, MEMORY_ALLOCATION, "memory allocation failed");
-        }
-        memcpy(hdr, dat, dat_len + 1);
+  if (!alc)
+    alc = &YYJSON_DEFAULT_ALC;
+  dat_len = strlen (dat);
+  if (dat_len < sizeof (buf))
+  {
+    memcpy (buf, dat, dat_len + 1);
+    hdr = buf;
+    cur = hdr;
+  }
+  else
+  {
+    hdr = (u8 *)alc->malloc (alc->ctx, dat_len + 1);
+    cur = hdr;
+    if (unlikely (!hdr))
+    {
+      return_err (cur, MEMORY_ALLOCATION, "memory allocation failed");
     }
+    memcpy (hdr, dat, dat_len + 1);
+  }
 #endif
-    
+
 #if YYJSON_DISABLE_NON_STANDARD
-    ext = false;
+  ext = false;
 #else
-    ext = (flg & YYJSON_READ_ALLOW_INF_AND_NAN) != 0;
+  ext = (flg & YYJSON_READ_ALLOW_INF_AND_NAN) != 0;
 #endif
-    
-    raw = (flg & YYJSON_READ_NUMBER_AS_RAW) != 0;
-    raw_end = NULL;
-    pre = raw ? &raw_end : NULL;
-    
+
+  raw     = (flg & YYJSON_READ_NUMBER_AS_RAW) != 0;
+  raw_end = NULL;
+  pre     = raw ? &raw_end : NULL;
+
 #if !YYJSON_HAS_IEEE_754 || YYJSON_DISABLE_FAST_FP_CONV
-    if (!read_number(&cur, pre, ext, val, &msg)) {
-        if (dat_len >= sizeof(buf)) alc->free(alc->ctx, hdr);
-        return_err(cur, INVALID_NUMBER, msg);
-    }
-    if (dat_len >= sizeof(buf)) alc->free(alc->ctx, hdr);
-    if (raw) val->uni.str = dat;
-    return dat + (cur - hdr);
+  if (!read_number (&cur, pre, ext, val, &msg))
+  {
+    if (dat_len >= sizeof (buf))
+      alc->free (alc->ctx, hdr);
+    return_err (cur, INVALID_NUMBER, msg);
+  }
+  if (dat_len >= sizeof (buf))
+    alc->free (alc->ctx, hdr);
+  if (raw)
+    val->uni.str = dat;
+  return dat + (cur - hdr);
 #else
-    if (!read_number(&cur, pre, ext, val, &msg)) {
-        return_err(cur, INVALID_NUMBER, msg);
-    }
-    return (const char *)cur;
+  if (!read_number (&cur, pre, ext, val, &msg))
+  {
+    return_err (cur, INVALID_NUMBER, msg);
+  }
+  return (const char *)cur;
 #endif
-    
+
 #undef return_err
 }
 
 #endif /* YYJSON_DISABLE_READER */
-
-
 
 #if !YYJSON_DISABLE_WRITER
 
@@ -6045,8 +7122,7 @@ const char *yyjson_read_number(const char *dat,
  *============================================================================*/
 
 /** Digit table from 00 to 99. */
-yyjson_align(2)
-static const char digit_table[200] = {
+yyjson_align (2) static const char digit_table[200] = {
     '0', '0', '0', '1', '0', '2', '0', '3', '0', '4',
     '0', '5', '0', '6', '0', '7', '0', '8', '0', '9',
     '1', '0', '1', '1', '1', '2', '1', '3', '1', '4',
@@ -6066,146 +7142,162 @@ static const char digit_table[200] = {
     '8', '0', '8', '1', '8', '2', '8', '3', '8', '4',
     '8', '5', '8', '6', '8', '7', '8', '8', '8', '9',
     '9', '0', '9', '1', '9', '2', '9', '3', '9', '4',
-    '9', '5', '9', '6', '9', '7', '9', '8', '9', '9'
-};
+    '9', '5', '9', '6', '9', '7', '9', '8', '9', '9'};
 
-static_inline u8 *write_u32_len_8(u32 val, u8 *buf) {
-    u32 aa, bb, cc, dd, aabb, ccdd;                 /* 8 digits: aabbccdd */
-    aabb = (u32)(((u64)val * 109951163) >> 40);     /* (val / 10000) */
-    ccdd = val - aabb * 10000;                      /* (val % 10000) */
-    aa = (aabb * 5243) >> 19;                       /* (aabb / 100) */
-    cc = (ccdd * 5243) >> 19;                       /* (ccdd / 100) */
-    bb = aabb - aa * 100;                           /* (aabb % 100) */
-    dd = ccdd - cc * 100;                           /* (ccdd % 100) */
-    ((v16 *)buf)[0] = ((const v16 *)digit_table)[aa];
+static_inline u8 *
+write_u32_len_8 (u32 val, u8 *buf)
+{
+  u32 aa, bb, cc, dd, aabb, ccdd;                        /* 8 digits: aabbccdd */
+  aabb            = (u32)(((u64)val * 109951163) >> 40); /* (val / 10000) */
+  ccdd            = val - aabb * 10000;                  /* (val % 10000) */
+  aa              = (aabb * 5243) >> 19;                 /* (aabb / 100) */
+  cc              = (ccdd * 5243) >> 19;                 /* (ccdd / 100) */
+  bb              = aabb - aa * 100;                     /* (aabb % 100) */
+  dd              = ccdd - cc * 100;                     /* (ccdd % 100) */
+  ((v16 *)buf)[0] = ((const v16 *)digit_table)[aa];
+  ((v16 *)buf)[1] = ((const v16 *)digit_table)[bb];
+  ((v16 *)buf)[2] = ((const v16 *)digit_table)[cc];
+  ((v16 *)buf)[3] = ((const v16 *)digit_table)[dd];
+  return buf + 8;
+}
+
+static_inline u8 *
+write_u32_len_4 (u32 val, u8 *buf)
+{
+  u32 aa, bb;                           /* 4 digits: aabb */
+  aa              = (val * 5243) >> 19; /* (val / 100) */
+  bb              = val - aa * 100;     /* (val % 100) */
+  ((v16 *)buf)[0] = ((const v16 *)digit_table)[aa];
+  ((v16 *)buf)[1] = ((const v16 *)digit_table)[bb];
+  return buf + 4;
+}
+
+static_inline u8 *
+write_u32_len_1_8 (u32 val, u8 *buf)
+{
+  u32 aa, bb, cc, dd, aabb, bbcc, ccdd, lz;
+
+  if (val < 100)
+  {                             /* 1-2 digits: aa */
+    lz              = val < 10; /* leading zero: 0 or 1 */
+    ((v16 *)buf)[0] = *(const v16 *)(digit_table + (val * 2 + lz));
+    buf -= lz;
+    return buf + 2;
+  }
+  else if (val < 10000)
+  {                                       /* 3-4 digits: aabb */
+    aa              = (val * 5243) >> 19; /* (val / 100) */
+    bb              = val - aa * 100;     /* (val % 100) */
+    lz              = aa < 10;            /* leading zero: 0 or 1 */
+    ((v16 *)buf)[0] = *(const v16 *)(digit_table + (aa * 2 + lz));
+    buf -= lz;
+    ((v16 *)buf)[1] = ((const v16 *)digit_table)[bb];
+    return buf + 4;
+  }
+  else if (val < 1000000)
+  {                                                     /* 5-6 digits: aabbcc */
+    aa              = (u32)(((u64)val * 429497) >> 32); /* (val / 10000) */
+    bbcc            = val - aa * 10000;                 /* (val % 10000) */
+    bb              = (bbcc * 5243) >> 19;              /* (bbcc / 100) */
+    cc              = bbcc - bb * 100;                  /* (bbcc % 100) */
+    lz              = aa < 10;                          /* leading zero: 0 or 1 */
+    ((v16 *)buf)[0] = *(const v16 *)(digit_table + (aa * 2 + lz));
+    buf -= lz;
+    ((v16 *)buf)[1] = ((const v16 *)digit_table)[bb];
+    ((v16 *)buf)[2] = ((const v16 *)digit_table)[cc];
+    return buf + 6;
+  }
+  else
+  {                                                        /* 7-8 digits: aabbccdd */
+    aabb            = (u32)(((u64)val * 109951163) >> 40); /* (val / 10000) */
+    ccdd            = val - aabb * 10000;                  /* (val % 10000) */
+    aa              = (aabb * 5243) >> 19;                 /* (aabb / 100) */
+    cc              = (ccdd * 5243) >> 19;                 /* (ccdd / 100) */
+    bb              = aabb - aa * 100;                     /* (aabb % 100) */
+    dd              = ccdd - cc * 100;                     /* (ccdd % 100) */
+    lz              = aa < 10;                             /* leading zero: 0 or 1 */
+    ((v16 *)buf)[0] = *(const v16 *)(digit_table + (aa * 2 + lz));
+    buf -= lz;
     ((v16 *)buf)[1] = ((const v16 *)digit_table)[bb];
     ((v16 *)buf)[2] = ((const v16 *)digit_table)[cc];
     ((v16 *)buf)[3] = ((const v16 *)digit_table)[dd];
     return buf + 8;
+  }
 }
 
-static_inline u8 *write_u32_len_4(u32 val, u8 *buf) {
-    u32 aa, bb;                                     /* 4 digits: aabb */
-    aa = (val * 5243) >> 19;                        /* (val / 100) */
-    bb = val - aa * 100;                            /* (val % 100) */
-    ((v16 *)buf)[0] = ((const v16 *)digit_table)[aa];
+static_inline u8 *
+write_u64_len_5_8 (u32 val, u8 *buf)
+{
+  u32 aa, bb, cc, dd, aabb, bbcc, ccdd, lz;
+
+  if (val < 1000000)
+  {                                                     /* 5-6 digits: aabbcc */
+    aa              = (u32)(((u64)val * 429497) >> 32); /* (val / 10000) */
+    bbcc            = val - aa * 10000;                 /* (val % 10000) */
+    bb              = (bbcc * 5243) >> 19;              /* (bbcc / 100) */
+    cc              = bbcc - bb * 100;                  /* (bbcc % 100) */
+    lz              = aa < 10;                          /* leading zero: 0 or 1 */
+    ((v16 *)buf)[0] = *(const v16 *)(digit_table + (aa * 2 + lz));
+    buf -= lz;
     ((v16 *)buf)[1] = ((const v16 *)digit_table)[bb];
-    return buf + 4;
+    ((v16 *)buf)[2] = ((const v16 *)digit_table)[cc];
+    return buf + 6;
+  }
+  else
+  {                                                        /* 7-8 digits: aabbccdd */
+    aabb            = (u32)(((u64)val * 109951163) >> 40); /* (val / 10000) */
+    ccdd            = val - aabb * 10000;                  /* (val % 10000) */
+    aa              = (aabb * 5243) >> 19;                 /* (aabb / 100) */
+    cc              = (ccdd * 5243) >> 19;                 /* (ccdd / 100) */
+    bb              = aabb - aa * 100;                     /* (aabb % 100) */
+    dd              = ccdd - cc * 100;                     /* (ccdd % 100) */
+    lz              = aa < 10;                             /* leading zero: 0 or 1 */
+    ((v16 *)buf)[0] = *(const v16 *)(digit_table + (aa * 2 + lz));
+    buf -= lz;
+    ((v16 *)buf)[1] = ((const v16 *)digit_table)[bb];
+    ((v16 *)buf)[2] = ((const v16 *)digit_table)[cc];
+    ((v16 *)buf)[3] = ((const v16 *)digit_table)[dd];
+    return buf + 8;
+  }
 }
 
-static_inline u8 *write_u32_len_1_8(u32 val, u8 *buf) {
-    u32 aa, bb, cc, dd, aabb, bbcc, ccdd, lz;
-    
-    if (val < 100) {                                /* 1-2 digits: aa */
-        lz = val < 10;                              /* leading zero: 0 or 1 */
-        ((v16 *)buf)[0] = *(const v16 *)(digit_table + (val * 2 + lz));
-        buf -= lz;
-        return buf + 2;
-        
-    } else if (val < 10000) {                       /* 3-4 digits: aabb */
-        aa = (val * 5243) >> 19;                    /* (val / 100) */
-        bb = val - aa * 100;                        /* (val % 100) */
-        lz = aa < 10;                               /* leading zero: 0 or 1 */
-        ((v16 *)buf)[0] = *(const v16 *)(digit_table + (aa * 2 + lz));
-        buf -= lz;
-        ((v16 *)buf)[1] = ((const v16 *)digit_table)[bb];
-        return buf + 4;
-        
-    } else if (val < 1000000) {                     /* 5-6 digits: aabbcc */
-        aa = (u32)(((u64)val * 429497) >> 32);      /* (val / 10000) */
-        bbcc = val - aa * 10000;                    /* (val % 10000) */
-        bb = (bbcc * 5243) >> 19;                   /* (bbcc / 100) */
-        cc = bbcc - bb * 100;                       /* (bbcc % 100) */
-        lz = aa < 10;                               /* leading zero: 0 or 1 */
-        ((v16 *)buf)[0] = *(const v16 *)(digit_table + (aa * 2 + lz));
-        buf -= lz;
-        ((v16 *)buf)[1] = ((const v16 *)digit_table)[bb];
-        ((v16 *)buf)[2] = ((const v16 *)digit_table)[cc];
-        return buf + 6;
-        
-    } else {                                        /* 7-8 digits: aabbccdd */
-        aabb = (u32)(((u64)val * 109951163) >> 40); /* (val / 10000) */
-        ccdd = val - aabb * 10000;                  /* (val % 10000) */
-        aa = (aabb * 5243) >> 19;                   /* (aabb / 100) */
-        cc = (ccdd * 5243) >> 19;                   /* (ccdd / 100) */
-        bb = aabb - aa * 100;                       /* (aabb % 100) */
-        dd = ccdd - cc * 100;                       /* (ccdd % 100) */
-        lz = aa < 10;                               /* leading zero: 0 or 1 */
-        ((v16 *)buf)[0] = *(const v16 *)(digit_table + (aa * 2 + lz));
-        buf -= lz;
-        ((v16 *)buf)[1] = ((const v16 *)digit_table)[bb];
-        ((v16 *)buf)[2] = ((const v16 *)digit_table)[cc];
-        ((v16 *)buf)[3] = ((const v16 *)digit_table)[dd];
-        return buf + 8;
-    }
+static_inline u8 *
+write_u64 (u64 val, u8 *buf)
+{
+  u64 tmp, hgh;
+  u32 mid, low;
+
+  if (val < 100000000)
+  { /* 1-8 digits */
+    buf = write_u32_len_1_8 ((u32)val, buf);
+    return buf;
+  }
+  else if (val < (u64)100000000 * 100000000)
+  {                                     /* 9-16 digits */
+    hgh = val / 100000000;              /* (val / 100000000) */
+    low = (u32)(val - hgh * 100000000); /* (val % 100000000) */
+    buf = write_u32_len_1_8 ((u32)hgh, buf);
+    buf = write_u32_len_8 (low, buf);
+    return buf;
+  }
+  else
+  {                                     /* 17-20 digits */
+    tmp = val / 100000000;              /* (val / 100000000) */
+    low = (u32)(val - tmp * 100000000); /* (val % 100000000) */
+    hgh = (u32)(tmp / 10000);           /* (tmp / 10000) */
+    mid = (u32)(tmp - hgh * 10000);     /* (tmp % 10000) */
+    buf = write_u64_len_5_8 ((u32)hgh, buf);
+    buf = write_u32_len_4 (mid, buf);
+    buf = write_u32_len_8 (low, buf);
+    return buf;
+  }
 }
-
-static_inline u8 *write_u64_len_5_8(u32 val, u8 *buf) {
-    u32 aa, bb, cc, dd, aabb, bbcc, ccdd, lz;
-    
-    if (val < 1000000) {                            /* 5-6 digits: aabbcc */
-        aa = (u32)(((u64)val * 429497) >> 32);      /* (val / 10000) */
-        bbcc = val - aa * 10000;                    /* (val % 10000) */
-        bb = (bbcc * 5243) >> 19;                   /* (bbcc / 100) */
-        cc = bbcc - bb * 100;                       /* (bbcc % 100) */
-        lz = aa < 10;                               /* leading zero: 0 or 1 */
-        ((v16 *)buf)[0] = *(const v16 *)(digit_table + (aa * 2 + lz));
-        buf -= lz;
-        ((v16 *)buf)[1] = ((const v16 *)digit_table)[bb];
-        ((v16 *)buf)[2] = ((const v16 *)digit_table)[cc];
-        return buf + 6;
-        
-    } else {                                        /* 7-8 digits: aabbccdd */
-        aabb = (u32)(((u64)val * 109951163) >> 40); /* (val / 10000) */
-        ccdd = val - aabb * 10000;                  /* (val % 10000) */
-        aa = (aabb * 5243) >> 19;                   /* (aabb / 100) */
-        cc = (ccdd * 5243) >> 19;                   /* (ccdd / 100) */
-        bb = aabb - aa * 100;                       /* (aabb % 100) */
-        dd = ccdd - cc * 100;                       /* (ccdd % 100) */
-        lz = aa < 10;                               /* leading zero: 0 or 1 */
-        ((v16 *)buf)[0] = *(const v16 *)(digit_table + (aa * 2 + lz));
-        buf -= lz;
-        ((v16 *)buf)[1] = ((const v16 *)digit_table)[bb];
-        ((v16 *)buf)[2] = ((const v16 *)digit_table)[cc];
-        ((v16 *)buf)[3] = ((const v16 *)digit_table)[dd];
-        return buf + 8;
-    }
-}
-
-static_inline u8 *write_u64(u64 val, u8 *buf) {
-    u64 tmp, hgh;
-    u32 mid, low;
-    
-    if (val < 100000000) {                          /* 1-8 digits */
-        buf = write_u32_len_1_8((u32)val, buf);
-        return buf;
-        
-    } else if (val < (u64)100000000 * 100000000) {  /* 9-16 digits */
-        hgh = val / 100000000;                      /* (val / 100000000) */
-        low = (u32)(val - hgh * 100000000);         /* (val % 100000000) */
-        buf = write_u32_len_1_8((u32)hgh, buf);
-        buf = write_u32_len_8(low, buf);
-        return buf;
-        
-    } else {                                        /* 17-20 digits */
-        tmp = val / 100000000;                      /* (val / 100000000) */
-        low = (u32)(val - tmp * 100000000);         /* (val % 100000000) */
-        hgh = (u32)(tmp / 10000);                   /* (tmp / 10000) */
-        mid = (u32)(tmp - hgh * 10000);             /* (tmp % 10000) */
-        buf = write_u64_len_5_8((u32)hgh, buf);
-        buf = write_u32_len_4(mid, buf);
-        buf = write_u32_len_8(low, buf);
-        return buf;
-    }
-}
-
-
 
 /*==============================================================================
  * Number Writer
  *============================================================================*/
 
-#if YYJSON_HAS_IEEE_754 && !YYJSON_DISABLE_FAST_FP_CONV  /* FP_WRITER */
+#if YYJSON_HAS_IEEE_754 && !YYJSON_DISABLE_FAST_FP_CONV /* FP_WRITER */
 
 /** Trailing zero count table for number 0 to 99.
     (generate with misc/make_tables.c) */
@@ -6219,49 +7311,60 @@ static const u8 dec_trailing_zero_table[] = {
     1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    1, 0, 0, 0, 0, 0, 0, 0, 0, 0
-};
+    1, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
 /** Write an unsigned integer with a length of 1 to 16. */
-static_inline u8 *write_u64_len_1_to_16(u64 val, u8 *buf) {
-    u64 hgh;
-    u32 low;
-    if (val < 100000000) {                          /* 1-8 digits */
-        buf = write_u32_len_1_8((u32)val, buf);
-        return buf;
-    } else {                                        /* 9-16 digits */
-        hgh = val / 100000000;                      /* (val / 100000000) */
-        low = (u32)(val - hgh * 100000000);         /* (val % 100000000) */
-        buf = write_u32_len_1_8((u32)hgh, buf);
-        buf = write_u32_len_8(low, buf);
-        return buf;
-    }
+static_inline u8 *
+write_u64_len_1_to_16 (u64 val, u8 *buf)
+{
+  u64 hgh;
+  u32 low;
+  if (val < 100000000)
+  { /* 1-8 digits */
+    buf = write_u32_len_1_8 ((u32)val, buf);
+    return buf;
+  }
+  else
+  {                                     /* 9-16 digits */
+    hgh = val / 100000000;              /* (val / 100000000) */
+    low = (u32)(val - hgh * 100000000); /* (val % 100000000) */
+    buf = write_u32_len_1_8 ((u32)hgh, buf);
+    buf = write_u32_len_8 (low, buf);
+    return buf;
+  }
 }
 
 /** Write an unsigned integer with a length of 1 to 17. */
-static_inline u8 *write_u64_len_1_to_17(u64 val, u8 *buf) {
-    u64 hgh;
-    u32 mid, low, one;
-    if (val >= (u64)100000000 * 10000000) {         /* len: 16 to 17 */
-        hgh = val / 100000000;                      /* (val / 100000000) */
-        low = (u32)(val - hgh * 100000000);         /* (val % 100000000) */
-        one = (u32)(hgh / 100000000);               /* (hgh / 100000000) */
-        mid = (u32)(hgh - (u64)one * 100000000);    /* (hgh % 100000000) */
-        *buf = (u8)((u8)one + (u8)'0');
-        buf += one > 0;
-        buf = write_u32_len_8(mid, buf);
-        buf = write_u32_len_8(low, buf);
-        return buf;
-    } else if (val >= (u64)100000000){              /* len: 9 to 15 */
-        hgh = val / 100000000;                      /* (val / 100000000) */
-        low = (u32)(val - hgh * 100000000);         /* (val % 100000000) */
-        buf = write_u32_len_1_8((u32)hgh, buf);
-        buf = write_u32_len_8(low, buf);
-        return buf;
-    } else { /* len: 1 to 8 */
-        buf = write_u32_len_1_8((u32)val, buf);
-        return buf;
-    }
+static_inline u8 *
+write_u64_len_1_to_17 (u64 val, u8 *buf)
+{
+  u64 hgh;
+  u32 mid, low, one;
+  if (val >= (u64)100000000 * 10000000)
+  {                                           /* len: 16 to 17 */
+    hgh  = val / 100000000;                   /* (val / 100000000) */
+    low  = (u32)(val - hgh * 100000000);      /* (val % 100000000) */
+    one  = (u32)(hgh / 100000000);            /* (hgh / 100000000) */
+    mid  = (u32)(hgh - (u64)one * 100000000); /* (hgh % 100000000) */
+    *buf = (u8)((u8)one + (u8)'0');
+    buf += one > 0;
+    buf = write_u32_len_8 (mid, buf);
+    buf = write_u32_len_8 (low, buf);
+    return buf;
+  }
+  else if (val >= (u64)100000000)
+  {                                     /* len: 9 to 15 */
+    hgh = val / 100000000;              /* (val / 100000000) */
+    low = (u32)(val - hgh * 100000000); /* (val % 100000000) */
+    buf = write_u32_len_1_8 ((u32)hgh, buf);
+    buf = write_u32_len_8 (low, buf);
+    return buf;
+  }
+  else
+  { /* len: 1 to 8 */
+    buf = write_u32_len_1_8 ((u32)val, buf);
+    return buf;
+  }
 }
 
 /**
@@ -6269,118 +7372,136 @@ static_inline u8 *write_u64_len_1_to_17(u64 val, u8 *buf) {
  These digits are named as "aabbccddeeffgghhii" here.
  For example, input 1234567890123000, output "1234567890123".
  */
-static_inline u8 *write_u64_len_15_to_17_trim(u8 *buf, u64 sig) {
-    bool lz;                                        /* leading zero */
-    u32 tz1, tz2, tz;                               /* trailing zero */
-    
-    u32 abbccddee = (u32)(sig / 100000000);
-    u32 ffgghhii = (u32)(sig - (u64)abbccddee * 100000000);
-    u32 abbcc = abbccddee / 10000;                  /* (abbccddee / 10000) */
-    u32 ddee = abbccddee - abbcc * 10000;           /* (abbccddee % 10000) */
-    u32 abb = (u32)(((u64)abbcc * 167773) >> 24);   /* (abbcc / 100) */
-    u32 a = (abb * 41) >> 12;                       /* (abb / 100) */
-    u32 bb = abb - a * 100;                         /* (abb % 100) */
-    u32 cc = abbcc - abb * 100;                     /* (abbcc % 100) */
-    
-    /* write abbcc */
-    buf[0] = (u8)(a + '0');
-    buf += a > 0;
-    lz = bb < 10 && a == 0;
-    ((v16 *)buf)[0] = *(const v16 *)(digit_table + (bb * 2 + lz));
-    buf -= lz;
-    ((v16 *)buf)[1] = ((const v16 *)digit_table)[cc];
-    
-    if (ffgghhii) {
-        u32 dd = (ddee * 5243) >> 19;               /* (ddee / 100) */
-        u32 ee = ddee - dd * 100;                   /* (ddee % 100) */
-        u32 ffgg = (u32)(((u64)ffgghhii * 109951163) >> 40); /* (val / 10000) */
-        u32 hhii = ffgghhii - ffgg * 10000;         /* (val % 10000) */
-        u32 ff = (ffgg * 5243) >> 19;               /* (aabb / 100) */
-        u32 gg = ffgg - ff * 100;                   /* (aabb % 100) */
-        ((v16 *)buf)[2] = ((const v16 *)digit_table)[dd];
-        ((v16 *)buf)[3] = ((const v16 *)digit_table)[ee];
-        ((v16 *)buf)[4] = ((const v16 *)digit_table)[ff];
-        ((v16 *)buf)[5] = ((const v16 *)digit_table)[gg];
-        if (hhii) {
-            u32 hh = (hhii * 5243) >> 19;           /* (ccdd / 100) */
-            u32 ii = hhii - hh * 100;               /* (ccdd % 100) */
-            ((v16 *)buf)[6] = ((const v16 *)digit_table)[hh];
-            ((v16 *)buf)[7] = ((const v16 *)digit_table)[ii];
-            tz1 = dec_trailing_zero_table[hh];
-            tz2 = dec_trailing_zero_table[ii];
-            tz = ii ? tz2 : (tz1 + 2);
-            buf += 16 - tz;
-            return buf;
-        } else {
-            tz1 = dec_trailing_zero_table[ff];
-            tz2 = dec_trailing_zero_table[gg];
-            tz = gg ? tz2 : (tz1 + 2);
-            buf += 12 - tz;
-            return buf;
-        }
-    } else {
-        if (ddee) {
-            u32 dd = (ddee * 5243) >> 19;           /* (ddee / 100) */
-            u32 ee = ddee - dd * 100;               /* (ddee % 100) */
-            ((v16 *)buf)[2] = ((const v16 *)digit_table)[dd];
-            ((v16 *)buf)[3] = ((const v16 *)digit_table)[ee];
-            tz1 = dec_trailing_zero_table[dd];
-            tz2 = dec_trailing_zero_table[ee];
-            tz = ee ? tz2 : (tz1 + 2);
-            buf += 8 - tz;
-            return buf;
-        } else {
-            tz1 = dec_trailing_zero_table[bb];
-            tz2 = dec_trailing_zero_table[cc];
-            tz = cc ? tz2 : (tz1 + tz2);
-            buf += 4 - tz;
-            return buf;
-        }
+static_inline u8 *
+write_u64_len_15_to_17_trim (u8 *buf, u64 sig)
+{
+  bool lz;          /* leading zero */
+  u32 tz1, tz2, tz; /* trailing zero */
+
+  u32 abbccddee = (u32)(sig / 100000000);
+  u32 ffgghhii  = (u32)(sig - (u64)abbccddee * 100000000);
+  u32 abbcc     = abbccddee / 10000;                  /* (abbccddee / 10000) */
+  u32 ddee      = abbccddee - abbcc * 10000;          /* (abbccddee % 10000) */
+  u32 abb       = (u32)(((u64)abbcc * 167773) >> 24); /* (abbcc / 100) */
+  u32 a         = (abb * 41) >> 12;                   /* (abb / 100) */
+  u32 bb        = abb - a * 100;                      /* (abb % 100) */
+  u32 cc        = abbcc - abb * 100;                  /* (abbcc % 100) */
+
+  /* write abbcc */
+  buf[0] = (u8)(a + '0');
+  buf += a > 0;
+  lz              = bb < 10 && a == 0;
+  ((v16 *)buf)[0] = *(const v16 *)(digit_table + (bb * 2 + lz));
+  buf -= lz;
+  ((v16 *)buf)[1] = ((const v16 *)digit_table)[cc];
+
+  if (ffgghhii)
+  {
+    u32 dd          = (ddee * 5243) >> 19;                      /* (ddee / 100) */
+    u32 ee          = ddee - dd * 100;                          /* (ddee % 100) */
+    u32 ffgg        = (u32)(((u64)ffgghhii * 109951163) >> 40); /* (val / 10000) */
+    u32 hhii        = ffgghhii - ffgg * 10000;                  /* (val % 10000) */
+    u32 ff          = (ffgg * 5243) >> 19;                      /* (aabb / 100) */
+    u32 gg          = ffgg - ff * 100;                          /* (aabb % 100) */
+    ((v16 *)buf)[2] = ((const v16 *)digit_table)[dd];
+    ((v16 *)buf)[3] = ((const v16 *)digit_table)[ee];
+    ((v16 *)buf)[4] = ((const v16 *)digit_table)[ff];
+    ((v16 *)buf)[5] = ((const v16 *)digit_table)[gg];
+    if (hhii)
+    {
+      u32 hh          = (hhii * 5243) >> 19; /* (ccdd / 100) */
+      u32 ii          = hhii - hh * 100;     /* (ccdd % 100) */
+      ((v16 *)buf)[6] = ((const v16 *)digit_table)[hh];
+      ((v16 *)buf)[7] = ((const v16 *)digit_table)[ii];
+      tz1             = dec_trailing_zero_table[hh];
+      tz2             = dec_trailing_zero_table[ii];
+      tz              = ii ? tz2 : (tz1 + 2);
+      buf += 16 - tz;
+      return buf;
     }
+    else
+    {
+      tz1 = dec_trailing_zero_table[ff];
+      tz2 = dec_trailing_zero_table[gg];
+      tz  = gg ? tz2 : (tz1 + 2);
+      buf += 12 - tz;
+      return buf;
+    }
+  }
+  else
+  {
+    if (ddee)
+    {
+      u32 dd          = (ddee * 5243) >> 19; /* (ddee / 100) */
+      u32 ee          = ddee - dd * 100;     /* (ddee % 100) */
+      ((v16 *)buf)[2] = ((const v16 *)digit_table)[dd];
+      ((v16 *)buf)[3] = ((const v16 *)digit_table)[ee];
+      tz1             = dec_trailing_zero_table[dd];
+      tz2             = dec_trailing_zero_table[ee];
+      tz              = ee ? tz2 : (tz1 + 2);
+      buf += 8 - tz;
+      return buf;
+    }
+    else
+    {
+      tz1 = dec_trailing_zero_table[bb];
+      tz2 = dec_trailing_zero_table[cc];
+      tz  = cc ? tz2 : (tz1 + tz2);
+      buf += 4 - tz;
+      return buf;
+    }
+  }
 }
 
 /** Write a signed integer in the range -324 to 308. */
-static_inline u8 *write_f64_exp(i32 exp, u8 *buf) {
-    buf[0] = '-';
-    buf += exp < 0;
-    exp = exp < 0 ? -exp : exp;
-    if (exp < 100) {
-        u32 lz = exp < 10;
-        *(v16 *)&buf[0] = *(const v16 *)(digit_table + ((u32)exp * 2 + lz));
-        return buf + 2 - lz;
-    } else {
-        u32 hi = ((u32)exp * 656) >> 16;            /* exp / 100 */
-        u32 lo = (u32)exp - hi * 100;               /* exp % 100 */
-        buf[0] = (u8)((u8)hi + (u8)'0');
-        *(v16 *)&buf[1] = *(const v16 *)(digit_table + (lo * 2));
-        return buf + 3;
-    }
+static_inline u8 *
+write_f64_exp (i32 exp, u8 *buf)
+{
+  buf[0] = '-';
+  buf += exp < 0;
+  exp = exp < 0 ? -exp : exp;
+  if (exp < 100)
+  {
+    u32 lz          = exp < 10;
+    *(v16 *)&buf[0] = *(const v16 *)(digit_table + ((u32)exp * 2 + lz));
+    return buf + 2 - lz;
+  }
+  else
+  {
+    u32 hi          = ((u32)exp * 656) >> 16; /* exp / 100 */
+    u32 lo          = (u32)exp - hi * 100;    /* exp % 100 */
+    buf[0]          = (u8)((u8)hi + (u8)'0');
+    *(v16 *)&buf[1] = *(const v16 *)(digit_table + (lo * 2));
+    return buf + 3;
+  }
 }
 
 /** Multiplies 128-bit integer and returns highest 64-bit rounded value. */
-static_inline u64 round_to_odd(u64 hi, u64 lo, u64 cp) {
-    u64 x_hi, x_lo, y_hi, y_lo;
-    u128_mul(cp, lo, &x_hi, &x_lo);
-    u128_mul_add(cp, hi, x_hi, &y_hi, &y_lo);
-    return y_hi | (y_lo > 1);
+static_inline u64
+round_to_odd (u64 hi, u64 lo, u64 cp)
+{
+  u64 x_hi, x_lo, y_hi, y_lo;
+  u128_mul (cp, lo, &x_hi, &x_lo);
+  u128_mul_add (cp, hi, x_hi, &y_hi, &y_lo);
+  return y_hi | (y_lo > 1);
 }
 
 /**
  Convert double number from binary to decimal.
  The output significand is shortest decimal but may have trailing zeros.
- 
+
  This function use the Schubfach algorithm:
  Raffaello Giulietti, The Schubfach way to render doubles (5th version), 2022.
  https://drive.google.com/file/d/1gp5xv4CAa78SVgCeWfGqqI4FfYYYuNFb
  https://mail.openjdk.java.net/pipermail/core-libs-dev/2021-November/083536.html
  https://github.com/openjdk/jdk/pull/3402 (Java implementation)
  https://github.com/abolz/Drachennest (C++ implementation)
- 
+
  See also:
  Dragonbox: A New Floating-Point Binary-to-Decimal Conversion Algorithm, 2022.
  https://github.com/jk-jeon/dragonbox/blob/master/other_files/Dragonbox.pdf
  https://github.com/jk-jeon/dragonbox
- 
+
  @param sig_raw The raw value of significand in IEEE 754 format.
  @param exp_raw The raw value of exponent in IEEE 754 format.
  @param sig_bin The decoded value of significand in binary.
@@ -6389,304 +7510,352 @@ static_inline u64 round_to_odd(u64 hi, u64 lo, u64 cp) {
  @param exp_dec The output value of exponent in decimal.
  @warning The input double number should not be 0, inf, nan.
  */
-static_inline void f64_bin_to_dec(u64 sig_raw, u32 exp_raw,
-                                  u64 sig_bin, i32 exp_bin,
-                                  u64 *sig_dec, i32 *exp_dec) {
-    
-    bool is_even, regular_spacing, u_inside, w_inside, round_up;
-    u64 s, sp, cb, cbl, cbr, vb, vbl, vbr, pow10hi, pow10lo, upper, lower, mid;
-    i32 k, h, exp10;
-    
-    is_even = !(sig_bin & 1);
-    regular_spacing = (sig_raw == 0 && exp_raw > 1);
-    
-    cbl = 4 * sig_bin - 2 + regular_spacing;
-    cb  = 4 * sig_bin;
-    cbr = 4 * sig_bin + 2;
-    
-    /* exp_bin: [-1074, 971]                                                  */
-    /* k = regular_spacing ? floor(log10(pow(2, exp_bin)))                    */
-    /*                     : floor(log10(pow(2, exp_bin) * 3.0 / 4.0))        */
-    /*   = regular_spacing ? floor(exp_bin * log10(2))                        */
-    /*                     : floor(exp_bin * log10(2) + log10(3.0 / 4.0))     */
-    k = (i32)(exp_bin * 315653 - (regular_spacing ? 131237 : 0)) >> 20;
-    
-    /* k: [-324, 292]                                                         */
-    /* h = exp_bin + floor(log2(pow(10, e)))                                  */
-    /*   = exp_bin + floor(log2(10) * e)                                      */
-    exp10 = -k;
-    h = exp_bin + ((exp10 * 217707) >> 16) + 1;
-    
-    pow10_table_get_sig(exp10, &pow10hi, &pow10lo);
-    pow10lo += (exp10 < POW10_SIG_TABLE_MIN_EXACT_EXP ||
-                exp10 > POW10_SIG_TABLE_MAX_EXACT_EXP);
-    vbl = round_to_odd(pow10hi, pow10lo, cbl << h);
-    vb  = round_to_odd(pow10hi, pow10lo, cb  << h);
-    vbr = round_to_odd(pow10hi, pow10lo, cbr << h);
-    
-    lower = vbl + !is_even;
-    upper = vbr - !is_even;
-    
-    s = vb / 4;
-    if (s >= 10) {
-        sp = s / 10;
-        u_inside = (lower <= 40 * sp);
-        w_inside = (upper >= 40 * sp + 40);
-        if (u_inside != w_inside) {
-            *sig_dec = sp + w_inside;
-            *exp_dec = k + 1;
-            return;
-        }
+static_inline void
+f64_bin_to_dec (u64 sig_raw, u32 exp_raw,
+                u64 sig_bin, i32 exp_bin,
+                u64 *sig_dec, i32 *exp_dec)
+{
+
+  bool is_even, regular_spacing, u_inside, w_inside, round_up;
+  u64 s, sp, cb, cbl, cbr, vb, vbl, vbr, pow10hi, pow10lo, upper, lower, mid;
+  i32 k, h, exp10;
+
+  is_even         = !(sig_bin & 1);
+  regular_spacing = (sig_raw == 0 && exp_raw > 1);
+
+  cbl = 4 * sig_bin - 2 + regular_spacing;
+  cb  = 4 * sig_bin;
+  cbr = 4 * sig_bin + 2;
+
+  /* exp_bin: [-1074, 971]                                                  */
+  /* k = regular_spacing ? floor(log10(pow(2, exp_bin)))                    */
+  /*                     : floor(log10(pow(2, exp_bin) * 3.0 / 4.0))        */
+  /*   = regular_spacing ? floor(exp_bin * log10(2))                        */
+  /*                     : floor(exp_bin * log10(2) + log10(3.0 / 4.0))     */
+  k = (i32)(exp_bin * 315653 - (regular_spacing ? 131237 : 0)) >> 20;
+
+  /* k: [-324, 292]                                                         */
+  /* h = exp_bin + floor(log2(pow(10, e)))                                  */
+  /*   = exp_bin + floor(log2(10) * e)                                      */
+  exp10 = -k;
+  h     = exp_bin + ((exp10 * 217707) >> 16) + 1;
+
+  pow10_table_get_sig (exp10, &pow10hi, &pow10lo);
+  pow10lo += (exp10 < POW10_SIG_TABLE_MIN_EXACT_EXP ||
+              exp10 > POW10_SIG_TABLE_MAX_EXACT_EXP);
+  vbl = round_to_odd (pow10hi, pow10lo, cbl << h);
+  vb  = round_to_odd (pow10hi, pow10lo, cb << h);
+  vbr = round_to_odd (pow10hi, pow10lo, cbr << h);
+
+  lower = vbl + !is_even;
+  upper = vbr - !is_even;
+
+  s = vb / 4;
+  if (s >= 10)
+  {
+    sp       = s / 10;
+    u_inside = (lower <= 40 * sp);
+    w_inside = (upper >= 40 * sp + 40);
+    if (u_inside != w_inside)
+    {
+      *sig_dec = sp + w_inside;
+      *exp_dec = k + 1;
+      return;
     }
-    
-    u_inside = (lower <= 4 * s);
-    w_inside = (upper >= 4 * s + 4);
-    
-    mid = 4 * s + 2;
-    round_up = (vb > mid) || (vb == mid && (s & 1) != 0);
-    
-    *sig_dec = s + ((u_inside != w_inside) ? w_inside : round_up);
-    *exp_dec = k;
+  }
+
+  u_inside = (lower <= 4 * s);
+  w_inside = (upper >= 4 * s + 4);
+
+  mid      = 4 * s + 2;
+  round_up = (vb > mid) || (vb == mid && (s & 1) != 0);
+
+  *sig_dec = s + ((u_inside != w_inside) ? w_inside : round_up);
+  *exp_dec = k;
 }
 
 /**
  Write a double number (requires 32 bytes buffer).
- 
+
  We follows the ECMAScript specification to print floating point numbers,
  but with the following changes:
  1. Keep the negative sign of 0.0 to preserve input information.
  2. Keep decimal point to indicate the number is floating point.
  3. Remove positive sign of exponent part.
  */
-static_noinline u8 *write_f64_raw(u8 *buf, u64 raw, yyjson_write_flag flg) {
-    u64 sig_bin, sig_dec, sig_raw;
-    i32 exp_bin, exp_dec, sig_len, dot_pos, i, max;
-    u32 exp_raw, hi, lo;
-    u8 *hdr, *num_hdr, *num_end, *dot_end;
-    bool sign;
-    
-    /* decode raw bytes from IEEE-754 double format. */
-    sign = (bool)(raw >> (F64_BITS - 1));
-    sig_raw = raw & F64_SIG_MASK;
-    exp_raw = (u32)((raw & F64_EXP_MASK) >> F64_SIG_BITS);
-    
-    /* return inf and nan */
-    if (unlikely(exp_raw == ((u32)1 << F64_EXP_BITS) - 1)) {
-        if (flg & YYJSON_WRITE_INF_AND_NAN_AS_NULL) {
-            byte_copy_4(buf, "null");
-            return buf + 4;
-        } else if (flg & YYJSON_WRITE_ALLOW_INF_AND_NAN) {
-            if (sig_raw == 0) {
-                buf[0] = '-';
-                buf += sign;
-                byte_copy_8(buf, "Infinity");
-                buf += 8;
-                return buf;
-            } else {
-                byte_copy_4(buf, "NaN");
-                return buf + 3;
-            }
-        } else {
-            return NULL;
-        }
+static_noinline u8 *
+write_f64_raw (u8 *buf, u64 raw, yyjson_write_flag flg)
+{
+  u64 sig_bin, sig_dec, sig_raw;
+  i32 exp_bin, exp_dec, sig_len, dot_pos, i, max;
+  u32 exp_raw, hi, lo;
+  u8 *hdr, *num_hdr, *num_end, *dot_end;
+  bool sign;
+
+  /* decode raw bytes from IEEE-754 double format. */
+  sign    = (bool)(raw >> (F64_BITS - 1));
+  sig_raw = raw & F64_SIG_MASK;
+  exp_raw = (u32)((raw & F64_EXP_MASK) >> F64_SIG_BITS);
+
+  /* return inf and nan */
+  if (unlikely (exp_raw == ((u32)1 << F64_EXP_BITS) - 1))
+  {
+    if (flg & YYJSON_WRITE_INF_AND_NAN_AS_NULL)
+    {
+      byte_copy_4 (buf, "null");
+      return buf + 4;
     }
-    
-    /* add sign for all finite double value, including 0.0 and inf */
-    buf[0] = '-';
-    buf += sign;
-    hdr = buf;
-    
-    /* return zero */
-    if ((raw << 1) == 0) {
-        byte_copy_4(buf, "0.0");
-        buf += 3;
-        return buf;
-    }
-    
-    if (likely(exp_raw != 0)) {
-        /* normal number */
-        sig_bin = sig_raw | ((u64)1 << F64_SIG_BITS);
-        exp_bin = (i32)exp_raw - F64_EXP_BIAS - F64_SIG_BITS;
-        
-        /* fast path for small integer number without fraction */
-        if (-F64_SIG_BITS <= exp_bin && exp_bin <= 0) {
-            if (u64_tz_bits(sig_bin) >= (u32)-exp_bin) {
-                /* number is integer in range 1 to 0x1FFFFFFFFFFFFF */
-                sig_dec = sig_bin >> -exp_bin;
-                buf = write_u64_len_1_to_16(sig_dec, buf);
-                byte_copy_2(buf, ".0");
-                buf += 2;
-                return buf;
-            }
-        }
-        
-        /* binary to decimal */
-        f64_bin_to_dec(sig_raw, exp_raw, sig_bin, exp_bin, &sig_dec, &exp_dec);
-        
-        /* the sig length is 15 to 17 */
-        sig_len = 17;
-        sig_len -= (sig_dec < (u64)100000000 * 100000000);
-        sig_len -= (sig_dec < (u64)100000000 * 10000000);
-        
-        /* the decimal point position relative to the first digit */
-        dot_pos = sig_len + exp_dec;
-        
-        if (-6 < dot_pos && dot_pos <= 21) {
-            /* no need to write exponent part */
-            if (dot_pos <= 0) {
-                /* dot before first digit */
-                /* such as 0.1234, 0.000001234 */
-                num_hdr = hdr + (2 - dot_pos);
-                num_end = write_u64_len_15_to_17_trim(num_hdr, sig_dec);
-                hdr[0] = '0';
-                hdr[1] = '.';
-                hdr += 2;
-                max = -dot_pos;
-                for (i = 0; i < max; i++) hdr[i] = '0';
-                return num_end;
-            } else {
-                /* dot after first digit */
-                /* such as 1.234, 1234.0, 123400000000000000000.0 */
-                memset(hdr +  0, '0', 8);
-                memset(hdr +  8, '0', 8);
-                memset(hdr + 16, '0', 8);
-                num_hdr = hdr + 1;
-                num_end = write_u64_len_15_to_17_trim(num_hdr, sig_dec);
-                for (i = 0; i < dot_pos; i++) hdr[i] = hdr[i + 1];
-                hdr[dot_pos] = '.';
-                dot_end = hdr + dot_pos + 2;
-                return dot_end < num_end ? num_end : dot_end;
-            }
-        } else {
-            /* write with scientific notation */
-            /* such as 1.234e56 */
-            u8 *end = write_u64_len_15_to_17_trim(buf + 1, sig_dec);
-            end -= (end == buf + 2); /* remove '.0', e.g. 2.0e34 -> 2e34 */
-            exp_dec += sig_len - 1;
-            hdr[0] = hdr[1];
-            hdr[1] = '.';
-            end[0] = 'e';
-            buf = write_f64_exp(exp_dec, end + 1);
-            return buf;
-        }
-        
-    } else {
-        /* subnormal number */
-        sig_bin = sig_raw;
-        exp_bin = 1 - F64_EXP_BIAS - F64_SIG_BITS;
-        
-        /* binary to decimal */
-        f64_bin_to_dec(sig_raw, exp_raw, sig_bin, exp_bin, &sig_dec, &exp_dec);
-        
-        /* write significand part */
-        buf = write_u64_len_1_to_17(sig_dec, buf + 1);
-        hdr[0] = hdr[1];
-        hdr[1] = '.';
-        do {
-            buf--;
-            exp_dec++;
-        } while (*buf == '0');
-        exp_dec += (i32)(buf - hdr - 2);
-        buf += (*buf != '.');
-        buf[0] = 'e';
-        buf++;
-        
-        /* write exponent part */
+    else if (flg & YYJSON_WRITE_ALLOW_INF_AND_NAN)
+    {
+      if (sig_raw == 0)
+      {
         buf[0] = '-';
-        buf++;
-        exp_dec = -exp_dec;
-        hi = ((u32)exp_dec * 656) >> 16; /* exp / 100 */
-        lo = (u32)exp_dec - hi * 100; /* exp % 100 */
-        buf[0] = (u8)((u8)hi + (u8)'0');
-        *(v16 *)&buf[1] = *(const v16 *)(digit_table + (lo * 2));
-        buf += 3;
+        buf += sign;
+        byte_copy_8 (buf, "Infinity");
+        buf += 8;
         return buf;
+      }
+      else
+      {
+        byte_copy_4 (buf, "NaN");
+        return buf + 3;
+      }
     }
+    else
+    {
+      return NULL;
+    }
+  }
+
+  /* add sign for all finite double value, including 0.0 and inf */
+  buf[0] = '-';
+  buf += sign;
+  hdr = buf;
+
+  /* return zero */
+  if ((raw << 1) == 0)
+  {
+    byte_copy_4 (buf, "0.0");
+    buf += 3;
+    return buf;
+  }
+
+  if (likely (exp_raw != 0))
+  {
+    /* normal number */
+    sig_bin = sig_raw | ((u64)1 << F64_SIG_BITS);
+    exp_bin = (i32)exp_raw - F64_EXP_BIAS - F64_SIG_BITS;
+
+    /* fast path for small integer number without fraction */
+    if (-F64_SIG_BITS <= exp_bin && exp_bin <= 0)
+    {
+      if (u64_tz_bits (sig_bin) >= (u32)-exp_bin)
+      {
+        /* number is integer in range 1 to 0x1FFFFFFFFFFFFF */
+        sig_dec = sig_bin >> -exp_bin;
+        buf     = write_u64_len_1_to_16 (sig_dec, buf);
+        byte_copy_2 (buf, ".0");
+        buf += 2;
+        return buf;
+      }
+    }
+
+    /* binary to decimal */
+    f64_bin_to_dec (sig_raw, exp_raw, sig_bin, exp_bin, &sig_dec, &exp_dec);
+
+    /* the sig length is 15 to 17 */
+    sig_len = 17;
+    sig_len -= (sig_dec < (u64)100000000 * 100000000);
+    sig_len -= (sig_dec < (u64)100000000 * 10000000);
+
+    /* the decimal point position relative to the first digit */
+    dot_pos = sig_len + exp_dec;
+
+    if (-6 < dot_pos && dot_pos <= 21)
+    {
+      /* no need to write exponent part */
+      if (dot_pos <= 0)
+      {
+        /* dot before first digit */
+        /* such as 0.1234, 0.000001234 */
+        num_hdr = hdr + (2 - dot_pos);
+        num_end = write_u64_len_15_to_17_trim (num_hdr, sig_dec);
+        hdr[0]  = '0';
+        hdr[1]  = '.';
+        hdr += 2;
+        max = -dot_pos;
+        for (i = 0; i < max; i++)
+          hdr[i] = '0';
+        return num_end;
+      }
+      else
+      {
+        /* dot after first digit */
+        /* such as 1.234, 1234.0, 123400000000000000000.0 */
+        memset (hdr + 0, '0', 8);
+        memset (hdr + 8, '0', 8);
+        memset (hdr + 16, '0', 8);
+        num_hdr = hdr + 1;
+        num_end = write_u64_len_15_to_17_trim (num_hdr, sig_dec);
+        for (i = 0; i < dot_pos; i++)
+          hdr[i] = hdr[i + 1];
+        hdr[dot_pos] = '.';
+        dot_end      = hdr + dot_pos + 2;
+        return dot_end < num_end ? num_end : dot_end;
+      }
+    }
+    else
+    {
+      /* write with scientific notation */
+      /* such as 1.234e56 */
+      u8 *end = write_u64_len_15_to_17_trim (buf + 1, sig_dec);
+      end -= (end == buf + 2); /* remove '.0', e.g. 2.0e34 -> 2e34 */
+      exp_dec += sig_len - 1;
+      hdr[0] = hdr[1];
+      hdr[1] = '.';
+      end[0] = 'e';
+      buf    = write_f64_exp (exp_dec, end + 1);
+      return buf;
+    }
+  }
+  else
+  {
+    /* subnormal number */
+    sig_bin = sig_raw;
+    exp_bin = 1 - F64_EXP_BIAS - F64_SIG_BITS;
+
+    /* binary to decimal */
+    f64_bin_to_dec (sig_raw, exp_raw, sig_bin, exp_bin, &sig_dec, &exp_dec);
+
+    /* write significand part */
+    buf    = write_u64_len_1_to_17 (sig_dec, buf + 1);
+    hdr[0] = hdr[1];
+    hdr[1] = '.';
+    do
+    {
+      buf--;
+      exp_dec++;
+    } while (*buf == '0');
+    exp_dec += (i32)(buf - hdr - 2);
+    buf += (*buf != '.');
+    buf[0] = 'e';
+    buf++;
+
+    /* write exponent part */
+    buf[0] = '-';
+    buf++;
+    exp_dec         = -exp_dec;
+    hi              = ((u32)exp_dec * 656) >> 16; /* exp / 100 */
+    lo              = (u32)exp_dec - hi * 100;    /* exp % 100 */
+    buf[0]          = (u8)((u8)hi + (u8)'0');
+    *(v16 *)&buf[1] = *(const v16 *)(digit_table + (lo * 2));
+    buf += 3;
+    return buf;
+  }
 }
 
 #else /* FP_WRITER */
 
 /** Write a double number (requires 32 bytes buffer). */
-static_noinline u8 *write_f64_raw(u8 *buf, u64 raw, yyjson_write_flag flg) {
-    /*
-     For IEEE 754, `DBL_DECIMAL_DIG` is 17 for round-trip.
-     For non-IEEE formats, 17 is used to avoid buffer overflow,
-     round-trip is not guaranteed.
-     */
+static_noinline u8 *
+write_f64_raw (u8 *buf, u64 raw, yyjson_write_flag flg)
+{
+  /*
+   For IEEE 754, `DBL_DECIMAL_DIG` is 17 for round-trip.
+   For non-IEEE formats, 17 is used to avoid buffer overflow,
+   round-trip is not guaranteed.
+   */
 #if defined(DBL_DECIMAL_DIG) && DBL_DECIMAL_DIG != 17
-    int dig = DBL_DECIMAL_DIG > 17 ? 17 : DBL_DECIMAL_DIG;
+  int dig = DBL_DECIMAL_DIG > 17 ? 17 : DBL_DECIMAL_DIG;
 #else
-    int dig = 17;
+  int dig = 17;
 #endif
-    
-    /*
-     The snprintf() function is locale-dependent. For currently known locales,
-     (en, zh, ja, ko, am, he, hi) use '.' as the decimal point, while other
-     locales use ',' as the decimal point. we need to replace ',' with '.'
-     to avoid the locale setting.
-     */
-    f64 val = f64_from_raw(raw);
+
+  /*
+   The snprintf() function is locale-dependent. For currently known locales,
+   (en, zh, ja, ko, am, he, hi) use '.' as the decimal point, while other
+   locales use ',' as the decimal point. we need to replace ',' with '.'
+   to avoid the locale setting.
+   */
+  f64 val = f64_from_raw (raw);
 #if YYJSON_MSC_VER >= 1400
-    int len = sprintf_s((char *)buf, 32, "%.*g", dig, val);
+  int len = sprintf_s ((char *)buf, 32, "%.*g", dig, val);
 #elif defined(snprintf) || (YYJSON_STDC_VER >= 199901L)
-    int len = snprintf((char *)buf, 32, "%.*g", dig, val);
+  int len = snprintf ((char *)buf, 32, "%.*g", dig, val);
 #else
-    int len = sprintf((char *)buf, "%.*g", dig, val);
+  int len = sprintf ((char *)buf, "%.*g", dig, val);
 #endif
-    
-    u8 *cur = buf;
-    if (unlikely(len < 1)) return NULL;
-    cur += (*cur == '-');
-    if (unlikely(!digi_is_digit(*cur))) {
-        /* nan, inf, or bad output */
-        if (flg & YYJSON_WRITE_INF_AND_NAN_AS_NULL) {
-            byte_copy_4(buf, "null");
-            return buf + 4;
-        } else if (flg & YYJSON_WRITE_ALLOW_INF_AND_NAN) {
-            if (*cur == 'i') {
-                byte_copy_8(cur, "Infinity");
-                cur += 8;
-                return cur;
-            } else if (*cur == 'n') {
-                byte_copy_4(buf, "NaN");
-                return buf + 3;
-            }
-        }
-        return NULL;
-    } else {
-        /* finite number */
-        int i = 0;
-        bool fp = false;
-        for (; i < len; i++) {
-            if (buf[i] == ',') buf[i] = '.';
-            if (digi_is_fp((u8)buf[i])) fp = true;
-        }
-        if (!fp) {
-            buf[len++] = '.';
-            buf[len++] = '0';
-        }
+
+  u8 *cur = buf;
+  if (unlikely (len < 1))
+    return NULL;
+  cur += (*cur == '-');
+  if (unlikely (!digi_is_digit (*cur)))
+  {
+    /* nan, inf, or bad output */
+    if (flg & YYJSON_WRITE_INF_AND_NAN_AS_NULL)
+    {
+      byte_copy_4 (buf, "null");
+      return buf + 4;
     }
-    return buf + len;
+    else if (flg & YYJSON_WRITE_ALLOW_INF_AND_NAN)
+    {
+      if (*cur == 'i')
+      {
+        byte_copy_8 (cur, "Infinity");
+        cur += 8;
+        return cur;
+      }
+      else if (*cur == 'n')
+      {
+        byte_copy_4 (buf, "NaN");
+        return buf + 3;
+      }
+    }
+    return NULL;
+  }
+  else
+  {
+    /* finite number */
+    int i   = 0;
+    bool fp = false;
+    for (; i < len; i++)
+    {
+      if (buf[i] == ',')
+        buf[i] = '.';
+      if (digi_is_fp ((u8)buf[i]))
+        fp = true;
+    }
+    if (!fp)
+    {
+      buf[len++] = '.';
+      buf[len++] = '0';
+    }
+  }
+  return buf + len;
 }
 
 #endif /* FP_WRITER */
 
 /** Write a JSON number (requires 32 bytes buffer). */
-static_inline u8 *write_number(u8 *cur, yyjson_val *val,
-                               yyjson_write_flag flg) {
-    if (val->tag & YYJSON_SUBTYPE_REAL) {
-        u64 raw = val->uni.u64;
-        return write_f64_raw(cur, raw, flg);
-    } else {
-        u64 pos = val->uni.u64;
-        u64 neg = ~pos + 1;
-        usize sgn = ((val->tag & YYJSON_SUBTYPE_SINT) > 0) & ((i64)pos < 0);
-        *cur = '-';
-        return write_u64(sgn ? neg : pos, cur + sgn);
-    }
+static_inline u8 *
+write_number (u8 *cur, yyjson_val *val,
+              yyjson_write_flag flg)
+{
+  if (val->tag & YYJSON_SUBTYPE_REAL)
+  {
+    u64 raw = val->uni.u64;
+    return write_f64_raw (cur, raw, flg);
+  }
+  else
+  {
+    u64 pos   = val->uni.u64;
+    u64 neg   = ~pos + 1;
+    usize sgn = ((val->tag & YYJSON_SUBTYPE_SINT) > 0) & ((i64)pos < 0);
+    *cur      = '-';
+    return write_u64 (sgn ? neg : pos, cur + sgn);
+  }
 }
-
-
 
 /*==============================================================================
  * String Writer
@@ -6694,16 +7863,16 @@ static_inline u8 *write_number(u8 *cur, yyjson_val *val,
 
 /** Character encode type, if (type > CHAR_ENC_ERR_1) bytes = type / 2; */
 typedef u8 char_enc_type;
-#define CHAR_ENC_CPY_1  0 /* 1-byte UTF-8, copy. */
-#define CHAR_ENC_ERR_1  1 /* 1-byte UTF-8, error. */
-#define CHAR_ENC_ESC_A  2 /* 1-byte ASCII, escaped as '\x'. */
-#define CHAR_ENC_ESC_1  3 /* 1-byte UTF-8, escaped as '\uXXXX'. */
-#define CHAR_ENC_CPY_2  4 /* 2-byte UTF-8, copy. */
-#define CHAR_ENC_ESC_2  5 /* 2-byte UTF-8, escaped as '\uXXXX'. */
-#define CHAR_ENC_CPY_3  6 /* 3-byte UTF-8, copy. */
-#define CHAR_ENC_ESC_3  7 /* 3-byte UTF-8, escaped as '\uXXXX'. */
-#define CHAR_ENC_CPY_4  8 /* 4-byte UTF-8, copy. */
-#define CHAR_ENC_ESC_4  9 /* 4-byte UTF-8, escaped as '\uXXXX\uXXXX'. */
+#define CHAR_ENC_CPY_1 0 /* 1-byte UTF-8, copy. */
+#define CHAR_ENC_ERR_1 1 /* 1-byte UTF-8, error. */
+#define CHAR_ENC_ESC_A 2 /* 1-byte ASCII, escaped as '\x'. */
+#define CHAR_ENC_ESC_1 3 /* 1-byte UTF-8, escaped as '\uXXXX'. */
+#define CHAR_ENC_CPY_2 4 /* 2-byte UTF-8, copy. */
+#define CHAR_ENC_ESC_2 5 /* 2-byte UTF-8, escaped as '\uXXXX'. */
+#define CHAR_ENC_CPY_3 6 /* 3-byte UTF-8, copy. */
+#define CHAR_ENC_ESC_3 7 /* 3-byte UTF-8, escaped as '\uXXXX'. */
+#define CHAR_ENC_CPY_4 8 /* 4-byte UTF-8, copy. */
+#define CHAR_ENC_ESC_4 9 /* 4-byte UTF-8, escaped as '\uXXXX\uXXXX'. */
 
 /** Character encode type table: don't escape unicode, don't escape '/'.
     (generate with misc/make_tables.c) */
@@ -6723,8 +7892,7 @@ static const char_enc_type enc_table_cpy[256] = {
     4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
     4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
     6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
-    8, 8, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1, 1, 1, 1
-};
+    8, 8, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1, 1, 1, 1};
 
 /** Character encode type table: don't escape unicode, escape '/'.
     (generate with misc/make_tables.c) */
@@ -6744,8 +7912,7 @@ static const char_enc_type enc_table_cpy_slash[256] = {
     4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
     4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
     6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
-    8, 8, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1, 1, 1, 1
-};
+    8, 8, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1, 1, 1, 1};
 
 /** Character encode type table: escape unicode, don't escape '/'.
     (generate with misc/make_tables.c) */
@@ -6765,8 +7932,7 @@ static const char_enc_type enc_table_esc[256] = {
     5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
     5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
     7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-    9, 9, 9, 9, 9, 9, 9, 9, 1, 1, 1, 1, 1, 1, 1, 1
-};
+    9, 9, 9, 9, 9, 9, 9, 9, 1, 1, 1, 1, 1, 1, 1, 1};
 
 /** Character encode type table: escape unicode, escape '/'.
     (generate with misc/make_tables.c) */
@@ -6786,13 +7952,11 @@ static const char_enc_type enc_table_esc_slash[256] = {
     5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
     5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
     7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-    9, 9, 9, 9, 9, 9, 9, 9, 1, 1, 1, 1, 1, 1, 1, 1
-};
+    9, 9, 9, 9, 9, 9, 9, 9, 1, 1, 1, 1, 1, 1, 1, 1};
 
 /** Escaped hex character table: ["00" "01" "02" ... "FD" "FE" "FF"].
     (generate with misc/make_tables.c) */
-yyjson_align(2)
-static const u8 esc_hex_char_table[512] = {
+yyjson_align (2) static const u8 esc_hex_char_table[512] = {
     '0', '0', '0', '1', '0', '2', '0', '3',
     '0', '4', '0', '5', '0', '6', '0', '7',
     '0', '8', '0', '9', '0', 'A', '0', 'B',
@@ -6856,12 +8020,10 @@ static const u8 esc_hex_char_table[512] = {
     'F', '0', 'F', '1', 'F', '2', 'F', '3',
     'F', '4', 'F', '5', 'F', '6', 'F', '7',
     'F', '8', 'F', '9', 'F', 'A', 'F', 'B',
-    'F', 'C', 'F', 'D', 'F', 'E', 'F', 'F'
-};
+    'F', 'C', 'F', 'D', 'F', 'E', 'F', 'F'};
 
 /** Escaped single character table. (generate with misc/make_tables.c) */
-yyjson_align(2)
-static const u8 esc_single_char_table[512] = {
+yyjson_align (2) static const u8 esc_single_char_table[512] = {
     ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
     ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
     '\\', 'b', '\\', 't', '\\', 'n', ' ', ' ',
@@ -6925,31 +8087,43 @@ static const u8 esc_single_char_table[512] = {
     ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
     ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
     ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
-    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '
-};
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '};
 
 /** Returns the encode table with options. */
-static_inline const char_enc_type *get_enc_table_with_flag(
-    yyjson_read_flag flg) {
-    if (unlikely(flg & YYJSON_WRITE_ESCAPE_UNICODE)) {
-        if (unlikely(flg & YYJSON_WRITE_ESCAPE_SLASHES)) {
-            return enc_table_esc_slash;
-        } else {
-            return enc_table_esc;
-        }
-    } else {
-        if (unlikely(flg & YYJSON_WRITE_ESCAPE_SLASHES)) {
-            return enc_table_cpy_slash;
-        } else {
-            return enc_table_cpy;
-        }
+static_inline const char_enc_type *
+get_enc_table_with_flag (
+    yyjson_read_flag flg)
+{
+  if (unlikely (flg & YYJSON_WRITE_ESCAPE_UNICODE))
+  {
+    if (unlikely (flg & YYJSON_WRITE_ESCAPE_SLASHES))
+    {
+      return enc_table_esc_slash;
     }
+    else
+    {
+      return enc_table_esc;
+    }
+  }
+  else
+  {
+    if (unlikely (flg & YYJSON_WRITE_ESCAPE_SLASHES))
+    {
+      return enc_table_cpy_slash;
+    }
+    else
+    {
+      return enc_table_cpy;
+    }
+  }
 }
 
 /** Write raw string. */
-static_inline u8 *write_raw(u8 *cur, const u8 *raw, usize raw_len) {
-    memcpy(cur, raw, raw_len);
-    return cur + raw_len;
+static_inline u8 *
+write_raw (u8 *cur, const u8 *raw, usize raw_len)
+{
+  memcpy (cur, raw, raw_len);
+  return cur + raw_len;
 }
 
 /**
@@ -6962,454 +8136,520 @@ static_inline u8 *write_raw(u8 *cur, const u8 *raw, usize raw_len) {
  @param enc_table Encode type table for character.
  @return The buffer cursor after string, or NULL on invalid unicode.
  */
-static_inline u8 *write_string(u8 *cur, bool esc, bool inv,
-                               const u8 *str, usize str_len,
-                               const char_enc_type *enc_table) {
-    
-    /* UTF-8 character mask and pattern, see `read_string()` for details. */
+static_inline u8 *
+write_string (u8 *cur, bool esc, bool inv,
+              const u8 *str, usize str_len,
+              const char_enc_type *enc_table)
+{
+
+  /* UTF-8 character mask and pattern, see `read_string()` for details. */
 #if YYJSON_ENDIAN == YYJSON_BIG_ENDIAN
-    const u16 b2_mask = 0xE0C0UL;
-    const u16 b2_patt = 0xC080UL;
-    const u16 b2_requ = 0x1E00UL;
-    const u32 b3_mask = 0xF0C0C000UL;
-    const u32 b3_patt = 0xE0808000UL;
-    const u32 b3_requ = 0x0F200000UL;
-    const u32 b3_erro = 0x0D200000UL;
-    const u32 b4_mask = 0xF8C0C0C0UL;
-    const u32 b4_patt = 0xF0808080UL;
-    const u32 b4_requ = 0x07300000UL;
-    const u32 b4_err0 = 0x04000000UL;
-    const u32 b4_err1 = 0x03300000UL;
+  const u16 b2_mask = 0xE0C0UL;
+  const u16 b2_patt = 0xC080UL;
+  const u16 b2_requ = 0x1E00UL;
+  const u32 b3_mask = 0xF0C0C000UL;
+  const u32 b3_patt = 0xE0808000UL;
+  const u32 b3_requ = 0x0F200000UL;
+  const u32 b3_erro = 0x0D200000UL;
+  const u32 b4_mask = 0xF8C0C0C0UL;
+  const u32 b4_patt = 0xF0808080UL;
+  const u32 b4_requ = 0x07300000UL;
+  const u32 b4_err0 = 0x04000000UL;
+  const u32 b4_err1 = 0x03300000UL;
 #elif YYJSON_ENDIAN == YYJSON_LITTLE_ENDIAN
-    const u16 b2_mask = 0xC0E0UL;
-    const u16 b2_patt = 0x80C0UL;
-    const u16 b2_requ = 0x001EUL;
-    const u32 b3_mask = 0x00C0C0F0UL;
-    const u32 b3_patt = 0x008080E0UL;
-    const u32 b3_requ = 0x0000200FUL;
-    const u32 b3_erro = 0x0000200DUL;
-    const u32 b4_mask = 0xC0C0C0F8UL;
-    const u32 b4_patt = 0x808080F0UL;
-    const u32 b4_requ = 0x00003007UL;
-    const u32 b4_err0 = 0x00000004UL;
-    const u32 b4_err1 = 0x00003003UL;
+  const u16 b2_mask = 0xC0E0UL;
+  const u16 b2_patt = 0x80C0UL;
+  const u16 b2_requ = 0x001EUL;
+  const u32 b3_mask = 0x00C0C0F0UL;
+  const u32 b3_patt = 0x008080E0UL;
+  const u32 b3_requ = 0x0000200FUL;
+  const u32 b3_erro = 0x0000200DUL;
+  const u32 b4_mask = 0xC0C0C0F8UL;
+  const u32 b4_patt = 0x808080F0UL;
+  const u32 b4_requ = 0x00003007UL;
+  const u32 b4_err0 = 0x00000004UL;
+  const u32 b4_err1 = 0x00003003UL;
 #else
-    v16_uni b2_mask_uni = {{ 0xE0, 0xC0 }};
-    v16_uni b2_patt_uni = {{ 0xC0, 0x80 }};
-    v16_uni b2_requ_uni = {{ 0x1E, 0x00 }};
-    v32_uni b3_mask_uni = {{ 0xF0, 0xC0, 0xC0, 0x00 }};
-    v32_uni b3_patt_uni = {{ 0xE0, 0x80, 0x80, 0x00 }};
-    v32_uni b3_requ_uni = {{ 0x0F, 0x20, 0x00, 0x00 }};
-    v32_uni b3_erro_uni = {{ 0x0D, 0x20, 0x00, 0x00 }};
-    v32_uni b4_mask_uni = {{ 0xF8, 0xC0, 0xC0, 0xC0 }};
-    v32_uni b4_patt_uni = {{ 0xF0, 0x80, 0x80, 0x80 }};
-    v32_uni b4_requ_uni = {{ 0x07, 0x30, 0x00, 0x00 }};
-    v32_uni b4_err0_uni = {{ 0x04, 0x00, 0x00, 0x00 }};
-    v32_uni b4_err1_uni = {{ 0x03, 0x30, 0x00, 0x00 }};
-    u16 b2_mask = b2_mask_uni.u;
-    u16 b2_patt = b2_patt_uni.u;
-    u16 b2_requ = b2_requ_uni.u;
-    u32 b3_mask = b3_mask_uni.u;
-    u32 b3_patt = b3_patt_uni.u;
-    u32 b3_requ = b3_requ_uni.u;
-    u32 b3_erro = b3_erro_uni.u;
-    u32 b4_mask = b4_mask_uni.u;
-    u32 b4_patt = b4_patt_uni.u;
-    u32 b4_requ = b4_requ_uni.u;
-    u32 b4_err0 = b4_err0_uni.u;
-    u32 b4_err1 = b4_err1_uni.u;
+  v16_uni b2_mask_uni = {{0xE0, 0xC0}};
+  v16_uni b2_patt_uni = {{0xC0, 0x80}};
+  v16_uni b2_requ_uni = {{0x1E, 0x00}};
+  v32_uni b3_mask_uni = {{0xF0, 0xC0, 0xC0, 0x00}};
+  v32_uni b3_patt_uni = {{0xE0, 0x80, 0x80, 0x00}};
+  v32_uni b3_requ_uni = {{0x0F, 0x20, 0x00, 0x00}};
+  v32_uni b3_erro_uni = {{0x0D, 0x20, 0x00, 0x00}};
+  v32_uni b4_mask_uni = {{0xF8, 0xC0, 0xC0, 0xC0}};
+  v32_uni b4_patt_uni = {{0xF0, 0x80, 0x80, 0x80}};
+  v32_uni b4_requ_uni = {{0x07, 0x30, 0x00, 0x00}};
+  v32_uni b4_err0_uni = {{0x04, 0x00, 0x00, 0x00}};
+  v32_uni b4_err1_uni = {{0x03, 0x30, 0x00, 0x00}};
+  u16 b2_mask         = b2_mask_uni.u;
+  u16 b2_patt         = b2_patt_uni.u;
+  u16 b2_requ         = b2_requ_uni.u;
+  u32 b3_mask         = b3_mask_uni.u;
+  u32 b3_patt         = b3_patt_uni.u;
+  u32 b3_requ         = b3_requ_uni.u;
+  u32 b3_erro         = b3_erro_uni.u;
+  u32 b4_mask         = b4_mask_uni.u;
+  u32 b4_patt         = b4_patt_uni.u;
+  u32 b4_requ         = b4_requ_uni.u;
+  u32 b4_err0         = b4_err0_uni.u;
+  u32 b4_err1         = b4_err1_uni.u;
 #endif
-    
-#define is_valid_seq_2(uni) ( \
+
+#define is_valid_seq_2(uni) (       \
     ((uni & b2_mask) == b2_patt) && \
-    ((uni & b2_requ)) \
-)
-    
-#define is_valid_seq_3(uni) ( \
+    ((uni & b2_requ)))
+
+#define is_valid_seq_3(uni) (       \
     ((uni & b3_mask) == b3_patt) && \
-    ((tmp = (uni & b3_requ))) && \
-    ((tmp != b3_erro)) \
-)
-    
-#define is_valid_seq_4(uni) ( \
+    ((tmp = (uni & b3_requ))) &&    \
+    ((tmp != b3_erro)))
+
+#define is_valid_seq_4(uni) (       \
     ((uni & b4_mask) == b4_patt) && \
-    ((tmp = (uni & b4_requ))) && \
-    ((tmp & b4_err0) == 0 || (tmp & b4_err1) == 0) \
-)
-    
-    /* The replacement character U+FFFD, used to indicate invalid character. */
-    const v32 rep = { 'F', 'F', 'F', 'D' };
-    const v32 pre = { '\\', 'u', '0', '0' };
-    
-    const u8 *src = str;
-    const u8 *end = str + str_len;
-    *cur++ = '"';
-    
+    ((tmp = (uni & b4_requ))) &&    \
+    ((tmp & b4_err0) == 0 || (tmp & b4_err1) == 0))
+
+  /* The replacement character U+FFFD, used to indicate invalid character. */
+  const v32 rep = {'F', 'F', 'F', 'D'};
+  const v32 pre = {'\\', 'u', '0', '0'};
+
+  const u8 *src = str;
+  const u8 *end = str + str_len;
+  *cur++        = '"';
+
 copy_ascii:
-    /*
-     Copy continuous ASCII, loop unrolling, same as the following code:
-     
-         while (end > src) (
-            if (unlikely(enc_table[*src])) break;
-            *cur++ = *src++;
-         );
-     */
-#define expr_jump(i) \
-    if (unlikely(enc_table[src[i]])) goto stop_char_##i;
-    
-#define expr_stop(i) \
-    stop_char_##i: \
-    memcpy(cur, src, i); \
-    cur += i; src += i; goto copy_utf8;
-    
-    while (end - src >= 16) {
-        repeat16_incr(expr_jump)
-        byte_copy_16(cur, src);
-        cur += 16; src += 16;
-    }
-    
-    while (end - src >= 4) {
-        repeat4_incr(expr_jump)
-        byte_copy_4(cur, src);
-        cur += 4; src += 4;
-    }
-    
-    while (end > src) {
-        expr_jump(0)
+  /*
+   Copy continuous ASCII, loop unrolling, same as the following code:
+
+       while (end > src) (
+          if (unlikely(enc_table[*src])) break;
+          *cur++ = *src++;
+       );
+   */
+#define expr_jump(i)                \
+  if (unlikely (enc_table[src[i]])) \
+    goto stop_char_##i;
+
+#define expr_stop(i)                    \
+  stop_char_##i : memcpy (cur, src, i); \
+  cur += i;                             \
+  src += i;                             \
+  goto copy_utf8;
+
+  while (end - src >= 16)
+  {
+    repeat16_incr (expr_jump)
+        byte_copy_16 (cur, src);
+    cur += 16;
+    src += 16;
+  }
+
+  while (end - src >= 4)
+  {
+    repeat4_incr (expr_jump)
+        byte_copy_4 (cur, src);
+    cur += 4;
+    src += 4;
+  }
+
+  while (end > src)
+  {
+    expr_jump (0)
         *cur++ = *src++;
-    }
-    
-    *cur++ = '"';
-    return cur;
-    
-    repeat16_incr(expr_stop)
-    
+  }
+
+  *cur++ = '"';
+  return cur;
+
+  repeat16_incr (expr_stop)
+
 #undef expr_jump
 #undef expr_stop
-    
-copy_utf8:
-    if (unlikely(src + 4 > end)) {
-        if (end == src) goto copy_end;
-        if (end - src < enc_table[*src] / 2) goto err_one;
-    }
-    switch (enc_table[*src]) {
-        case CHAR_ENC_CPY_1: {
-            *cur++ = *src++;
-            goto copy_ascii;
-        }
-        case CHAR_ENC_CPY_2: {
-            u16 v;
-            v = byte_load_2(src);
-            if (unlikely(!is_valid_seq_2(v))) goto err_cpy;
-            
-            byte_copy_2(cur, src);
-            cur += 2;
-            src += 2;
-            goto copy_utf8;
-        }
-        case CHAR_ENC_CPY_3: {
-            u32 v, tmp;
-            if (likely(src + 4 <= end)) {
-                v = byte_load_4(src);
-                if (unlikely(!is_valid_seq_3(v))) goto err_cpy;
-                byte_copy_4(cur, src);
-            } else {
-                v = byte_load_3(src);
-                if (unlikely(!is_valid_seq_3(v))) goto err_cpy;
-                byte_copy_4(cur, &v);
-            }
-            cur += 3;
-            src += 3;
-            goto copy_utf8;
-        }
-        case CHAR_ENC_CPY_4: {
-            u32 v, tmp;
-            v = byte_load_4(src);
-            if (unlikely(!is_valid_seq_4(v))) goto err_cpy;
-            
-            byte_copy_4(cur, src);
-            cur += 4;
-            src += 4;
-            goto copy_utf8;
-        }
-        case CHAR_ENC_ESC_A: {
-            byte_move_2(cur, &esc_single_char_table[*src * 2]);
-            cur += 2;
-            src += 1;
-            goto copy_utf8;
-        }
-        case CHAR_ENC_ESC_1: {
-            byte_copy_4(cur + 0, &pre);
-            byte_copy_2(cur + 4, &esc_hex_char_table[*src * 2]);
-            cur += 6;
-            src += 1;
-            goto copy_utf8;
-        }
-        case CHAR_ENC_ESC_2: {
-            u16 u, v;
-            v = byte_load_2(src);
-            if (unlikely(!is_valid_seq_2(v))) goto err_esc;
-            
-            u = (u16)(((u16)(src[0] & 0x1F) << 6) |
-                      ((u16)(src[1] & 0x3F) << 0));
-            byte_copy_2(cur + 0, &pre);
-            byte_copy_2(cur + 2, &esc_hex_char_table[(u >> 8) * 2]);
-            byte_copy_2(cur + 4, &esc_hex_char_table[(u & 0xFF) * 2]);
-            cur += 6;
-            src += 2;
-            goto copy_utf8;
-        }
-        case CHAR_ENC_ESC_3: {
-            u16 u;
-            u32 v, tmp;
-            v = byte_load_3(src);
-            if (unlikely(!is_valid_seq_3(v))) goto err_esc;
-            
-            u = (u16)(((u16)(src[0] & 0x0F) << 12) |
-                      ((u16)(src[1] & 0x3F) << 6) |
-                      ((u16)(src[2] & 0x3F) << 0));
-            byte_copy_2(cur + 0, &pre);
-            byte_copy_2(cur + 2, &esc_hex_char_table[(u >> 8) * 2]);
-            byte_copy_2(cur + 4, &esc_hex_char_table[(u & 0xFF) * 2]);
-            cur += 6;
-            src += 3;
-            goto copy_utf8;
-        }
-        case CHAR_ENC_ESC_4: {
-            u32 hi, lo, u, v, tmp;
-            v = byte_load_4(src);
-            if (unlikely(!is_valid_seq_4(v))) goto err_esc;
-            
-            u = ((u32)(src[0] & 0x07) << 18) |
-                ((u32)(src[1] & 0x3F) << 12) |
-                ((u32)(src[2] & 0x3F) << 6) |
-                ((u32)(src[3] & 0x3F) << 0);
-            u -= 0x10000;
-            hi = (u >> 10) + 0xD800;
-            lo = (u & 0x3FF) + 0xDC00;
-            byte_copy_2(cur + 0, &pre);
-            byte_copy_2(cur + 2, &esc_hex_char_table[(hi >> 8) * 2]);
-            byte_copy_2(cur + 4, &esc_hex_char_table[(hi & 0xFF) * 2]);
-            byte_copy_2(cur + 6, &pre);
-            byte_copy_2(cur + 8, &esc_hex_char_table[(lo >> 8) * 2]);
-            byte_copy_2(cur + 10, &esc_hex_char_table[(lo & 0xFF) * 2]);
-            cur += 12;
-            src += 4;
-            goto copy_utf8;
-        }
-        case CHAR_ENC_ERR_1: {
-            goto err_one;
-        }
-        default: break;
-    }
-    
-copy_end:
-    *cur++ = '"';
-    return cur;
-    
-err_one:
-    if (esc) goto err_esc;
-    else goto err_cpy;
-    
-err_cpy:
-    if (!inv) return NULL;
+
+      copy_utf8 : if (unlikely (src + 4 > end))
+  {
+    if (end == src)
+      goto copy_end;
+    if (end - src < enc_table[*src] / 2)
+      goto err_one;
+  }
+  switch (enc_table[*src])
+  {
+  case CHAR_ENC_CPY_1:
+  {
     *cur++ = *src++;
+    goto copy_ascii;
+  }
+  case CHAR_ENC_CPY_2:
+  {
+    u16 v;
+    v = byte_load_2 (src);
+    if (unlikely (!is_valid_seq_2 (v)))
+      goto err_cpy;
+
+    byte_copy_2 (cur, src);
+    cur += 2;
+    src += 2;
     goto copy_utf8;
-    
-err_esc:
-    if (!inv) return NULL;
-    byte_copy_2(cur + 0, &pre);
-    byte_copy_4(cur + 2, &rep);
+  }
+  case CHAR_ENC_CPY_3:
+  {
+    u32 v, tmp;
+    if (likely (src + 4 <= end))
+    {
+      v = byte_load_4 (src);
+      if (unlikely (!is_valid_seq_3 (v)))
+        goto err_cpy;
+      byte_copy_4 (cur, src);
+    }
+    else
+    {
+      v = byte_load_3 (src);
+      if (unlikely (!is_valid_seq_3 (v)))
+        goto err_cpy;
+      byte_copy_4 (cur, &v);
+    }
+    cur += 3;
+    src += 3;
+    goto copy_utf8;
+  }
+  case CHAR_ENC_CPY_4:
+  {
+    u32 v, tmp;
+    v = byte_load_4 (src);
+    if (unlikely (!is_valid_seq_4 (v)))
+      goto err_cpy;
+
+    byte_copy_4 (cur, src);
+    cur += 4;
+    src += 4;
+    goto copy_utf8;
+  }
+  case CHAR_ENC_ESC_A:
+  {
+    byte_move_2 (cur, &esc_single_char_table[*src * 2]);
+    cur += 2;
+    src += 1;
+    goto copy_utf8;
+  }
+  case CHAR_ENC_ESC_1:
+  {
+    byte_copy_4 (cur + 0, &pre);
+    byte_copy_2 (cur + 4, &esc_hex_char_table[*src * 2]);
     cur += 6;
     src += 1;
     goto copy_utf8;
-    
+  }
+  case CHAR_ENC_ESC_2:
+  {
+    u16 u, v;
+    v = byte_load_2 (src);
+    if (unlikely (!is_valid_seq_2 (v)))
+      goto err_esc;
+
+    u = (u16)(((u16)(src[0] & 0x1F) << 6) |
+              ((u16)(src[1] & 0x3F) << 0));
+    byte_copy_2 (cur + 0, &pre);
+    byte_copy_2 (cur + 2, &esc_hex_char_table[(u >> 8) * 2]);
+    byte_copy_2 (cur + 4, &esc_hex_char_table[(u & 0xFF) * 2]);
+    cur += 6;
+    src += 2;
+    goto copy_utf8;
+  }
+  case CHAR_ENC_ESC_3:
+  {
+    u16 u;
+    u32 v, tmp;
+    v = byte_load_3 (src);
+    if (unlikely (!is_valid_seq_3 (v)))
+      goto err_esc;
+
+    u = (u16)(((u16)(src[0] & 0x0F) << 12) |
+              ((u16)(src[1] & 0x3F) << 6) |
+              ((u16)(src[2] & 0x3F) << 0));
+    byte_copy_2 (cur + 0, &pre);
+    byte_copy_2 (cur + 2, &esc_hex_char_table[(u >> 8) * 2]);
+    byte_copy_2 (cur + 4, &esc_hex_char_table[(u & 0xFF) * 2]);
+    cur += 6;
+    src += 3;
+    goto copy_utf8;
+  }
+  case CHAR_ENC_ESC_4:
+  {
+    u32 hi, lo, u, v, tmp;
+    v = byte_load_4 (src);
+    if (unlikely (!is_valid_seq_4 (v)))
+      goto err_esc;
+
+    u = ((u32)(src[0] & 0x07) << 18) |
+        ((u32)(src[1] & 0x3F) << 12) |
+        ((u32)(src[2] & 0x3F) << 6) |
+        ((u32)(src[3] & 0x3F) << 0);
+    u -= 0x10000;
+    hi = (u >> 10) + 0xD800;
+    lo = (u & 0x3FF) + 0xDC00;
+    byte_copy_2 (cur + 0, &pre);
+    byte_copy_2 (cur + 2, &esc_hex_char_table[(hi >> 8) * 2]);
+    byte_copy_2 (cur + 4, &esc_hex_char_table[(hi & 0xFF) * 2]);
+    byte_copy_2 (cur + 6, &pre);
+    byte_copy_2 (cur + 8, &esc_hex_char_table[(lo >> 8) * 2]);
+    byte_copy_2 (cur + 10, &esc_hex_char_table[(lo & 0xFF) * 2]);
+    cur += 12;
+    src += 4;
+    goto copy_utf8;
+  }
+  case CHAR_ENC_ERR_1:
+  {
+    goto err_one;
+  }
+  default:
+    break;
+  }
+
+copy_end:
+  *cur++ = '"';
+  return cur;
+
+err_one:
+  if (esc)
+    goto err_esc;
+  else
+    goto err_cpy;
+
+err_cpy:
+  if (!inv)
+    return NULL;
+  *cur++ = *src++;
+  goto copy_utf8;
+
+err_esc:
+  if (!inv)
+    return NULL;
+  byte_copy_2 (cur + 0, &pre);
+  byte_copy_4 (cur + 2, &rep);
+  cur += 6;
+  src += 1;
+  goto copy_utf8;
+
 #undef is_valid_seq_2
 #undef is_valid_seq_3
 #undef is_valid_seq_4
 }
-
-
 
 /*==============================================================================
  * Writer Utilities
  *============================================================================*/
 
 /** Write null (requires 8 bytes buffer). */
-static_inline u8 *write_null(u8 *cur) {
-    v64 v = { 'n', 'u', 'l', 'l', ',', '\n', 0, 0 };
-    byte_copy_8(cur, &v);
-    return cur + 4;
+static_inline u8 *
+write_null (u8 *cur)
+{
+  v64 v = {'n', 'u', 'l', 'l', ',', '\n', 0, 0};
+  byte_copy_8 (cur, &v);
+  return cur + 4;
 }
 
 /** Write bool (requires 8 bytes buffer). */
-static_inline u8 *write_bool(u8 *cur, bool val) {
-    v64 v0 = { 'f', 'a', 'l', 's', 'e', ',', '\n', 0 };
-    v64 v1 = { 't', 'r', 'u', 'e', ',', '\n', 0, 0 };
-    if (val) {
-        byte_copy_8(cur, &v1);
-    } else {
-        byte_copy_8(cur, &v0);
-    }
-    return cur + 5 - val;
+static_inline u8 *
+write_bool (u8 *cur, bool val)
+{
+  v64 v0 = {'f', 'a', 'l', 's', 'e', ',', '\n', 0};
+  v64 v1 = {'t', 'r', 'u', 'e', ',', '\n', 0, 0};
+  if (val)
+  {
+    byte_copy_8 (cur, &v1);
+  }
+  else
+  {
+    byte_copy_8 (cur, &v0);
+  }
+  return cur + 5 - val;
 }
 
 /** Write indent (requires level x 4 bytes buffer).
     Param spaces should not larger than 4. */
-static_inline u8 *write_indent(u8 *cur, usize level, usize spaces) {
-    while (level-- > 0) {
-        byte_copy_4(cur, "    ");
-        cur += spaces;
-    }
-    return cur;
+static_inline u8 *
+write_indent (u8 *cur, usize level, usize spaces)
+{
+  while (level-- > 0)
+  {
+    byte_copy_4 (cur, "    ");
+    cur += spaces;
+  }
+  return cur;
 }
 
 /** Write data to file. */
-static bool write_dat_to_file(const char *path, u8 *dat, usize len,
-                              yyjson_write_err *err) {
-    
-#define return_err(_code, _msg) do { \
-    err->msg = _msg; \
+static bool
+write_dat_to_file (const char *path, u8 *dat, usize len,
+                   yyjson_write_err *err)
+{
+
+#define return_err(_code, _msg)             \
+  do                                        \
+  {                                         \
+    err->msg  = _msg;                       \
     err->code = YYJSON_WRITE_ERROR_##_code; \
-    if (file) fclose(file); \
-    return false; \
-} while (false)
-    
-    FILE *file = fopen_writeonly(path);
-    if (file == NULL) {
-        return_err(FILE_OPEN, "file opening failed");
-    }
-    if (fwrite(dat, len, 1, file) != 1) {
-        return_err(FILE_WRITE, "file writing failed");
-    }
-    if (fclose(file) != 0) {
-        file = NULL;
-        return_err(FILE_WRITE, "file closing failed");
-    }
-    return true;
-    
+    if (file)                               \
+      fclose (file);                        \
+    return false;                           \
+  } while (false)
+
+  FILE *file = fopen_writeonly (path);
+  if (file == NULL)
+  {
+    return_err (FILE_OPEN, "file opening failed");
+  }
+  if (fwrite (dat, len, 1, file) != 1)
+  {
+    return_err (FILE_WRITE, "file writing failed");
+  }
+  if (fclose (file) != 0)
+  {
+    file = NULL;
+    return_err (FILE_WRITE, "file closing failed");
+  }
+  return true;
+
 #undef return_err
 }
-
-
 
 /*==============================================================================
  * JSON Writer Implementation
  *============================================================================*/
 
-typedef struct yyjson_write_ctx {
-    usize tag;
+typedef struct yyjson_write_ctx
+{
+  usize tag;
 } yyjson_write_ctx;
 
-static_inline void yyjson_write_ctx_set(yyjson_write_ctx *ctx,
-                                        usize size, bool is_obj) {
-    ctx->tag = (size << 1) | (usize)is_obj;
+static_inline void
+yyjson_write_ctx_set (yyjson_write_ctx *ctx,
+                      usize size, bool is_obj)
+{
+  ctx->tag = (size << 1) | (usize)is_obj;
 }
 
-static_inline void yyjson_write_ctx_get(yyjson_write_ctx *ctx,
-                                        usize *size, bool *is_obj) {
-    usize tag = ctx->tag;
-    *size = tag >> 1;
-    *is_obj = (bool)(tag & 1);
+static_inline void
+yyjson_write_ctx_get (yyjson_write_ctx *ctx,
+                      usize *size, bool *is_obj)
+{
+  usize tag = ctx->tag;
+  *size     = tag >> 1;
+  *is_obj   = (bool)(tag & 1);
 }
 
 /** Write single JSON value. */
-static_inline u8 *yyjson_write_single(yyjson_val *val,
-                                      yyjson_write_flag flg,
-                                      yyjson_alc alc,
-                                      usize *dat_len,
-                                      yyjson_write_err *err) {
-    
-#define return_err(_code, _msg) do { \
-    if (hdr) alc.free(alc.ctx, (void *)hdr); \
-    *dat_len = 0; \
+static_inline u8 *
+yyjson_write_single (yyjson_val *val,
+                     yyjson_write_flag flg,
+                     yyjson_alc alc,
+                     usize *dat_len,
+                     yyjson_write_err *err)
+{
+
+#define return_err(_code, _msg)             \
+  do                                        \
+  {                                         \
+    if (hdr)                                \
+      alc.free (alc.ctx, (void *)hdr);      \
+    *dat_len  = 0;                          \
     err->code = YYJSON_WRITE_ERROR_##_code; \
-    err->msg = _msg; \
-    return NULL; \
-} while (false)
-    
-#define incr_len(_len) do { \
-    hdr = (u8 *)alc.malloc(alc.ctx, _len); \
-    if (!hdr) goto fail_alloc; \
-    cur = hdr; \
-} while (false)
-    
-#define check_str_len(_len) do { \
+    err->msg  = _msg;                       \
+    return NULL;                            \
+  } while (false)
+
+#define incr_len(_len)                      \
+  do                                        \
+  {                                         \
+    hdr = (u8 *)alc.malloc (alc.ctx, _len); \
+    if (!hdr)                               \
+      goto fail_alloc;                      \
+    cur = hdr;                              \
+  } while (false)
+
+#define check_str_len(_len)                                      \
+  do                                                             \
+  {                                                              \
     if ((USIZE_MAX < U64_MAX) && (_len >= (USIZE_MAX - 16) / 6)) \
-        goto fail_alloc; \
-} while (false)
-    
-    u8 *hdr = NULL, *cur;
-    usize str_len;
-    const u8 *str_ptr;
-    const char_enc_type *enc_table = get_enc_table_with_flag(flg);
-    bool esc = (flg & YYJSON_WRITE_ESCAPE_UNICODE) != 0;
-    bool inv = (flg & YYJSON_WRITE_ALLOW_INVALID_UNICODE) != 0;
-    
-    switch (unsafe_yyjson_get_type(val)) {
-        case YYJSON_TYPE_RAW:
-            str_len = unsafe_yyjson_get_len(val);
-            str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-            check_str_len(str_len);
-            incr_len(str_len + 1);
-            cur = write_raw(cur, str_ptr, str_len);
-            break;
-            
-        case YYJSON_TYPE_STR:
-            str_len = unsafe_yyjson_get_len(val);
-            str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-            check_str_len(str_len);
-            incr_len(str_len * 6 + 4);
-            cur = write_string(cur, esc, inv, str_ptr, str_len, enc_table);
-            if (unlikely(!cur)) goto fail_str;
-            break;
-            
-        case YYJSON_TYPE_NUM:
-            incr_len(32);
-            cur = write_number(cur, val, flg);
-            if (unlikely(!cur)) goto fail_num;
-            break;
-            
-        case YYJSON_TYPE_BOOL:
-            incr_len(8);
-            cur = write_bool(cur, unsafe_yyjson_get_bool(val));
-            break;
-            
-        case YYJSON_TYPE_NULL:
-            incr_len(8);
-            cur = write_null(cur);
-            break;
-            
-        case YYJSON_TYPE_ARR:
-            incr_len(4);
-            byte_copy_2(cur, "[]");
-            cur += 2;
-            break;
-            
-        case YYJSON_TYPE_OBJ:
-            incr_len(4);
-            byte_copy_2(cur, "{}");
-            cur += 2;
-            break;
-            
-        default:
-            goto fail_type;
-    }
-    
-    *cur = '\0';
-    *dat_len = (usize)(cur - hdr);
-    memset(err, 0, sizeof(yyjson_write_err));
-    return hdr;
-    
+      goto fail_alloc;                                           \
+  } while (false)
+
+  u8 *hdr = NULL, *cur;
+  usize str_len;
+  const u8 *str_ptr;
+  const char_enc_type *enc_table = get_enc_table_with_flag (flg);
+  bool esc                       = (flg & YYJSON_WRITE_ESCAPE_UNICODE) != 0;
+  bool inv                       = (flg & YYJSON_WRITE_ALLOW_INVALID_UNICODE) != 0;
+
+  switch (unsafe_yyjson_get_type (val))
+  {
+  case YYJSON_TYPE_RAW:
+    str_len = unsafe_yyjson_get_len (val);
+    str_ptr = (const u8 *)unsafe_yyjson_get_str (val);
+    check_str_len (str_len);
+    incr_len (str_len + 1);
+    cur = write_raw (cur, str_ptr, str_len);
+    break;
+
+  case YYJSON_TYPE_STR:
+    str_len = unsafe_yyjson_get_len (val);
+    str_ptr = (const u8 *)unsafe_yyjson_get_str (val);
+    check_str_len (str_len);
+    incr_len (str_len * 6 + 4);
+    cur = write_string (cur, esc, inv, str_ptr, str_len, enc_table);
+    if (unlikely (!cur))
+      goto fail_str;
+    break;
+
+  case YYJSON_TYPE_NUM:
+    incr_len (32);
+    cur = write_number (cur, val, flg);
+    if (unlikely (!cur))
+      goto fail_num;
+    break;
+
+  case YYJSON_TYPE_BOOL:
+    incr_len (8);
+    cur = write_bool (cur, unsafe_yyjson_get_bool (val));
+    break;
+
+  case YYJSON_TYPE_NULL:
+    incr_len (8);
+    cur = write_null (cur);
+    break;
+
+  case YYJSON_TYPE_ARR:
+    incr_len (4);
+    byte_copy_2 (cur, "[]");
+    cur += 2;
+    break;
+
+  case YYJSON_TYPE_OBJ:
+    incr_len (4);
+    byte_copy_2 (cur, "{}");
+    cur += 2;
+    break;
+
+  default:
+    goto fail_type;
+  }
+
+  *cur     = '\0';
+  *dat_len = (usize)(cur - hdr);
+  memset (err, 0, sizeof (yyjson_write_err));
+  return hdr;
+
 fail_alloc:
-    return_err(MEMORY_ALLOCATION, "memory allocation failed");
+  return_err (MEMORY_ALLOCATION, "memory allocation failed");
 fail_type:
-    return_err(INVALID_VALUE_TYPE, "invalid JSON value type");
+  return_err (INVALID_VALUE_TYPE, "invalid JSON value type");
 fail_num:
-    return_err(NAN_OR_INF, "nan or inf number is not allowed");
+  return_err (NAN_OR_INF, "nan or inf number is not allowed");
 fail_str:
-    return_err(INVALID_STRING, "invalid utf-8 encoding in string");
-    
+  return_err (INVALID_STRING, "invalid utf-8 encoding in string");
+
 #undef return_err
 #undef check_str_len
 #undef incr_len
@@ -7417,171 +8657,200 @@ fail_str:
 
 /** Write JSON document minify.
     The root of this document should be a non-empty container. */
-static_inline u8 *yyjson_write_minify(const yyjson_val *root,
-                                      const yyjson_write_flag flg,
-                                      const yyjson_alc alc,
-                                      usize *dat_len,
-                                      yyjson_write_err *err) {
-    
-#define return_err(_code, _msg) do { \
-    *dat_len = 0; \
+static_inline u8 *
+yyjson_write_minify (const yyjson_val *root,
+                     const yyjson_write_flag flg,
+                     const yyjson_alc alc,
+                     usize *dat_len,
+                     yyjson_write_err *err)
+{
+
+#define return_err(_code, _msg)             \
+  do                                        \
+  {                                         \
+    *dat_len  = 0;                          \
     err->code = YYJSON_WRITE_ERROR_##_code; \
-    err->msg = _msg; \
-    if (hdr) alc.free(alc.ctx, hdr); \
-    return NULL; \
-} while (false)
-    
-#define incr_len(_len) do { \
-    ext_len = (usize)(_len); \
-    if (unlikely((u8 *)(cur + ext_len) >= (u8 *)ctx)) { \
-        alc_inc = yyjson_max(alc_len / 2, ext_len); \
-        alc_inc = size_align_up(alc_inc, sizeof(yyjson_write_ctx)); \
-        if (size_add_is_overflow(alc_len, alc_inc)) goto fail_alloc; \
-        alc_len += alc_inc; \
-        tmp = (u8 *)alc.realloc(alc.ctx, hdr, alc_len - alc_inc, alc_len); \
-        if (unlikely(!tmp)) goto fail_alloc; \
-        ctx_len = (usize)(end - (u8 *)ctx); \
-        ctx_tmp = (yyjson_write_ctx *)(void *)(tmp + (alc_len - ctx_len)); \
-        memmove((void *)ctx_tmp, (void *)(tmp + ((u8 *)ctx - hdr)), ctx_len); \
-        ctx = ctx_tmp; \
-        cur = tmp + (cur - hdr); \
-        end = tmp + alc_len; \
-        hdr = tmp; \
-    } \
-} while (false)
-    
-#define check_str_len(_len) do { \
+    err->msg  = _msg;                       \
+    if (hdr)                                \
+      alc.free (alc.ctx, hdr);              \
+    return NULL;                            \
+  } while (false)
+
+#define incr_len(_len)                                                       \
+  do                                                                         \
+  {                                                                          \
+    ext_len = (usize)(_len);                                                 \
+    if (unlikely ((u8 *)(cur + ext_len) >= (u8 *)ctx))                       \
+    {                                                                        \
+      alc_inc = yyjson_max (alc_len / 2, ext_len);                           \
+      alc_inc = size_align_up (alc_inc, sizeof (yyjson_write_ctx));          \
+      if (size_add_is_overflow (alc_len, alc_inc))                           \
+        goto fail_alloc;                                                     \
+      alc_len += alc_inc;                                                    \
+      tmp = (u8 *)alc.realloc (alc.ctx, hdr, alc_len - alc_inc, alc_len);    \
+      if (unlikely (!tmp))                                                   \
+        goto fail_alloc;                                                     \
+      ctx_len = (usize)(end - (u8 *)ctx);                                    \
+      ctx_tmp = (yyjson_write_ctx *)(void *)(tmp + (alc_len - ctx_len));     \
+      memmove ((void *)ctx_tmp, (void *)(tmp + ((u8 *)ctx - hdr)), ctx_len); \
+      ctx = ctx_tmp;                                                         \
+      cur = tmp + (cur - hdr);                                               \
+      end = tmp + alc_len;                                                   \
+      hdr = tmp;                                                             \
+    }                                                                        \
+  } while (false)
+
+#define check_str_len(_len)                                      \
+  do                                                             \
+  {                                                              \
     if ((USIZE_MAX < U64_MAX) && (_len >= (USIZE_MAX - 16) / 6)) \
-        goto fail_alloc; \
-} while (false)
-    
-    yyjson_val *val;
-    yyjson_type val_type;
-    usize ctn_len, ctn_len_tmp;
-    bool ctn_obj, ctn_obj_tmp, is_key;
-    u8 *hdr, *cur, *end, *tmp;
-    yyjson_write_ctx *ctx, *ctx_tmp;
-    usize alc_len, alc_inc, ctx_len, ext_len, str_len;
-    const u8 *str_ptr;
-    const char_enc_type *enc_table = get_enc_table_with_flag(flg);
-    bool esc = (flg & YYJSON_WRITE_ESCAPE_UNICODE) != 0;
-    bool inv = (flg & YYJSON_WRITE_ALLOW_INVALID_UNICODE) != 0;
-    
-    alc_len = root->uni.ofs / sizeof(yyjson_val);
-    alc_len = alc_len * YYJSON_WRITER_ESTIMATED_MINIFY_RATIO + 64;
-    alc_len = size_align_up(alc_len, sizeof(yyjson_write_ctx));
-    hdr = (u8 *)alc.malloc(alc.ctx, alc_len);
-    if (!hdr) goto fail_alloc;
-    cur = hdr;
-    end = hdr + alc_len;
-    ctx = (yyjson_write_ctx *)(void *)end;
-    
+      goto fail_alloc;                                           \
+  } while (false)
+
+  yyjson_val *val;
+  yyjson_type val_type;
+  usize ctn_len, ctn_len_tmp;
+  bool ctn_obj, ctn_obj_tmp, is_key;
+  u8 *hdr, *cur, *end, *tmp;
+  yyjson_write_ctx *ctx, *ctx_tmp;
+  usize alc_len, alc_inc, ctx_len, ext_len, str_len;
+  const u8 *str_ptr;
+  const char_enc_type *enc_table = get_enc_table_with_flag (flg);
+  bool esc                       = (flg & YYJSON_WRITE_ESCAPE_UNICODE) != 0;
+  bool inv                       = (flg & YYJSON_WRITE_ALLOW_INVALID_UNICODE) != 0;
+
+  alc_len = root->uni.ofs / sizeof (yyjson_val);
+  alc_len = alc_len * YYJSON_WRITER_ESTIMATED_MINIFY_RATIO + 64;
+  alc_len = size_align_up (alc_len, sizeof (yyjson_write_ctx));
+  hdr     = (u8 *)alc.malloc (alc.ctx, alc_len);
+  if (!hdr)
+    goto fail_alloc;
+  cur = hdr;
+  end = hdr + alc_len;
+  ctx = (yyjson_write_ctx *)(void *)end;
+
 doc_begin:
-    val = constcast(yyjson_val *)root;
-    val_type = unsafe_yyjson_get_type(val);
-    ctn_obj = (val_type == YYJSON_TYPE_OBJ);
-    ctn_len = unsafe_yyjson_get_len(val) << (u8)ctn_obj;
-    *cur++ = (u8)('[' | ((u8)ctn_obj << 5));
-    val++;
-    
+  val      = constcast (yyjson_val *) root;
+  val_type = unsafe_yyjson_get_type (val);
+  ctn_obj  = (val_type == YYJSON_TYPE_OBJ);
+  ctn_len  = unsafe_yyjson_get_len (val) << (u8)ctn_obj;
+  *cur++   = (u8)('[' | ((u8)ctn_obj << 5));
+  val++;
+
 val_begin:
-    val_type = unsafe_yyjson_get_type(val);
-    if (val_type == YYJSON_TYPE_STR) {
-        is_key = ((u8)ctn_obj & (u8)~ctn_len);
-        str_len = unsafe_yyjson_get_len(val);
-        str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-        check_str_len(str_len);
-        incr_len(str_len * 6 + 16);
-        cur = write_string(cur, esc, inv, str_ptr, str_len, enc_table);
-        if (unlikely(!cur)) goto fail_str;
-        *cur++ = is_key ? ':' : ',';
-        goto val_end;
-    }
-    if (val_type == YYJSON_TYPE_NUM) {
-        incr_len(32);
-        cur = write_number(cur, val, flg);
-        if (unlikely(!cur)) goto fail_num;
-        *cur++ = ',';
-        goto val_end;
-    }
-    if ((val_type & (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) ==
-                    (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) {
-        ctn_len_tmp = unsafe_yyjson_get_len(val);
-        ctn_obj_tmp = (val_type == YYJSON_TYPE_OBJ);
-        incr_len(16);
-        if (unlikely(ctn_len_tmp == 0)) {
-            /* write empty container */
-            *cur++ = (u8)('[' | ((u8)ctn_obj_tmp << 5));
-            *cur++ = (u8)(']' | ((u8)ctn_obj_tmp << 5));
-            *cur++ = ',';
-            goto val_end;
-        } else {
-            /* push context, setup new container */
-            yyjson_write_ctx_set(--ctx, ctn_len, ctn_obj);
-            ctn_len = ctn_len_tmp << (u8)ctn_obj_tmp;
-            ctn_obj = ctn_obj_tmp;
-            *cur++ = (u8)('[' | ((u8)ctn_obj << 5));
-            val++;
-            goto val_begin;
-        }
-    }
-    if (val_type == YYJSON_TYPE_BOOL) {
-        incr_len(16);
-        cur = write_bool(cur, unsafe_yyjson_get_bool(val));
-        cur++;
-        goto val_end;
-    }
-    if (val_type == YYJSON_TYPE_NULL) {
-        incr_len(16);
-        cur = write_null(cur);
-        cur++;
-        goto val_end;
-    }
-    if (val_type == YYJSON_TYPE_RAW) {
-        str_len = unsafe_yyjson_get_len(val);
-        str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-        check_str_len(str_len);
-        incr_len(str_len + 2);
-        cur = write_raw(cur, str_ptr, str_len);
-        *cur++ = ',';
-        goto val_end;
-    }
-    goto fail_type;
-    
-val_end:
-    val++;
-    ctn_len--;
-    if (unlikely(ctn_len == 0)) goto ctn_end;
-    goto val_begin;
-    
-ctn_end:
-    cur--;
-    *cur++ = (u8)(']' | ((u8)ctn_obj << 5));
+  val_type = unsafe_yyjson_get_type (val);
+  if (val_type == YYJSON_TYPE_STR)
+  {
+    is_key  = ((u8)ctn_obj & (u8)~ctn_len);
+    str_len = unsafe_yyjson_get_len (val);
+    str_ptr = (const u8 *)unsafe_yyjson_get_str (val);
+    check_str_len (str_len);
+    incr_len (str_len * 6 + 16);
+    cur = write_string (cur, esc, inv, str_ptr, str_len, enc_table);
+    if (unlikely (!cur))
+      goto fail_str;
+    *cur++ = is_key ? ':' : ',';
+    goto val_end;
+  }
+  if (val_type == YYJSON_TYPE_NUM)
+  {
+    incr_len (32);
+    cur = write_number (cur, val, flg);
+    if (unlikely (!cur))
+      goto fail_num;
     *cur++ = ',';
-    if (unlikely((u8 *)ctx >= end)) goto doc_end;
-    yyjson_write_ctx_get(ctx++, &ctn_len, &ctn_obj);
-    ctn_len--;
-    if (likely(ctn_len > 0)) {
-        goto val_begin;
-    } else {
-        goto ctn_end;
+    goto val_end;
+  }
+  if ((val_type & (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) ==
+      (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ))
+  {
+    ctn_len_tmp = unsafe_yyjson_get_len (val);
+    ctn_obj_tmp = (val_type == YYJSON_TYPE_OBJ);
+    incr_len (16);
+    if (unlikely (ctn_len_tmp == 0))
+    {
+      /* write empty container */
+      *cur++ = (u8)('[' | ((u8)ctn_obj_tmp << 5));
+      *cur++ = (u8)(']' | ((u8)ctn_obj_tmp << 5));
+      *cur++ = ',';
+      goto val_end;
     }
-    
+    else
+    {
+      /* push context, setup new container */
+      yyjson_write_ctx_set (--ctx, ctn_len, ctn_obj);
+      ctn_len = ctn_len_tmp << (u8)ctn_obj_tmp;
+      ctn_obj = ctn_obj_tmp;
+      *cur++  = (u8)('[' | ((u8)ctn_obj << 5));
+      val++;
+      goto val_begin;
+    }
+  }
+  if (val_type == YYJSON_TYPE_BOOL)
+  {
+    incr_len (16);
+    cur = write_bool (cur, unsafe_yyjson_get_bool (val));
+    cur++;
+    goto val_end;
+  }
+  if (val_type == YYJSON_TYPE_NULL)
+  {
+    incr_len (16);
+    cur = write_null (cur);
+    cur++;
+    goto val_end;
+  }
+  if (val_type == YYJSON_TYPE_RAW)
+  {
+    str_len = unsafe_yyjson_get_len (val);
+    str_ptr = (const u8 *)unsafe_yyjson_get_str (val);
+    check_str_len (str_len);
+    incr_len (str_len + 2);
+    cur    = write_raw (cur, str_ptr, str_len);
+    *cur++ = ',';
+    goto val_end;
+  }
+  goto fail_type;
+
+val_end:
+  val++;
+  ctn_len--;
+  if (unlikely (ctn_len == 0))
+    goto ctn_end;
+  goto val_begin;
+
+ctn_end:
+  cur--;
+  *cur++ = (u8)(']' | ((u8)ctn_obj << 5));
+  *cur++ = ',';
+  if (unlikely ((u8 *)ctx >= end))
+    goto doc_end;
+  yyjson_write_ctx_get (ctx++, &ctn_len, &ctn_obj);
+  ctn_len--;
+  if (likely (ctn_len > 0))
+  {
+    goto val_begin;
+  }
+  else
+  {
+    goto ctn_end;
+  }
+
 doc_end:
-    *--cur = '\0';
-    *dat_len = (usize)(cur - hdr);
-    memset(err, 0, sizeof(yyjson_write_err));
-    return hdr;
-    
+  *--cur   = '\0';
+  *dat_len = (usize)(cur - hdr);
+  memset (err, 0, sizeof (yyjson_write_err));
+  return hdr;
+
 fail_alloc:
-    return_err(MEMORY_ALLOCATION, "memory allocation failed");
+  return_err (MEMORY_ALLOCATION, "memory allocation failed");
 fail_type:
-    return_err(INVALID_VALUE_TYPE, "invalid JSON value type");
+  return_err (INVALID_VALUE_TYPE, "invalid JSON value type");
 fail_num:
-    return_err(NAN_OR_INF, "nan or inf number is not allowed");
+  return_err (NAN_OR_INF, "nan or inf number is not allowed");
 fail_str:
-    return_err(INVALID_STRING, "invalid utf-8 encoding in string");
-    
+  return_err (INVALID_STRING, "invalid utf-8 encoding in string");
+
 #undef return_err
 #undef incr_len
 #undef check_str_len
@@ -7589,503 +8858,586 @@ fail_str:
 
 /** Write JSON document pretty.
     The root of this document should be a non-empty container. */
-static_inline u8 *yyjson_write_pretty(const yyjson_val *root,
-                                      const yyjson_write_flag flg,
-                                      const yyjson_alc alc,
-                                      usize *dat_len,
-                                      yyjson_write_err *err) {
-    
-#define return_err(_code, _msg) do { \
-    *dat_len = 0; \
+static_inline u8 *
+yyjson_write_pretty (const yyjson_val *root,
+                     const yyjson_write_flag flg,
+                     const yyjson_alc alc,
+                     usize *dat_len,
+                     yyjson_write_err *err)
+{
+
+#define return_err(_code, _msg)             \
+  do                                        \
+  {                                         \
+    *dat_len  = 0;                          \
     err->code = YYJSON_WRITE_ERROR_##_code; \
-    err->msg = _msg; \
-    if (hdr) alc.free(alc.ctx, hdr); \
-    return NULL; \
-} while (false)
-    
-#define incr_len(_len) do { \
-    ext_len = (usize)(_len); \
-    if (unlikely((u8 *)(cur + ext_len) >= (u8 *)ctx)) { \
-        alc_inc = yyjson_max(alc_len / 2, ext_len); \
-        alc_inc = size_align_up(alc_inc, sizeof(yyjson_write_ctx)); \
-        if (size_add_is_overflow(alc_len, alc_inc)) goto fail_alloc; \
-        alc_len += alc_inc; \
-        tmp = (u8 *)alc.realloc(alc.ctx, hdr, alc_len - alc_inc, alc_len); \
-        if (unlikely(!tmp)) goto fail_alloc; \
-        ctx_len = (usize)(end - (u8 *)ctx); \
-        ctx_tmp = (yyjson_write_ctx *)(void *)(tmp + (alc_len - ctx_len)); \
-        memmove((void *)ctx_tmp, (void *)(tmp + ((u8 *)ctx - hdr)), ctx_len); \
-        ctx = ctx_tmp; \
-        cur = tmp + (cur - hdr); \
-        end = tmp + alc_len; \
-        hdr = tmp; \
-    } \
-} while (false)
-    
-#define check_str_len(_len) do { \
+    err->msg  = _msg;                       \
+    if (hdr)                                \
+      alc.free (alc.ctx, hdr);              \
+    return NULL;                            \
+  } while (false)
+
+#define incr_len(_len)                                                       \
+  do                                                                         \
+  {                                                                          \
+    ext_len = (usize)(_len);                                                 \
+    if (unlikely ((u8 *)(cur + ext_len) >= (u8 *)ctx))                       \
+    {                                                                        \
+      alc_inc = yyjson_max (alc_len / 2, ext_len);                           \
+      alc_inc = size_align_up (alc_inc, sizeof (yyjson_write_ctx));          \
+      if (size_add_is_overflow (alc_len, alc_inc))                           \
+        goto fail_alloc;                                                     \
+      alc_len += alc_inc;                                                    \
+      tmp = (u8 *)alc.realloc (alc.ctx, hdr, alc_len - alc_inc, alc_len);    \
+      if (unlikely (!tmp))                                                   \
+        goto fail_alloc;                                                     \
+      ctx_len = (usize)(end - (u8 *)ctx);                                    \
+      ctx_tmp = (yyjson_write_ctx *)(void *)(tmp + (alc_len - ctx_len));     \
+      memmove ((void *)ctx_tmp, (void *)(tmp + ((u8 *)ctx - hdr)), ctx_len); \
+      ctx = ctx_tmp;                                                         \
+      cur = tmp + (cur - hdr);                                               \
+      end = tmp + alc_len;                                                   \
+      hdr = tmp;                                                             \
+    }                                                                        \
+  } while (false)
+
+#define check_str_len(_len)                                      \
+  do                                                             \
+  {                                                              \
     if ((USIZE_MAX < U64_MAX) && (_len >= (USIZE_MAX - 16) / 6)) \
-        goto fail_alloc; \
-} while (false)
-    
-    yyjson_val *val;
-    yyjson_type val_type;
-    usize ctn_len, ctn_len_tmp;
-    bool ctn_obj, ctn_obj_tmp, is_key, no_indent;
-    u8 *hdr, *cur, *end, *tmp;
-    yyjson_write_ctx *ctx, *ctx_tmp;
-    usize alc_len, alc_inc, ctx_len, ext_len, str_len, level;
-    const u8 *str_ptr;
-    const char_enc_type *enc_table = get_enc_table_with_flag(flg);
-    bool esc = (flg & YYJSON_WRITE_ESCAPE_UNICODE) != 0;
-    bool inv = (flg & YYJSON_WRITE_ALLOW_INVALID_UNICODE) != 0;
-    usize spaces = (flg & YYJSON_WRITE_PRETTY_TWO_SPACES) ? 2 : 4;
-    
-    alc_len = root->uni.ofs / sizeof(yyjson_val);
-    alc_len = alc_len * YYJSON_WRITER_ESTIMATED_PRETTY_RATIO + 64;
-    alc_len = size_align_up(alc_len, sizeof(yyjson_write_ctx));
-    hdr = (u8 *)alc.malloc(alc.ctx, alc_len);
-    if (!hdr) goto fail_alloc;
-    cur = hdr;
-    end = hdr + alc_len;
-    ctx = (yyjson_write_ctx *)(void *)end;
-    
+      goto fail_alloc;                                           \
+  } while (false)
+
+  yyjson_val *val;
+  yyjson_type val_type;
+  usize ctn_len, ctn_len_tmp;
+  bool ctn_obj, ctn_obj_tmp, is_key, no_indent;
+  u8 *hdr, *cur, *end, *tmp;
+  yyjson_write_ctx *ctx, *ctx_tmp;
+  usize alc_len, alc_inc, ctx_len, ext_len, str_len, level;
+  const u8 *str_ptr;
+  const char_enc_type *enc_table = get_enc_table_with_flag (flg);
+  bool esc                       = (flg & YYJSON_WRITE_ESCAPE_UNICODE) != 0;
+  bool inv                       = (flg & YYJSON_WRITE_ALLOW_INVALID_UNICODE) != 0;
+  usize spaces                   = (flg & YYJSON_WRITE_PRETTY_TWO_SPACES) ? 2 : 4;
+
+  alc_len = root->uni.ofs / sizeof (yyjson_val);
+  alc_len = alc_len * YYJSON_WRITER_ESTIMATED_PRETTY_RATIO + 64;
+  alc_len = size_align_up (alc_len, sizeof (yyjson_write_ctx));
+  hdr     = (u8 *)alc.malloc (alc.ctx, alc_len);
+  if (!hdr)
+    goto fail_alloc;
+  cur = hdr;
+  end = hdr + alc_len;
+  ctx = (yyjson_write_ctx *)(void *)end;
+
 doc_begin:
-    val = constcast(yyjson_val *)root;
-    val_type = unsafe_yyjson_get_type(val);
-    ctn_obj = (val_type == YYJSON_TYPE_OBJ);
-    ctn_len = unsafe_yyjson_get_len(val) << (u8)ctn_obj;
-    *cur++ = (u8)('[' | ((u8)ctn_obj << 5));
-    *cur++ = '\n';
-    val++;
-    level = 1;
-    
+  val      = constcast (yyjson_val *) root;
+  val_type = unsafe_yyjson_get_type (val);
+  ctn_obj  = (val_type == YYJSON_TYPE_OBJ);
+  ctn_len  = unsafe_yyjson_get_len (val) << (u8)ctn_obj;
+  *cur++   = (u8)('[' | ((u8)ctn_obj << 5));
+  *cur++   = '\n';
+  val++;
+  level = 1;
+
 val_begin:
-    val_type = unsafe_yyjson_get_type(val);
-    if (val_type == YYJSON_TYPE_STR) {
-        is_key = (bool)((u8)ctn_obj & (u8)~ctn_len);
-        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-        str_len = unsafe_yyjson_get_len(val);
-        str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-        check_str_len(str_len);
-        incr_len(str_len * 6 + 16 + (no_indent ? 0 : level * 4));
-        cur = write_indent(cur, no_indent ? 0 : level, spaces);
-        cur = write_string(cur, esc, inv, str_ptr, str_len, enc_table);
-        if (unlikely(!cur)) goto fail_str;
-        *cur++ = is_key ? ':' : ',';
-        *cur++ = is_key ? ' ' : '\n';
-        goto val_end;
-    }
-    if (val_type == YYJSON_TYPE_NUM) {
-        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-        incr_len(32 + (no_indent ? 0 : level * 4));
-        cur = write_indent(cur, no_indent ? 0 : level, spaces);
-        cur = write_number(cur, val, flg);
-        if (unlikely(!cur)) goto fail_num;
-        *cur++ = ',';
-        *cur++ = '\n';
-        goto val_end;
-    }
-    if ((val_type & (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) ==
-                    (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) {
-        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-        ctn_len_tmp = unsafe_yyjson_get_len(val);
-        ctn_obj_tmp = (val_type == YYJSON_TYPE_OBJ);
-        if (unlikely(ctn_len_tmp == 0)) {
-            /* write empty container */
-            incr_len(16 + (no_indent ? 0 : level * 4));
-            cur = write_indent(cur, no_indent ? 0 : level, spaces);
-            *cur++ = (u8)('[' | ((u8)ctn_obj_tmp << 5));
-            *cur++ = (u8)(']' | ((u8)ctn_obj_tmp << 5));
-            *cur++ = ',';
-            *cur++ = '\n';
-            goto val_end;
-        } else {
-            /* push context, setup new container */
-            incr_len(32 + (no_indent ? 0 : level * 4));
-            yyjson_write_ctx_set(--ctx, ctn_len, ctn_obj);
-            ctn_len = ctn_len_tmp << (u8)ctn_obj_tmp;
-            ctn_obj = ctn_obj_tmp;
-            cur = write_indent(cur, no_indent ? 0 : level, spaces);
-            level++;
-            *cur++ = (u8)('[' | ((u8)ctn_obj << 5));
-            *cur++ = '\n';
-            val++;
-            goto val_begin;
-        }
-    }
-    if (val_type == YYJSON_TYPE_BOOL) {
-        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-        incr_len(16 + (no_indent ? 0 : level * 4));
-        cur = write_indent(cur, no_indent ? 0 : level, spaces);
-        cur = write_bool(cur, unsafe_yyjson_get_bool(val));
-        cur += 2;
-        goto val_end;
-    }
-    if (val_type == YYJSON_TYPE_NULL) {
-        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-        incr_len(16 + (no_indent ? 0 : level * 4));
-        cur = write_indent(cur, no_indent ? 0 : level, spaces);
-        cur = write_null(cur);
-        cur += 2;
-        goto val_end;
-    }
-    if (val_type == YYJSON_TYPE_RAW) {
-        str_len = unsafe_yyjson_get_len(val);
-        str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-        check_str_len(str_len);
-        incr_len(str_len + 3);
-        cur = write_raw(cur, str_ptr, str_len);
-        *cur++ = ',';
-        *cur++ = '\n';
-        goto val_end;
-    }
-    goto fail_type;
-    
-val_end:
-    val++;
-    ctn_len--;
-    if (unlikely(ctn_len == 0)) goto ctn_end;
-    goto val_begin;
-    
-ctn_end:
-    cur -= 2;
-    *cur++ = '\n';
-    incr_len(level * 4);
-    cur = write_indent(cur, --level, spaces);
-    *cur++ = (u8)(']' | ((u8)ctn_obj << 5));
-    if (unlikely((u8 *)ctx >= end)) goto doc_end;
-    yyjson_write_ctx_get(ctx++, &ctn_len, &ctn_obj);
-    ctn_len--;
+  val_type = unsafe_yyjson_get_type (val);
+  if (val_type == YYJSON_TYPE_STR)
+  {
+    is_key    = (bool)((u8)ctn_obj & (u8)~ctn_len);
+    no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
+    str_len   = unsafe_yyjson_get_len (val);
+    str_ptr   = (const u8 *)unsafe_yyjson_get_str (val);
+    check_str_len (str_len);
+    incr_len (str_len * 6 + 16 + (no_indent ? 0 : level * 4));
+    cur = write_indent (cur, no_indent ? 0 : level, spaces);
+    cur = write_string (cur, esc, inv, str_ptr, str_len, enc_table);
+    if (unlikely (!cur))
+      goto fail_str;
+    *cur++ = is_key ? ':' : ',';
+    *cur++ = is_key ? ' ' : '\n';
+    goto val_end;
+  }
+  if (val_type == YYJSON_TYPE_NUM)
+  {
+    no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
+    incr_len (32 + (no_indent ? 0 : level * 4));
+    cur = write_indent (cur, no_indent ? 0 : level, spaces);
+    cur = write_number (cur, val, flg);
+    if (unlikely (!cur))
+      goto fail_num;
     *cur++ = ',';
     *cur++ = '\n';
-    if (likely(ctn_len > 0)) {
-        goto val_begin;
-    } else {
-        goto ctn_end;
+    goto val_end;
+  }
+  if ((val_type & (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) ==
+      (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ))
+  {
+    no_indent   = (bool)((u8)ctn_obj & (u8)ctn_len);
+    ctn_len_tmp = unsafe_yyjson_get_len (val);
+    ctn_obj_tmp = (val_type == YYJSON_TYPE_OBJ);
+    if (unlikely (ctn_len_tmp == 0))
+    {
+      /* write empty container */
+      incr_len (16 + (no_indent ? 0 : level * 4));
+      cur    = write_indent (cur, no_indent ? 0 : level, spaces);
+      *cur++ = (u8)('[' | ((u8)ctn_obj_tmp << 5));
+      *cur++ = (u8)(']' | ((u8)ctn_obj_tmp << 5));
+      *cur++ = ',';
+      *cur++ = '\n';
+      goto val_end;
     }
-    
+    else
+    {
+      /* push context, setup new container */
+      incr_len (32 + (no_indent ? 0 : level * 4));
+      yyjson_write_ctx_set (--ctx, ctn_len, ctn_obj);
+      ctn_len = ctn_len_tmp << (u8)ctn_obj_tmp;
+      ctn_obj = ctn_obj_tmp;
+      cur     = write_indent (cur, no_indent ? 0 : level, spaces);
+      level++;
+      *cur++ = (u8)('[' | ((u8)ctn_obj << 5));
+      *cur++ = '\n';
+      val++;
+      goto val_begin;
+    }
+  }
+  if (val_type == YYJSON_TYPE_BOOL)
+  {
+    no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
+    incr_len (16 + (no_indent ? 0 : level * 4));
+    cur = write_indent (cur, no_indent ? 0 : level, spaces);
+    cur = write_bool (cur, unsafe_yyjson_get_bool (val));
+    cur += 2;
+    goto val_end;
+  }
+  if (val_type == YYJSON_TYPE_NULL)
+  {
+    no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
+    incr_len (16 + (no_indent ? 0 : level * 4));
+    cur = write_indent (cur, no_indent ? 0 : level, spaces);
+    cur = write_null (cur);
+    cur += 2;
+    goto val_end;
+  }
+  if (val_type == YYJSON_TYPE_RAW)
+  {
+    str_len = unsafe_yyjson_get_len (val);
+    str_ptr = (const u8 *)unsafe_yyjson_get_str (val);
+    check_str_len (str_len);
+    incr_len (str_len + 3);
+    cur    = write_raw (cur, str_ptr, str_len);
+    *cur++ = ',';
+    *cur++ = '\n';
+    goto val_end;
+  }
+  goto fail_type;
+
+val_end:
+  val++;
+  ctn_len--;
+  if (unlikely (ctn_len == 0))
+    goto ctn_end;
+  goto val_begin;
+
+ctn_end:
+  cur -= 2;
+  *cur++ = '\n';
+  incr_len (level * 4);
+  cur    = write_indent (cur, --level, spaces);
+  *cur++ = (u8)(']' | ((u8)ctn_obj << 5));
+  if (unlikely ((u8 *)ctx >= end))
+    goto doc_end;
+  yyjson_write_ctx_get (ctx++, &ctn_len, &ctn_obj);
+  ctn_len--;
+  *cur++ = ',';
+  *cur++ = '\n';
+  if (likely (ctn_len > 0))
+  {
+    goto val_begin;
+  }
+  else
+  {
+    goto ctn_end;
+  }
+
 doc_end:
-    *cur = '\0';
-    *dat_len = (usize)(cur - hdr);
-    memset(err, 0, sizeof(yyjson_write_err));
-    return hdr;
-    
+  *cur     = '\0';
+  *dat_len = (usize)(cur - hdr);
+  memset (err, 0, sizeof (yyjson_write_err));
+  return hdr;
+
 fail_alloc:
-    return_err(MEMORY_ALLOCATION, "memory allocation failed");
+  return_err (MEMORY_ALLOCATION, "memory allocation failed");
 fail_type:
-    return_err(INVALID_VALUE_TYPE, "invalid JSON value type");
+  return_err (INVALID_VALUE_TYPE, "invalid JSON value type");
 fail_num:
-    return_err(NAN_OR_INF, "nan or inf number is not allowed");
+  return_err (NAN_OR_INF, "nan or inf number is not allowed");
 fail_str:
-    return_err(INVALID_STRING, "invalid utf-8 encoding in string");
-    
+  return_err (INVALID_STRING, "invalid utf-8 encoding in string");
+
 #undef return_err
 #undef incr_len
 #undef check_str_len
 }
 
-char *yyjson_val_write_opts(const yyjson_val *val,
-                            yyjson_write_flag flg,
-                            const yyjson_alc *alc_ptr,
-                            usize *dat_len,
-                            yyjson_write_err *err) {
-    yyjson_write_err dummy_err;
-    usize dummy_dat_len;
-    yyjson_alc alc = alc_ptr ? *alc_ptr : YYJSON_DEFAULT_ALC;
-    yyjson_val *root = constcast(yyjson_val *)val;
-    
-    err = err ? err : &dummy_err;
-    dat_len = dat_len ? dat_len : &dummy_dat_len;
-    
-#if YYJSON_DISABLE_NON_STANDARD
-    flg &= ~YYJSON_WRITE_ALLOW_INF_AND_NAN;
-    flg &= ~YYJSON_WRITE_ALLOW_INVALID_UNICODE;
-#endif
-    
-    if (unlikely(!root)) {
-        *dat_len = 0;
-        err->msg = "input JSON is NULL";
-        err->code = YYJSON_READ_ERROR_INVALID_PARAMETER;
-        return NULL;
-    }
-    
-    if (!unsafe_yyjson_is_ctn(root) || unsafe_yyjson_get_len(root) == 0) {
-        return (char *)yyjson_write_single(root, flg, alc, dat_len, err);
-    } else if (flg & (YYJSON_WRITE_PRETTY | YYJSON_WRITE_PRETTY_TWO_SPACES)) {
-        return (char *)yyjson_write_pretty(root, flg, alc, dat_len, err);
-    } else {
-        return (char *)yyjson_write_minify(root, flg, alc, dat_len, err);
-    }
-}
-
-char *yyjson_write_opts(const yyjson_doc *doc,
-                        yyjson_write_flag flg,
-                        const yyjson_alc *alc_ptr,
-                        usize *dat_len,
-                        yyjson_write_err *err) {
-    yyjson_val *root = doc ? doc->root : NULL;
-    return yyjson_val_write_opts(root, flg, alc_ptr, dat_len, err);
-}
-
-bool yyjson_val_write_file(const char *path,
-                           const yyjson_val *val,
-                           yyjson_write_flag flg,
-                           const yyjson_alc *alc_ptr,
-                           yyjson_write_err *err) {
-    yyjson_write_err dummy_err;
-    u8 *dat;
-    usize dat_len = 0;
-    yyjson_val *root = constcast(yyjson_val *)val;
-    bool suc;
-    
-    alc_ptr = alc_ptr ? alc_ptr : &YYJSON_DEFAULT_ALC;
-    err = err ? err : &dummy_err;
-    if (unlikely(!path || !*path)) {
-        err->msg = "input path is invalid";
-        err->code = YYJSON_READ_ERROR_INVALID_PARAMETER;
-        return false;
-    }
-    
-    dat = (u8 *)yyjson_val_write_opts(root, flg, alc_ptr, &dat_len, err);
-    if (unlikely(!dat)) return false;
-    suc = write_dat_to_file(path, dat, dat_len, err);
-    alc_ptr->free(alc_ptr->ctx, dat);
-    return suc;
-}
-
-bool yyjson_write_file(const char *path,
-                       const yyjson_doc *doc,
+char *
+yyjson_val_write_opts (const yyjson_val *val,
                        yyjson_write_flag flg,
                        const yyjson_alc *alc_ptr,
-                       yyjson_write_err *err) {
-    yyjson_val *root = doc ? doc->root : NULL;
-    return yyjson_val_write_file(path, root, flg, alc_ptr, err);
+                       usize *dat_len,
+                       yyjson_write_err *err)
+{
+  yyjson_write_err dummy_err;
+  usize dummy_dat_len;
+  yyjson_alc alc   = alc_ptr ? *alc_ptr : YYJSON_DEFAULT_ALC;
+  yyjson_val *root = constcast (yyjson_val *) val;
+
+  err     = err ? err : &dummy_err;
+  dat_len = dat_len ? dat_len : &dummy_dat_len;
+
+#if YYJSON_DISABLE_NON_STANDARD
+  flg &= ~YYJSON_WRITE_ALLOW_INF_AND_NAN;
+  flg &= ~YYJSON_WRITE_ALLOW_INVALID_UNICODE;
+#endif
+
+  if (unlikely (!root))
+  {
+    *dat_len  = 0;
+    err->msg  = "input JSON is NULL";
+    err->code = YYJSON_READ_ERROR_INVALID_PARAMETER;
+    return NULL;
+  }
+
+  if (!unsafe_yyjson_is_ctn (root) || unsafe_yyjson_get_len (root) == 0)
+  {
+    return (char *)yyjson_write_single (root, flg, alc, dat_len, err);
+  }
+  else if (flg & (YYJSON_WRITE_PRETTY | YYJSON_WRITE_PRETTY_TWO_SPACES))
+  {
+    return (char *)yyjson_write_pretty (root, flg, alc, dat_len, err);
+  }
+  else
+  {
+    return (char *)yyjson_write_minify (root, flg, alc, dat_len, err);
+  }
 }
 
+char *
+yyjson_write_opts (const yyjson_doc *doc,
+                   yyjson_write_flag flg,
+                   const yyjson_alc *alc_ptr,
+                   usize *dat_len,
+                   yyjson_write_err *err)
+{
+  yyjson_val *root = doc ? doc->root : NULL;
+  return yyjson_val_write_opts (root, flg, alc_ptr, dat_len, err);
+}
 
+bool
+yyjson_val_write_file (const char *path,
+                       const yyjson_val *val,
+                       yyjson_write_flag flg,
+                       const yyjson_alc *alc_ptr,
+                       yyjson_write_err *err)
+{
+  yyjson_write_err dummy_err;
+  u8 *dat;
+  usize dat_len    = 0;
+  yyjson_val *root = constcast (yyjson_val *) val;
+  bool suc;
+
+  alc_ptr = alc_ptr ? alc_ptr : &YYJSON_DEFAULT_ALC;
+  err     = err ? err : &dummy_err;
+  if (unlikely (!path || !*path))
+  {
+    err->msg  = "input path is invalid";
+    err->code = YYJSON_READ_ERROR_INVALID_PARAMETER;
+    return false;
+  }
+
+  dat = (u8 *)yyjson_val_write_opts (root, flg, alc_ptr, &dat_len, err);
+  if (unlikely (!dat))
+    return false;
+  suc = write_dat_to_file (path, dat, dat_len, err);
+  alc_ptr->free (alc_ptr->ctx, dat);
+  return suc;
+}
+
+bool
+yyjson_write_file (const char *path,
+                   const yyjson_doc *doc,
+                   yyjson_write_flag flg,
+                   const yyjson_alc *alc_ptr,
+                   yyjson_write_err *err)
+{
+  yyjson_val *root = doc ? doc->root : NULL;
+  return yyjson_val_write_file (path, root, flg, alc_ptr, err);
+}
 
 /*==============================================================================
  * Mutable JSON Writer Implementation
  *============================================================================*/
 
-typedef struct yyjson_mut_write_ctx {
-    usize tag;
-    yyjson_mut_val *ctn;
+typedef struct yyjson_mut_write_ctx
+{
+  usize tag;
+  yyjson_mut_val *ctn;
 } yyjson_mut_write_ctx;
 
-static_inline void yyjson_mut_write_ctx_set(yyjson_mut_write_ctx *ctx,
-                                            yyjson_mut_val *ctn,
-                                            usize size, bool is_obj) {
-    ctx->tag = (size << 1) | (usize)is_obj;
-    ctx->ctn = ctn;
+static_inline void
+yyjson_mut_write_ctx_set (yyjson_mut_write_ctx *ctx,
+                          yyjson_mut_val *ctn,
+                          usize size, bool is_obj)
+{
+  ctx->tag = (size << 1) | (usize)is_obj;
+  ctx->ctn = ctn;
 }
 
-static_inline void yyjson_mut_write_ctx_get(yyjson_mut_write_ctx *ctx,
-                                            yyjson_mut_val **ctn,
-                                            usize *size, bool *is_obj) {
-    usize tag = ctx->tag;
-    *size = tag >> 1;
-    *is_obj = (bool)(tag & 1);
-    *ctn = ctx->ctn;
+static_inline void
+yyjson_mut_write_ctx_get (yyjson_mut_write_ctx *ctx,
+                          yyjson_mut_val **ctn,
+                          usize *size, bool *is_obj)
+{
+  usize tag = ctx->tag;
+  *size     = tag >> 1;
+  *is_obj   = (bool)(tag & 1);
+  *ctn      = ctx->ctn;
 }
 
 /** Get the estimated number of values for the mutable JSON document. */
-static_inline usize yyjson_mut_doc_estimated_val_num(
-    const yyjson_mut_doc *doc) {
-    usize sum = 0;
-    yyjson_val_chunk *chunk = doc->val_pool.chunks;
-    while (chunk) {
-        sum += chunk->chunk_size / sizeof(yyjson_mut_val) - 1;
-        if (chunk == doc->val_pool.chunks) {
-            sum -= (usize)(doc->val_pool.end - doc->val_pool.cur);
-        }
-        chunk = chunk->next;
+static_inline usize
+yyjson_mut_doc_estimated_val_num (
+    const yyjson_mut_doc *doc)
+{
+  usize sum               = 0;
+  yyjson_val_chunk *chunk = doc->val_pool.chunks;
+  while (chunk)
+  {
+    sum += chunk->chunk_size / sizeof (yyjson_mut_val) - 1;
+    if (chunk == doc->val_pool.chunks)
+    {
+      sum -= (usize)(doc->val_pool.end - doc->val_pool.cur);
     }
-    return sum;
+    chunk = chunk->next;
+  }
+  return sum;
 }
 
 /** Write single JSON value. */
-static_inline u8 *yyjson_mut_write_single(yyjson_mut_val *val,
-                                          yyjson_write_flag flg,
-                                          yyjson_alc alc,
-                                          usize *dat_len,
-                                          yyjson_write_err *err) {
-    return yyjson_write_single((yyjson_val *)val, flg, alc, dat_len, err);
+static_inline u8 *
+yyjson_mut_write_single (yyjson_mut_val *val,
+                         yyjson_write_flag flg,
+                         yyjson_alc alc,
+                         usize *dat_len,
+                         yyjson_write_err *err)
+{
+  return yyjson_write_single ((yyjson_val *)val, flg, alc, dat_len, err);
 }
 
 /** Write JSON document minify.
     The root of this document should be a non-empty container. */
-static_inline u8 *yyjson_mut_write_minify(const yyjson_mut_val *root,
-                                          usize estimated_val_num,
-                                          yyjson_write_flag flg,
-                                          yyjson_alc alc,
-                                          usize *dat_len,
-                                          yyjson_write_err *err) {
-    
-#define return_err(_code, _msg) do { \
-    *dat_len = 0; \
+static_inline u8 *
+yyjson_mut_write_minify (const yyjson_mut_val *root,
+                         usize estimated_val_num,
+                         yyjson_write_flag flg,
+                         yyjson_alc alc,
+                         usize *dat_len,
+                         yyjson_write_err *err)
+{
+
+#define return_err(_code, _msg)             \
+  do                                        \
+  {                                         \
+    *dat_len  = 0;                          \
     err->code = YYJSON_WRITE_ERROR_##_code; \
-    err->msg = _msg; \
-    if (hdr) alc.free(alc.ctx, hdr); \
-    return NULL; \
-} while (false)
-    
-#define incr_len(_len) do { \
-    ext_len = (usize)(_len); \
-    if (unlikely((u8 *)(cur + ext_len) >= (u8 *)ctx)) { \
-        alc_inc = yyjson_max(alc_len / 2, ext_len); \
-        alc_inc = size_align_up(alc_inc, sizeof(yyjson_mut_write_ctx)); \
-        if (size_add_is_overflow(alc_len, alc_inc)) goto fail_alloc; \
-        alc_len += alc_inc; \
-        tmp = (u8 *)alc.realloc(alc.ctx, hdr, alc_len - alc_inc, alc_len); \
-        if (unlikely(!tmp)) goto fail_alloc; \
-        ctx_len = (usize)(end - (u8 *)ctx); \
-        ctx_tmp = (yyjson_mut_write_ctx *)(void *)(tmp + (alc_len - ctx_len)); \
-        memmove((void *)ctx_tmp, (void *)(tmp + ((u8 *)ctx - hdr)), ctx_len); \
-        ctx = ctx_tmp; \
-        cur = tmp + (cur - hdr); \
-        end = tmp + alc_len; \
-        hdr = tmp; \
-    } \
-} while (false)
-    
-#define check_str_len(_len) do { \
+    err->msg  = _msg;                       \
+    if (hdr)                                \
+      alc.free (alc.ctx, hdr);              \
+    return NULL;                            \
+  } while (false)
+
+#define incr_len(_len)                                                       \
+  do                                                                         \
+  {                                                                          \
+    ext_len = (usize)(_len);                                                 \
+    if (unlikely ((u8 *)(cur + ext_len) >= (u8 *)ctx))                       \
+    {                                                                        \
+      alc_inc = yyjson_max (alc_len / 2, ext_len);                           \
+      alc_inc = size_align_up (alc_inc, sizeof (yyjson_mut_write_ctx));      \
+      if (size_add_is_overflow (alc_len, alc_inc))                           \
+        goto fail_alloc;                                                     \
+      alc_len += alc_inc;                                                    \
+      tmp = (u8 *)alc.realloc (alc.ctx, hdr, alc_len - alc_inc, alc_len);    \
+      if (unlikely (!tmp))                                                   \
+        goto fail_alloc;                                                     \
+      ctx_len = (usize)(end - (u8 *)ctx);                                    \
+      ctx_tmp = (yyjson_mut_write_ctx *)(void *)(tmp + (alc_len - ctx_len)); \
+      memmove ((void *)ctx_tmp, (void *)(tmp + ((u8 *)ctx - hdr)), ctx_len); \
+      ctx = ctx_tmp;                                                         \
+      cur = tmp + (cur - hdr);                                               \
+      end = tmp + alc_len;                                                   \
+      hdr = tmp;                                                             \
+    }                                                                        \
+  } while (false)
+
+#define check_str_len(_len)                                      \
+  do                                                             \
+  {                                                              \
     if ((USIZE_MAX < U64_MAX) && (_len >= (USIZE_MAX - 16) / 6)) \
-        goto fail_alloc; \
-} while (false)
-    
-    yyjson_mut_val *val, *ctn;
-    yyjson_type val_type;
-    usize ctn_len, ctn_len_tmp;
-    bool ctn_obj, ctn_obj_tmp, is_key;
-    u8 *hdr, *cur, *end, *tmp;
-    yyjson_mut_write_ctx *ctx, *ctx_tmp;
-    usize alc_len, alc_inc, ctx_len, ext_len, str_len;
-    const u8 *str_ptr;
-    const char_enc_type *enc_table = get_enc_table_with_flag(flg);
-    bool esc = (flg & YYJSON_WRITE_ESCAPE_UNICODE) != 0;
-    bool inv = (flg & YYJSON_WRITE_ALLOW_INVALID_UNICODE) != 0;
-    
-    alc_len = estimated_val_num * YYJSON_WRITER_ESTIMATED_MINIFY_RATIO + 64;
-    alc_len = size_align_up(alc_len, sizeof(yyjson_mut_write_ctx));
-    hdr = (u8 *)alc.malloc(alc.ctx, alc_len);
-    if (!hdr) goto fail_alloc;
-    cur = hdr;
-    end = hdr + alc_len;
-    ctx = (yyjson_mut_write_ctx *)(void *)end;
-    
+      goto fail_alloc;                                           \
+  } while (false)
+
+  yyjson_mut_val *val, *ctn;
+  yyjson_type val_type;
+  usize ctn_len, ctn_len_tmp;
+  bool ctn_obj, ctn_obj_tmp, is_key;
+  u8 *hdr, *cur, *end, *tmp;
+  yyjson_mut_write_ctx *ctx, *ctx_tmp;
+  usize alc_len, alc_inc, ctx_len, ext_len, str_len;
+  const u8 *str_ptr;
+  const char_enc_type *enc_table = get_enc_table_with_flag (flg);
+  bool esc                       = (flg & YYJSON_WRITE_ESCAPE_UNICODE) != 0;
+  bool inv                       = (flg & YYJSON_WRITE_ALLOW_INVALID_UNICODE) != 0;
+
+  alc_len = estimated_val_num * YYJSON_WRITER_ESTIMATED_MINIFY_RATIO + 64;
+  alc_len = size_align_up (alc_len, sizeof (yyjson_mut_write_ctx));
+  hdr     = (u8 *)alc.malloc (alc.ctx, alc_len);
+  if (!hdr)
+    goto fail_alloc;
+  cur = hdr;
+  end = hdr + alc_len;
+  ctx = (yyjson_mut_write_ctx *)(void *)end;
+
 doc_begin:
-    val = constcast(yyjson_mut_val *)root;
-    val_type = unsafe_yyjson_get_type(val);
-    ctn_obj = (val_type == YYJSON_TYPE_OBJ);
-    ctn_len = unsafe_yyjson_get_len(val) << (u8)ctn_obj;
-    *cur++ = (u8)('[' | ((u8)ctn_obj << 5));
-    ctn = val;
-    val = (yyjson_mut_val *)val->uni.ptr; /* tail */
-    val = ctn_obj ? val->next->next : val->next;
-    
+  val      = constcast (yyjson_mut_val *) root;
+  val_type = unsafe_yyjson_get_type (val);
+  ctn_obj  = (val_type == YYJSON_TYPE_OBJ);
+  ctn_len  = unsafe_yyjson_get_len (val) << (u8)ctn_obj;
+  *cur++   = (u8)('[' | ((u8)ctn_obj << 5));
+  ctn      = val;
+  val      = (yyjson_mut_val *)val->uni.ptr; /* tail */
+  val      = ctn_obj ? val->next->next : val->next;
+
 val_begin:
-    val_type = unsafe_yyjson_get_type(val);
-    if (val_type == YYJSON_TYPE_STR) {
-        is_key = ((u8)ctn_obj & (u8)~ctn_len);
-        str_len = unsafe_yyjson_get_len(val);
-        str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-        check_str_len(str_len);
-        incr_len(str_len * 6 + 16);
-        cur = write_string(cur, esc, inv, str_ptr, str_len, enc_table);
-        if (unlikely(!cur)) goto fail_str;
-        *cur++ = is_key ? ':' : ',';
-        goto val_end;
-    }
-    if (val_type == YYJSON_TYPE_NUM) {
-        incr_len(32);
-        cur = write_number(cur, (yyjson_val *)val, flg);
-        if (unlikely(!cur)) goto fail_num;
-        *cur++ = ',';
-        goto val_end;
-    }
-    if ((val_type & (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) ==
-                    (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) {
-        ctn_len_tmp = unsafe_yyjson_get_len(val);
-        ctn_obj_tmp = (val_type == YYJSON_TYPE_OBJ);
-        incr_len(16);
-        if (unlikely(ctn_len_tmp == 0)) {
-            /* write empty container */
-            *cur++ = (u8)('[' | ((u8)ctn_obj_tmp << 5));
-            *cur++ = (u8)(']' | ((u8)ctn_obj_tmp << 5));
-            *cur++ = ',';
-            goto val_end;
-        } else {
-            /* push context, setup new container */
-            yyjson_mut_write_ctx_set(--ctx, ctn, ctn_len, ctn_obj);
-            ctn_len = ctn_len_tmp << (u8)ctn_obj_tmp;
-            ctn_obj = ctn_obj_tmp;
-            *cur++ = (u8)('[' | ((u8)ctn_obj << 5));
-            ctn = val;
-            val = (yyjson_mut_val *)ctn->uni.ptr; /* tail */
-            val = ctn_obj ? val->next->next : val->next;
-            goto val_begin;
-        }
-    }
-    if (val_type == YYJSON_TYPE_BOOL) {
-        incr_len(16);
-        cur = write_bool(cur, unsafe_yyjson_get_bool(val));
-        cur++;
-        goto val_end;
-    }
-    if (val_type == YYJSON_TYPE_NULL) {
-        incr_len(16);
-        cur = write_null(cur);
-        cur++;
-        goto val_end;
-    }
-    if (val_type == YYJSON_TYPE_RAW) {
-        str_len = unsafe_yyjson_get_len(val);
-        str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-        check_str_len(str_len);
-        incr_len(str_len + 2);
-        cur = write_raw(cur, str_ptr, str_len);
-        *cur++ = ',';
-        goto val_end;
-    }
-    goto fail_type;
-    
-val_end:
-    ctn_len--;
-    if (unlikely(ctn_len == 0)) goto ctn_end;
-    val = val->next;
-    goto val_begin;
-    
-ctn_end:
-    cur--;
-    *cur++ = (u8)(']' | ((u8)ctn_obj << 5));
+  val_type = unsafe_yyjson_get_type (val);
+  if (val_type == YYJSON_TYPE_STR)
+  {
+    is_key  = ((u8)ctn_obj & (u8)~ctn_len);
+    str_len = unsafe_yyjson_get_len (val);
+    str_ptr = (const u8 *)unsafe_yyjson_get_str (val);
+    check_str_len (str_len);
+    incr_len (str_len * 6 + 16);
+    cur = write_string (cur, esc, inv, str_ptr, str_len, enc_table);
+    if (unlikely (!cur))
+      goto fail_str;
+    *cur++ = is_key ? ':' : ',';
+    goto val_end;
+  }
+  if (val_type == YYJSON_TYPE_NUM)
+  {
+    incr_len (32);
+    cur = write_number (cur, (yyjson_val *)val, flg);
+    if (unlikely (!cur))
+      goto fail_num;
     *cur++ = ',';
-    if (unlikely((u8 *)ctx >= end)) goto doc_end;
-    val = ctn->next;
-    yyjson_mut_write_ctx_get(ctx++, &ctn, &ctn_len, &ctn_obj);
-    ctn_len--;
-    if (likely(ctn_len > 0)) {
-        goto val_begin;
-    } else {
-        goto ctn_end;
+    goto val_end;
+  }
+  if ((val_type & (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) ==
+      (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ))
+  {
+    ctn_len_tmp = unsafe_yyjson_get_len (val);
+    ctn_obj_tmp = (val_type == YYJSON_TYPE_OBJ);
+    incr_len (16);
+    if (unlikely (ctn_len_tmp == 0))
+    {
+      /* write empty container */
+      *cur++ = (u8)('[' | ((u8)ctn_obj_tmp << 5));
+      *cur++ = (u8)(']' | ((u8)ctn_obj_tmp << 5));
+      *cur++ = ',';
+      goto val_end;
     }
-    
+    else
+    {
+      /* push context, setup new container */
+      yyjson_mut_write_ctx_set (--ctx, ctn, ctn_len, ctn_obj);
+      ctn_len = ctn_len_tmp << (u8)ctn_obj_tmp;
+      ctn_obj = ctn_obj_tmp;
+      *cur++  = (u8)('[' | ((u8)ctn_obj << 5));
+      ctn     = val;
+      val     = (yyjson_mut_val *)ctn->uni.ptr; /* tail */
+      val     = ctn_obj ? val->next->next : val->next;
+      goto val_begin;
+    }
+  }
+  if (val_type == YYJSON_TYPE_BOOL)
+  {
+    incr_len (16);
+    cur = write_bool (cur, unsafe_yyjson_get_bool (val));
+    cur++;
+    goto val_end;
+  }
+  if (val_type == YYJSON_TYPE_NULL)
+  {
+    incr_len (16);
+    cur = write_null (cur);
+    cur++;
+    goto val_end;
+  }
+  if (val_type == YYJSON_TYPE_RAW)
+  {
+    str_len = unsafe_yyjson_get_len (val);
+    str_ptr = (const u8 *)unsafe_yyjson_get_str (val);
+    check_str_len (str_len);
+    incr_len (str_len + 2);
+    cur    = write_raw (cur, str_ptr, str_len);
+    *cur++ = ',';
+    goto val_end;
+  }
+  goto fail_type;
+
+val_end:
+  ctn_len--;
+  if (unlikely (ctn_len == 0))
+    goto ctn_end;
+  val = val->next;
+  goto val_begin;
+
+ctn_end:
+  cur--;
+  *cur++ = (u8)(']' | ((u8)ctn_obj << 5));
+  *cur++ = ',';
+  if (unlikely ((u8 *)ctx >= end))
+    goto doc_end;
+  val = ctn->next;
+  yyjson_mut_write_ctx_get (ctx++, &ctn, &ctn_len, &ctn_obj);
+  ctn_len--;
+  if (likely (ctn_len > 0))
+  {
+    goto val_begin;
+  }
+  else
+  {
+    goto ctn_end;
+  }
+
 doc_end:
-    *--cur = '\0';
-    *dat_len = (usize)(cur - hdr);
-    err->code = YYJSON_WRITE_SUCCESS;
-    err->msg = "success";
-    return hdr;
-    
+  *--cur    = '\0';
+  *dat_len  = (usize)(cur - hdr);
+  err->code = YYJSON_WRITE_SUCCESS;
+  err->msg  = "success";
+  return hdr;
+
 fail_alloc:
-    return_err(MEMORY_ALLOCATION, "memory allocation failed");
+  return_err (MEMORY_ALLOCATION, "memory allocation failed");
 fail_type:
-    return_err(INVALID_VALUE_TYPE, "invalid JSON value type");
+  return_err (INVALID_VALUE_TYPE, "invalid JSON value type");
 fail_num:
-    return_err(NAN_OR_INF, "nan or inf number is not allowed");
+  return_err (NAN_OR_INF, "nan or inf number is not allowed");
 fail_str:
-    return_err(INVALID_STRING, "invalid utf-8 encoding in string");
-    
+  return_err (INVALID_STRING, "invalid utf-8 encoding in string");
+
 #undef return_err
 #undef incr_len
 #undef check_str_len
@@ -8093,320 +9445,367 @@ fail_str:
 
 /** Write JSON document pretty.
     The root of this document should be a non-empty container. */
-static_inline u8 *yyjson_mut_write_pretty(const yyjson_mut_val *root,
-                                          usize estimated_val_num,
-                                          yyjson_write_flag flg,
-                                          yyjson_alc alc,
-                                          usize *dat_len,
-                                          yyjson_write_err *err) {
-    
-#define return_err(_code, _msg) do { \
-    *dat_len = 0; \
+static_inline u8 *
+yyjson_mut_write_pretty (const yyjson_mut_val *root,
+                         usize estimated_val_num,
+                         yyjson_write_flag flg,
+                         yyjson_alc alc,
+                         usize *dat_len,
+                         yyjson_write_err *err)
+{
+
+#define return_err(_code, _msg)             \
+  do                                        \
+  {                                         \
+    *dat_len  = 0;                          \
     err->code = YYJSON_WRITE_ERROR_##_code; \
-    err->msg = _msg; \
-    if (hdr) alc.free(alc.ctx, hdr); \
-    return NULL; \
-} while (false)
-    
-#define incr_len(_len) do { \
-    ext_len = (usize)(_len); \
-    if (unlikely((u8 *)(cur + ext_len) >= (u8 *)ctx)) { \
-        alc_inc = yyjson_max(alc_len / 2, ext_len); \
-        alc_inc = size_align_up(alc_inc, sizeof(yyjson_mut_write_ctx)); \
-        if (size_add_is_overflow(alc_len, alc_inc)) goto fail_alloc; \
-        alc_len += alc_inc; \
-        tmp = (u8 *)alc.realloc(alc.ctx, hdr, alc_len - alc_inc, alc_len); \
-        if (unlikely(!tmp)) goto fail_alloc; \
-        ctx_len = (usize)(end - (u8 *)ctx); \
-        ctx_tmp = (yyjson_mut_write_ctx *)(void *)(tmp + (alc_len - ctx_len)); \
-        memmove((void *)ctx_tmp, (void *)(tmp + ((u8 *)ctx - hdr)), ctx_len); \
-        ctx = ctx_tmp; \
-        cur = tmp + (cur - hdr); \
-        end = tmp + alc_len; \
-        hdr = tmp; \
-    } \
-} while (false)
-    
-#define check_str_len(_len) do { \
+    err->msg  = _msg;                       \
+    if (hdr)                                \
+      alc.free (alc.ctx, hdr);              \
+    return NULL;                            \
+  } while (false)
+
+#define incr_len(_len)                                                       \
+  do                                                                         \
+  {                                                                          \
+    ext_len = (usize)(_len);                                                 \
+    if (unlikely ((u8 *)(cur + ext_len) >= (u8 *)ctx))                       \
+    {                                                                        \
+      alc_inc = yyjson_max (alc_len / 2, ext_len);                           \
+      alc_inc = size_align_up (alc_inc, sizeof (yyjson_mut_write_ctx));      \
+      if (size_add_is_overflow (alc_len, alc_inc))                           \
+        goto fail_alloc;                                                     \
+      alc_len += alc_inc;                                                    \
+      tmp = (u8 *)alc.realloc (alc.ctx, hdr, alc_len - alc_inc, alc_len);    \
+      if (unlikely (!tmp))                                                   \
+        goto fail_alloc;                                                     \
+      ctx_len = (usize)(end - (u8 *)ctx);                                    \
+      ctx_tmp = (yyjson_mut_write_ctx *)(void *)(tmp + (alc_len - ctx_len)); \
+      memmove ((void *)ctx_tmp, (void *)(tmp + ((u8 *)ctx - hdr)), ctx_len); \
+      ctx = ctx_tmp;                                                         \
+      cur = tmp + (cur - hdr);                                               \
+      end = tmp + alc_len;                                                   \
+      hdr = tmp;                                                             \
+    }                                                                        \
+  } while (false)
+
+#define check_str_len(_len)                                      \
+  do                                                             \
+  {                                                              \
     if ((USIZE_MAX < U64_MAX) && (_len >= (USIZE_MAX - 16) / 6)) \
-        goto fail_alloc; \
-} while (false)
-    
-    yyjson_mut_val *val, *ctn;
-    yyjson_type val_type;
-    usize ctn_len, ctn_len_tmp;
-    bool ctn_obj, ctn_obj_tmp, is_key, no_indent;
-    u8 *hdr, *cur, *end, *tmp;
-    yyjson_mut_write_ctx *ctx, *ctx_tmp;
-    usize alc_len, alc_inc, ctx_len, ext_len, str_len, level;
-    const u8 *str_ptr;
-    const char_enc_type *enc_table = get_enc_table_with_flag(flg);
-    bool esc = (flg & YYJSON_WRITE_ESCAPE_UNICODE) != 0;
-    bool inv = (flg & YYJSON_WRITE_ALLOW_INVALID_UNICODE) != 0;
-    usize spaces = (flg & YYJSON_WRITE_PRETTY_TWO_SPACES) ? 2 : 4;
-    
-    alc_len = estimated_val_num * YYJSON_WRITER_ESTIMATED_PRETTY_RATIO + 64;
-    alc_len = size_align_up(alc_len, sizeof(yyjson_mut_write_ctx));
-    hdr = (u8 *)alc.malloc(alc.ctx, alc_len);
-    if (!hdr) goto fail_alloc;
-    cur = hdr;
-    end = hdr + alc_len;
-    ctx = (yyjson_mut_write_ctx *)(void *)end;
-    
+      goto fail_alloc;                                           \
+  } while (false)
+
+  yyjson_mut_val *val, *ctn;
+  yyjson_type val_type;
+  usize ctn_len, ctn_len_tmp;
+  bool ctn_obj, ctn_obj_tmp, is_key, no_indent;
+  u8 *hdr, *cur, *end, *tmp;
+  yyjson_mut_write_ctx *ctx, *ctx_tmp;
+  usize alc_len, alc_inc, ctx_len, ext_len, str_len, level;
+  const u8 *str_ptr;
+  const char_enc_type *enc_table = get_enc_table_with_flag (flg);
+  bool esc                       = (flg & YYJSON_WRITE_ESCAPE_UNICODE) != 0;
+  bool inv                       = (flg & YYJSON_WRITE_ALLOW_INVALID_UNICODE) != 0;
+  usize spaces                   = (flg & YYJSON_WRITE_PRETTY_TWO_SPACES) ? 2 : 4;
+
+  alc_len = estimated_val_num * YYJSON_WRITER_ESTIMATED_PRETTY_RATIO + 64;
+  alc_len = size_align_up (alc_len, sizeof (yyjson_mut_write_ctx));
+  hdr     = (u8 *)alc.malloc (alc.ctx, alc_len);
+  if (!hdr)
+    goto fail_alloc;
+  cur = hdr;
+  end = hdr + alc_len;
+  ctx = (yyjson_mut_write_ctx *)(void *)end;
+
 doc_begin:
-    val = constcast(yyjson_mut_val *)root;
-    val_type = unsafe_yyjson_get_type(val);
-    ctn_obj = (val_type == YYJSON_TYPE_OBJ);
-    ctn_len = unsafe_yyjson_get_len(val) << (u8)ctn_obj;
-    *cur++ = (u8)('[' | ((u8)ctn_obj << 5));
-    *cur++ = '\n';
-    ctn = val;
-    val = (yyjson_mut_val *)val->uni.ptr; /* tail */
-    val = ctn_obj ? val->next->next : val->next;
-    level = 1;
-    
+  val      = constcast (yyjson_mut_val *) root;
+  val_type = unsafe_yyjson_get_type (val);
+  ctn_obj  = (val_type == YYJSON_TYPE_OBJ);
+  ctn_len  = unsafe_yyjson_get_len (val) << (u8)ctn_obj;
+  *cur++   = (u8)('[' | ((u8)ctn_obj << 5));
+  *cur++   = '\n';
+  ctn      = val;
+  val      = (yyjson_mut_val *)val->uni.ptr; /* tail */
+  val      = ctn_obj ? val->next->next : val->next;
+  level    = 1;
+
 val_begin:
-    val_type = unsafe_yyjson_get_type(val);
-    if (val_type == YYJSON_TYPE_STR) {
-        is_key = (bool)((u8)ctn_obj & (u8)~ctn_len);
-        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-        str_len = unsafe_yyjson_get_len(val);
-        str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-        check_str_len(str_len);
-        incr_len(str_len * 6 + 16 + (no_indent ? 0 : level * 4));
-        cur = write_indent(cur, no_indent ? 0 : level, spaces);
-        cur = write_string(cur, esc, inv, str_ptr, str_len, enc_table);
-        if (unlikely(!cur)) goto fail_str;
-        *cur++ = is_key ? ':' : ',';
-        *cur++ = is_key ? ' ' : '\n';
-        goto val_end;
-    }
-    if (val_type == YYJSON_TYPE_NUM) {
-        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-        incr_len(32 + (no_indent ? 0 : level * 4));
-        cur = write_indent(cur, no_indent ? 0 : level, spaces);
-        cur = write_number(cur, (yyjson_val *)val, flg);
-        if (unlikely(!cur)) goto fail_num;
-        *cur++ = ',';
-        *cur++ = '\n';
-        goto val_end;
-    }
-    if ((val_type & (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) ==
-                    (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) {
-        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-        ctn_len_tmp = unsafe_yyjson_get_len(val);
-        ctn_obj_tmp = (val_type == YYJSON_TYPE_OBJ);
-        if (unlikely(ctn_len_tmp == 0)) {
-            /* write empty container */
-            incr_len(16 + (no_indent ? 0 : level * 4));
-            cur = write_indent(cur, no_indent ? 0 : level, spaces);
-            *cur++ = (u8)('[' | ((u8)ctn_obj_tmp << 5));
-            *cur++ = (u8)(']' | ((u8)ctn_obj_tmp << 5));
-            *cur++ = ',';
-            *cur++ = '\n';
-            goto val_end;
-        } else {
-            /* push context, setup new container */
-            incr_len(32 + (no_indent ? 0 : level * 4));
-            yyjson_mut_write_ctx_set(--ctx, ctn, ctn_len, ctn_obj);
-            ctn_len = ctn_len_tmp << (u8)ctn_obj_tmp;
-            ctn_obj = ctn_obj_tmp;
-            cur = write_indent(cur, no_indent ? 0 : level, spaces);
-            level++;
-            *cur++ = (u8)('[' | ((u8)ctn_obj << 5));
-            *cur++ = '\n';
-            ctn = val;
-            val = (yyjson_mut_val *)ctn->uni.ptr; /* tail */
-            val = ctn_obj ? val->next->next : val->next;
-            goto val_begin;
-        }
-    }
-    if (val_type == YYJSON_TYPE_BOOL) {
-        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-        incr_len(16 + (no_indent ? 0 : level * 4));
-        cur = write_indent(cur, no_indent ? 0 : level, spaces);
-        cur = write_bool(cur, unsafe_yyjson_get_bool(val));
-        cur += 2;
-        goto val_end;
-    }
-    if (val_type == YYJSON_TYPE_NULL) {
-        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-        incr_len(16 + (no_indent ? 0 : level * 4));
-        cur = write_indent(cur, no_indent ? 0 : level, spaces);
-        cur = write_null(cur);
-        cur += 2;
-        goto val_end;
-    }
-    if (val_type == YYJSON_TYPE_RAW) {
-        str_len = unsafe_yyjson_get_len(val);
-        str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-        check_str_len(str_len);
-        incr_len(str_len + 3);
-        cur = write_raw(cur, str_ptr, str_len);
-        *cur++ = ',';
-        *cur++ = '\n';
-        goto val_end;
-    }
-    goto fail_type;
-    
-val_end:
-    ctn_len--;
-    if (unlikely(ctn_len == 0)) goto ctn_end;
-    val = val->next;
-    goto val_begin;
-    
-ctn_end:
-    cur -= 2;
-    *cur++ = '\n';
-    incr_len(level * 4);
-    cur = write_indent(cur, --level, spaces);
-    *cur++ = (u8)(']' | ((u8)ctn_obj << 5));
-    if (unlikely((u8 *)ctx >= end)) goto doc_end;
-    val = ctn->next;
-    yyjson_mut_write_ctx_get(ctx++, &ctn, &ctn_len, &ctn_obj);
-    ctn_len--;
+  val_type = unsafe_yyjson_get_type (val);
+  if (val_type == YYJSON_TYPE_STR)
+  {
+    is_key    = (bool)((u8)ctn_obj & (u8)~ctn_len);
+    no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
+    str_len   = unsafe_yyjson_get_len (val);
+    str_ptr   = (const u8 *)unsafe_yyjson_get_str (val);
+    check_str_len (str_len);
+    incr_len (str_len * 6 + 16 + (no_indent ? 0 : level * 4));
+    cur = write_indent (cur, no_indent ? 0 : level, spaces);
+    cur = write_string (cur, esc, inv, str_ptr, str_len, enc_table);
+    if (unlikely (!cur))
+      goto fail_str;
+    *cur++ = is_key ? ':' : ',';
+    *cur++ = is_key ? ' ' : '\n';
+    goto val_end;
+  }
+  if (val_type == YYJSON_TYPE_NUM)
+  {
+    no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
+    incr_len (32 + (no_indent ? 0 : level * 4));
+    cur = write_indent (cur, no_indent ? 0 : level, spaces);
+    cur = write_number (cur, (yyjson_val *)val, flg);
+    if (unlikely (!cur))
+      goto fail_num;
     *cur++ = ',';
     *cur++ = '\n';
-    if (likely(ctn_len > 0)) {
-        goto val_begin;
-    } else {
-        goto ctn_end;
+    goto val_end;
+  }
+  if ((val_type & (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) ==
+      (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ))
+  {
+    no_indent   = (bool)((u8)ctn_obj & (u8)ctn_len);
+    ctn_len_tmp = unsafe_yyjson_get_len (val);
+    ctn_obj_tmp = (val_type == YYJSON_TYPE_OBJ);
+    if (unlikely (ctn_len_tmp == 0))
+    {
+      /* write empty container */
+      incr_len (16 + (no_indent ? 0 : level * 4));
+      cur    = write_indent (cur, no_indent ? 0 : level, spaces);
+      *cur++ = (u8)('[' | ((u8)ctn_obj_tmp << 5));
+      *cur++ = (u8)(']' | ((u8)ctn_obj_tmp << 5));
+      *cur++ = ',';
+      *cur++ = '\n';
+      goto val_end;
     }
-    
+    else
+    {
+      /* push context, setup new container */
+      incr_len (32 + (no_indent ? 0 : level * 4));
+      yyjson_mut_write_ctx_set (--ctx, ctn, ctn_len, ctn_obj);
+      ctn_len = ctn_len_tmp << (u8)ctn_obj_tmp;
+      ctn_obj = ctn_obj_tmp;
+      cur     = write_indent (cur, no_indent ? 0 : level, spaces);
+      level++;
+      *cur++ = (u8)('[' | ((u8)ctn_obj << 5));
+      *cur++ = '\n';
+      ctn    = val;
+      val    = (yyjson_mut_val *)ctn->uni.ptr; /* tail */
+      val    = ctn_obj ? val->next->next : val->next;
+      goto val_begin;
+    }
+  }
+  if (val_type == YYJSON_TYPE_BOOL)
+  {
+    no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
+    incr_len (16 + (no_indent ? 0 : level * 4));
+    cur = write_indent (cur, no_indent ? 0 : level, spaces);
+    cur = write_bool (cur, unsafe_yyjson_get_bool (val));
+    cur += 2;
+    goto val_end;
+  }
+  if (val_type == YYJSON_TYPE_NULL)
+  {
+    no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
+    incr_len (16 + (no_indent ? 0 : level * 4));
+    cur = write_indent (cur, no_indent ? 0 : level, spaces);
+    cur = write_null (cur);
+    cur += 2;
+    goto val_end;
+  }
+  if (val_type == YYJSON_TYPE_RAW)
+  {
+    str_len = unsafe_yyjson_get_len (val);
+    str_ptr = (const u8 *)unsafe_yyjson_get_str (val);
+    check_str_len (str_len);
+    incr_len (str_len + 3);
+    cur    = write_raw (cur, str_ptr, str_len);
+    *cur++ = ',';
+    *cur++ = '\n';
+    goto val_end;
+  }
+  goto fail_type;
+
+val_end:
+  ctn_len--;
+  if (unlikely (ctn_len == 0))
+    goto ctn_end;
+  val = val->next;
+  goto val_begin;
+
+ctn_end:
+  cur -= 2;
+  *cur++ = '\n';
+  incr_len (level * 4);
+  cur    = write_indent (cur, --level, spaces);
+  *cur++ = (u8)(']' | ((u8)ctn_obj << 5));
+  if (unlikely ((u8 *)ctx >= end))
+    goto doc_end;
+  val = ctn->next;
+  yyjson_mut_write_ctx_get (ctx++, &ctn, &ctn_len, &ctn_obj);
+  ctn_len--;
+  *cur++ = ',';
+  *cur++ = '\n';
+  if (likely (ctn_len > 0))
+  {
+    goto val_begin;
+  }
+  else
+  {
+    goto ctn_end;
+  }
+
 doc_end:
-    *cur = '\0';
-    *dat_len = (usize)(cur - hdr);
-    err->code = YYJSON_WRITE_SUCCESS;
-    err->msg = "success";
-    return hdr;
-    
+  *cur      = '\0';
+  *dat_len  = (usize)(cur - hdr);
+  err->code = YYJSON_WRITE_SUCCESS;
+  err->msg  = "success";
+  return hdr;
+
 fail_alloc:
-    return_err(MEMORY_ALLOCATION, "memory allocation failed");
+  return_err (MEMORY_ALLOCATION, "memory allocation failed");
 fail_type:
-    return_err(INVALID_VALUE_TYPE, "invalid JSON value type");
+  return_err (INVALID_VALUE_TYPE, "invalid JSON value type");
 fail_num:
-    return_err(NAN_OR_INF, "nan or inf number is not allowed");
+  return_err (NAN_OR_INF, "nan or inf number is not allowed");
 fail_str:
-    return_err(INVALID_STRING, "invalid utf-8 encoding in string");
-    
+  return_err (INVALID_STRING, "invalid utf-8 encoding in string");
+
 #undef return_err
 #undef incr_len
 #undef check_str_len
 }
 
-static char *yyjson_mut_write_opts_impl(const yyjson_mut_val *val,
-                                        usize estimated_val_num,
-                                        yyjson_write_flag flg,
-                                        const yyjson_alc *alc_ptr,
-                                        usize *dat_len,
-                                        yyjson_write_err *err) {
-    yyjson_write_err dummy_err;
-    usize dummy_dat_len;
-    yyjson_alc alc = alc_ptr ? *alc_ptr : YYJSON_DEFAULT_ALC;
-    yyjson_mut_val *root = constcast(yyjson_mut_val *)val;
-    
-    err = err ? err : &dummy_err;
-    dat_len = dat_len ? dat_len : &dummy_dat_len;
-    
-#if YYJSON_DISABLE_NON_STANDARD
-    flg &= ~YYJSON_WRITE_ALLOW_INF_AND_NAN;
-    flg &= ~YYJSON_WRITE_ALLOW_INVALID_UNICODE;
-#endif
-    
-    if (unlikely(!root)) {
-        *dat_len = 0;
-        err->msg = "input JSON is NULL";
-        err->code = YYJSON_WRITE_ERROR_INVALID_PARAMETER;
-        return NULL;
-    }
-    
-    if (!unsafe_yyjson_is_ctn(root) || unsafe_yyjson_get_len(root) == 0) {
-        return (char *)yyjson_mut_write_single(root, flg, alc, dat_len, err);
-    } else if (flg & (YYJSON_WRITE_PRETTY | YYJSON_WRITE_PRETTY_TWO_SPACES)) {
-        return (char *)yyjson_mut_write_pretty(root, estimated_val_num,
-                                               flg, alc, dat_len, err);
-    } else {
-        return (char *)yyjson_mut_write_minify(root, estimated_val_num,
-                                               flg, alc, dat_len, err);
-    }
-}
-
-char *yyjson_mut_val_write_opts(const yyjson_mut_val *val,
-                                yyjson_write_flag flg,
-                                const yyjson_alc *alc_ptr,
-                                usize *dat_len,
-                                yyjson_write_err *err) {
-    return yyjson_mut_write_opts_impl(val, 0, flg, alc_ptr, dat_len, err);
-}
-
-char *yyjson_mut_write_opts(const yyjson_mut_doc *doc,
+static char *
+yyjson_mut_write_opts_impl (const yyjson_mut_val *val,
+                            usize estimated_val_num,
                             yyjson_write_flag flg,
                             const yyjson_alc *alc_ptr,
                             usize *dat_len,
-                            yyjson_write_err *err) {
-    yyjson_mut_val *root;
-    usize estimated_val_num;
-    if (likely(doc)) {
-        root = doc->root;
-        estimated_val_num = yyjson_mut_doc_estimated_val_num(doc);
-    } else {
-        root = NULL;
-        estimated_val_num = 0;
-    }
-    return yyjson_mut_write_opts_impl(root, estimated_val_num,
-                                      flg, alc_ptr, dat_len, err);
+                            yyjson_write_err *err)
+{
+  yyjson_write_err dummy_err;
+  usize dummy_dat_len;
+  yyjson_alc alc       = alc_ptr ? *alc_ptr : YYJSON_DEFAULT_ALC;
+  yyjson_mut_val *root = constcast (yyjson_mut_val *) val;
+
+  err     = err ? err : &dummy_err;
+  dat_len = dat_len ? dat_len : &dummy_dat_len;
+
+#if YYJSON_DISABLE_NON_STANDARD
+  flg &= ~YYJSON_WRITE_ALLOW_INF_AND_NAN;
+  flg &= ~YYJSON_WRITE_ALLOW_INVALID_UNICODE;
+#endif
+
+  if (unlikely (!root))
+  {
+    *dat_len  = 0;
+    err->msg  = "input JSON is NULL";
+    err->code = YYJSON_WRITE_ERROR_INVALID_PARAMETER;
+    return NULL;
+  }
+
+  if (!unsafe_yyjson_is_ctn (root) || unsafe_yyjson_get_len (root) == 0)
+  {
+    return (char *)yyjson_mut_write_single (root, flg, alc, dat_len, err);
+  }
+  else if (flg & (YYJSON_WRITE_PRETTY | YYJSON_WRITE_PRETTY_TWO_SPACES))
+  {
+    return (char *)yyjson_mut_write_pretty (root, estimated_val_num,
+                                            flg, alc, dat_len, err);
+  }
+  else
+  {
+    return (char *)yyjson_mut_write_minify (root, estimated_val_num,
+                                            flg, alc, dat_len, err);
+  }
 }
 
-bool yyjson_mut_val_write_file(const char *path,
-                               const yyjson_mut_val *val,
-                               yyjson_write_flag flg,
-                               const yyjson_alc *alc_ptr,
-                               yyjson_write_err *err) {
-    yyjson_write_err dummy_err;
-    u8 *dat;
-    usize dat_len = 0;
-    yyjson_mut_val *root = constcast(yyjson_mut_val *)val;
-    bool suc;
-    
-    alc_ptr = alc_ptr ? alc_ptr : &YYJSON_DEFAULT_ALC;
-    err = err ? err : &dummy_err;
-    if (unlikely(!path || !*path)) {
-        err->msg = "input path is invalid";
-        err->code = YYJSON_WRITE_ERROR_INVALID_PARAMETER;
-        return false;
-    }
-    
-    dat = (u8 *)yyjson_mut_val_write_opts(root, flg, alc_ptr, &dat_len, err);
-    if (unlikely(!dat)) return false;
-    suc = write_dat_to_file(path, dat, dat_len, err);
-    alc_ptr->free(alc_ptr->ctx, dat);
-    return suc;
-    
-}
-
-bool yyjson_mut_write_file(const char *path,
-                           const yyjson_mut_doc *doc,
+char *
+yyjson_mut_val_write_opts (const yyjson_mut_val *val,
                            yyjson_write_flag flg,
                            const yyjson_alc *alc_ptr,
-                           yyjson_write_err *err) {
-    yyjson_mut_val *root = doc ? doc->root : NULL;
-    return yyjson_mut_val_write_file(path, root, flg, alc_ptr, err);
+                           usize *dat_len,
+                           yyjson_write_err *err)
+{
+  return yyjson_mut_write_opts_impl (val, 0, flg, alc_ptr, dat_len, err);
+}
+
+char *
+yyjson_mut_write_opts (const yyjson_mut_doc *doc,
+                       yyjson_write_flag flg,
+                       const yyjson_alc *alc_ptr,
+                       usize *dat_len,
+                       yyjson_write_err *err)
+{
+  yyjson_mut_val *root;
+  usize estimated_val_num;
+  if (likely (doc))
+  {
+    root              = doc->root;
+    estimated_val_num = yyjson_mut_doc_estimated_val_num (doc);
+  }
+  else
+  {
+    root              = NULL;
+    estimated_val_num = 0;
+  }
+  return yyjson_mut_write_opts_impl (root, estimated_val_num,
+                                     flg, alc_ptr, dat_len, err);
+}
+
+bool
+yyjson_mut_val_write_file (const char *path,
+                           const yyjson_mut_val *val,
+                           yyjson_write_flag flg,
+                           const yyjson_alc *alc_ptr,
+                           yyjson_write_err *err)
+{
+  yyjson_write_err dummy_err;
+  u8 *dat;
+  usize dat_len        = 0;
+  yyjson_mut_val *root = constcast (yyjson_mut_val *) val;
+  bool suc;
+
+  alc_ptr = alc_ptr ? alc_ptr : &YYJSON_DEFAULT_ALC;
+  err     = err ? err : &dummy_err;
+  if (unlikely (!path || !*path))
+  {
+    err->msg  = "input path is invalid";
+    err->code = YYJSON_WRITE_ERROR_INVALID_PARAMETER;
+    return false;
+  }
+
+  dat = (u8 *)yyjson_mut_val_write_opts (root, flg, alc_ptr, &dat_len, err);
+  if (unlikely (!dat))
+    return false;
+  suc = write_dat_to_file (path, dat, dat_len, err);
+  alc_ptr->free (alc_ptr->ctx, dat);
+  return suc;
+}
+
+bool
+yyjson_mut_write_file (const char *path,
+                       const yyjson_mut_doc *doc,
+                       yyjson_write_flag flg,
+                       const yyjson_alc *alc_ptr,
+                       yyjson_write_err *err)
+{
+  yyjson_mut_val *root = doc ? doc->root : NULL;
+  return yyjson_mut_val_write_file (path, root, flg, alc_ptr, err);
 }
 
 #endif /* YYJSON_DISABLE_WRITER */
-
-
 
 /*==============================================================================
  * Compiler Hint End
  *============================================================================*/
 
 #if defined(__clang__)
-#   pragma clang diagnostic pop
+#pragma clang diagnostic pop
 #elif defined(__GNUC__)
-#   if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
-#   pragma GCC diagnostic pop
-#   endif
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+#pragma GCC diagnostic pop
+#endif
 #elif defined(_MSC_VER)
-#   pragma warning(pop)
+#pragma warning(pop)
 #endif /* warning suppress end */

--- a/yyjson.h
+++ b/yyjson.h
@@ -11,19 +11,15 @@
 #ifndef YYJSON_H
 #define YYJSON_H
 
-
-
 /*==============================================================================
  * Header Files
  *============================================================================*/
 
-#include <stdlib.h>
-#include <stddef.h>
-#include <limits.h>
-#include <string.h>
 #include <float.h>
-
-
+#include <limits.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
 
 /*==============================================================================
  * Compile-time Options
@@ -31,14 +27,14 @@
 
 /*
  Define as 1 to disable JSON reader if you don't need to parse JSON.
- 
+
  This will disable these functions at compile-time:
     - yyjson_read_opts()
     - yyjson_read_file()
     - yyjson_read()
     - yyjson_read_number()
     - yyjson_mut_read_number()
- 
+
  This will reduce the binary size by about 60%.
  */
 #ifndef YYJSON_DISABLE_READER
@@ -46,7 +42,7 @@
 
 /*
  Define as 1 to disable JSON writer if you don't need to serialize JSON.
- 
+
  This will disable these functions at compile-time:
     - yyjson_write()
     - yyjson_write_file()
@@ -60,7 +56,7 @@
     - yyjson_mut_val_write()
     - yyjson_mut_val_write_file()
     - yyjson_mut_val_write_opts()
- 
+
  This will reduce the binary size by about 30%.
  */
 #ifndef YYJSON_DISABLE_WRITER
@@ -69,7 +65,7 @@
 /*
  Define as 1 to disable the fast floating-point number conversion in yyjson,
  and use libc's `strtod/snprintf` instead.
- 
+
  This will reduce the binary size by about 30%, but significantly slow down the
  floating-point read/write speed.
  */
@@ -82,7 +78,7 @@
     - Single line and multiple line comments.
     - Single trailing comma at the end of an object or array.
     - Invalid unicode in string value.
- 
+
  This will also invalidate these run-time options:
     - YYJSON_READ_ALLOW_INF_AND_NAN
     - YYJSON_READ_ALLOW_COMMENTS
@@ -90,7 +86,7 @@
     - YYJSON_READ_ALLOW_INVALID_UNICODE
     - YYJSON_WRITE_ALLOW_INF_AND_NAN
     - YYJSON_WRITE_ALLOW_INVALID_UNICODE
- 
+
  This will reduce the binary size by about 10%, and slightly improve the JSON
  read/write speed.
  */
@@ -100,7 +96,7 @@
 /*
  Define as 1 to disable unaligned memory access if target architecture does not
  support unaligned memory access (such as some embedded processors).
- 
+
  If this value is not defined, yyjson will perform some automatic detection.
  The wrong definition of this option may cause some performance degradation,
  but will not cause any run-time errors.
@@ -124,254 +120,252 @@
 #ifndef YYJSON_HAS_STDBOOL_H
 #endif
 
-
-
 /*==============================================================================
  * Compiler Macros
  *============================================================================*/
 
 /** compiler version (MSVC) */
 #ifdef _MSC_VER
-#   define YYJSON_MSC_VER _MSC_VER
+#define YYJSON_MSC_VER _MSC_VER
 #else
-#   define YYJSON_MSC_VER 0
+#define YYJSON_MSC_VER 0
 #endif
 
 /** compiler version (GCC) */
 #ifdef __GNUC__
-#   define YYJSON_GCC_VER __GNUC__
+#define YYJSON_GCC_VER __GNUC__
 #else
-#   define YYJSON_GCC_VER 0
+#define YYJSON_GCC_VER 0
 #endif
 
 /** C version (STDC) */
 #if defined(__STDC__) && (__STDC__ >= 1) && defined(__STDC_VERSION__)
-#   define YYJSON_STDC_VER __STDC_VERSION__
+#define YYJSON_STDC_VER __STDC_VERSION__
 #else
-#   define YYJSON_STDC_VER 0
+#define YYJSON_STDC_VER 0
 #endif
 
 /** C++ version */
 #if defined(__cplusplus)
-#   define YYJSON_CPP_VER __cplusplus
+#define YYJSON_CPP_VER __cplusplus
 #else
-#   define YYJSON_CPP_VER 0
+#define YYJSON_CPP_VER 0
 #endif
 
 /** compiler builtin check (since gcc 10.0, clang 2.6, icc 2021) */
 #ifndef yyjson_has_builtin
-#   ifdef __has_builtin
-#       define yyjson_has_builtin(x) __has_builtin(x)
-#   else
-#       define yyjson_has_builtin(x) 0
-#   endif
+#ifdef __has_builtin
+#define yyjson_has_builtin(x) __has_builtin (x)
+#else
+#define yyjson_has_builtin(x) 0
+#endif
 #endif
 
 /** compiler attribute check (since gcc 5.0, clang 2.9, icc 17) */
 #ifndef yyjson_has_attribute
-#   ifdef __has_attribute
-#       define yyjson_has_attribute(x) __has_attribute(x)
-#   else
-#       define yyjson_has_attribute(x) 0
-#   endif
+#ifdef __has_attribute
+#define yyjson_has_attribute(x) __has_attribute (x)
+#else
+#define yyjson_has_attribute(x) 0
+#endif
 #endif
 
 /** include check (since gcc 5.0, clang 2.7, icc 16, msvc 2017 15.3) */
 #ifndef yyjson_has_include
-#   ifdef __has_include
-#       define yyjson_has_include(x) __has_include(x)
-#   else
-#       define yyjson_has_include(x) 0
-#   endif
+#ifdef __has_include
+#define yyjson_has_include(x) __has_include(x)
+#else
+#define yyjson_has_include(x) 0
+#endif
 #endif
 
 /** inline for compiler */
 #ifndef yyjson_inline
-#   if YYJSON_MSC_VER >= 1200
-#       define yyjson_inline __forceinline
-#   elif defined(_MSC_VER)
-#       define yyjson_inline __inline
-#   elif yyjson_has_attribute(always_inline) || YYJSON_GCC_VER >= 4
-#       define yyjson_inline __inline__ __attribute__((always_inline))
-#   elif defined(__clang__) || defined(__GNUC__)
-#       define yyjson_inline __inline__
-#   elif defined(__cplusplus) || YYJSON_STDC_VER >= 199901L
-#       define yyjson_inline inline
-#   else
-#       define yyjson_inline
-#   endif
+#if YYJSON_MSC_VER >= 1200
+#define yyjson_inline __forceinline
+#elif defined(_MSC_VER)
+#define yyjson_inline __inline
+#elif yyjson_has_attribute(always_inline) || YYJSON_GCC_VER >= 4
+#define yyjson_inline __inline__ __attribute__ ((always_inline))
+#elif defined(__clang__) || defined(__GNUC__)
+#define yyjson_inline __inline__
+#elif defined(__cplusplus) || YYJSON_STDC_VER >= 199901L
+#define yyjson_inline inline
+#else
+#define yyjson_inline
+#endif
 #endif
 
 /** noinline for compiler */
 #ifndef yyjson_noinline
-#   if YYJSON_MSC_VER >= 1400
-#       define yyjson_noinline __declspec(noinline)
-#   elif yyjson_has_attribute(noinline) || YYJSON_GCC_VER >= 4
-#       define yyjson_noinline __attribute__((noinline))
-#   else
-#       define yyjson_noinline
-#   endif
+#if YYJSON_MSC_VER >= 1400
+#define yyjson_noinline __declspec(noinline)
+#elif yyjson_has_attribute(noinline) || YYJSON_GCC_VER >= 4
+#define yyjson_noinline __attribute__ ((noinline))
+#else
+#define yyjson_noinline
+#endif
 #endif
 
 /** align for compiler */
 #ifndef yyjson_align
-#   if YYJSON_MSC_VER >= 1300
-#       define yyjson_align(x) __declspec(align(x))
-#   elif yyjson_has_attribute(aligned) || defined(__GNUC__)
-#       define yyjson_align(x) __attribute__((aligned(x)))
-#   elif YYJSON_CPP_VER >= 201103L
-#       define yyjson_align(x) alignas(x)
-#   else
-#       define yyjson_align(x)
-#   endif
+#if YYJSON_MSC_VER >= 1300
+#define yyjson_align(x) __declspec(align (x))
+#elif yyjson_has_attribute(aligned) || defined(__GNUC__)
+#define yyjson_align(x) __attribute__ ((aligned (x)))
+#elif YYJSON_CPP_VER >= 201103L
+#define yyjson_align(x) alignas (x)
+#else
+#define yyjson_align(x)
+#endif
 #endif
 
 /** likely for compiler */
 #ifndef yyjson_likely
-#   if yyjson_has_builtin(__builtin_expect) || \
+#if yyjson_has_builtin(__builtin_expect) || \
     (YYJSON_GCC_VER >= 4 && YYJSON_GCC_VER != 5)
-#       define yyjson_likely(expr) __builtin_expect(!!(expr), 1)
-#   else
-#       define yyjson_likely(expr) (expr)
-#   endif
+#define yyjson_likely(expr) __builtin_expect (!!(expr), 1)
+#else
+#define yyjson_likely(expr) (expr)
+#endif
 #endif
 
 /** unlikely for compiler */
 #ifndef yyjson_unlikely
-#   if yyjson_has_builtin(__builtin_expect) || \
+#if yyjson_has_builtin(__builtin_expect) || \
     (YYJSON_GCC_VER >= 4 && YYJSON_GCC_VER != 5)
-#       define yyjson_unlikely(expr) __builtin_expect(!!(expr), 0)
-#   else
-#       define yyjson_unlikely(expr) (expr)
-#   endif
+#define yyjson_unlikely(expr) __builtin_expect (!!(expr), 0)
+#else
+#define yyjson_unlikely(expr) (expr)
+#endif
 #endif
 
 /** function export */
 #ifndef yyjson_api
-#   if defined(_WIN32)
-#       if defined(YYJSON_EXPORTS) && YYJSON_EXPORTS
-#           define yyjson_api __declspec(dllexport)
-#       elif defined(YYJSON_IMPORTS) && YYJSON_IMPORTS
-#           define yyjson_api __declspec(dllimport)
-#       else
-#           define yyjson_api
-#       endif
-#   elif yyjson_has_attribute(visibility) || YYJSON_GCC_VER >= 4
-#       define yyjson_api __attribute__((visibility("default")))
-#   else
-#       define yyjson_api
-#   endif
+#if defined(_WIN32)
+#if defined(YYJSON_EXPORTS) && YYJSON_EXPORTS
+#define yyjson_api __declspec(dllexport)
+#elif defined(YYJSON_IMPORTS) && YYJSON_IMPORTS
+#define yyjson_api __declspec(dllimport)
+#else
+#define yyjson_api
+#endif
+#elif yyjson_has_attribute(visibility) || YYJSON_GCC_VER >= 4
+#define yyjson_api __attribute__ ((visibility ("default")))
+#else
+#define yyjson_api
+#endif
 #endif
 
 /** inline function export */
 #ifndef yyjson_api_inline
-#   define yyjson_api_inline static yyjson_inline
+#define yyjson_api_inline static yyjson_inline
 #endif
 
 /** stdint (C89 compatible) */
-#if (defined(YYJSON_HAS_STDINT_H) && YYJSON_HAS_STDINT_H) || \
-    YYJSON_MSC_VER >= 1600 || YYJSON_STDC_VER >= 199901L || \
-    defined(_STDINT_H) || defined(_STDINT_H_) || \
+#if (defined(YYJSON_HAS_STDINT_H) && YYJSON_HAS_STDINT_H) ||    \
+    YYJSON_MSC_VER >= 1600 || YYJSON_STDC_VER >= 199901L ||     \
+    defined(_STDINT_H) || defined(_STDINT_H_) ||                \
     defined(__CLANG_STDINT_H) || defined(_STDINT_H_INCLUDED) || \
     yyjson_has_include(<stdint.h>)
-#   include <stdint.h>
+#include <stdint.h>
 #elif defined(_MSC_VER)
-#   if _MSC_VER < 1300
-        typedef signed char         int8_t;
-        typedef signed short        int16_t;
-        typedef signed int          int32_t;
-        typedef unsigned char       uint8_t;
-        typedef unsigned short      uint16_t;
-        typedef unsigned int        uint32_t;
-        typedef signed __int64      int64_t;
-        typedef unsigned __int64    uint64_t;
-#   else
-        typedef signed __int8       int8_t;
-        typedef signed __int16      int16_t;
-        typedef signed __int32      int32_t;
-        typedef unsigned __int8     uint8_t;
-        typedef unsigned __int16    uint16_t;
-        typedef unsigned __int32    uint32_t;
-        typedef signed __int64      int64_t;
-        typedef unsigned __int64    uint64_t;
-#   endif
+#if _MSC_VER < 1300
+typedef signed char int8_t;
+typedef signed short int16_t;
+typedef signed int int32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef signed __int64 int64_t;
+typedef unsigned __int64 uint64_t;
 #else
-#   if UCHAR_MAX == 0xFFU
-        typedef signed char     int8_t;
-        typedef unsigned char   uint8_t;
-#   else
-#       error cannot find 8-bit integer type
-#   endif
-#   if USHRT_MAX == 0xFFFFU
-        typedef unsigned short  uint16_t;
-        typedef signed short    int16_t;
-#   elif UINT_MAX == 0xFFFFU
-        typedef unsigned int    uint16_t;
-        typedef signed int      int16_t;
-#   else
-#       error cannot find 16-bit integer type
-#   endif
-#   if UINT_MAX == 0xFFFFFFFFUL
-        typedef unsigned int    uint32_t;
-        typedef signed int      int32_t;
-#   elif ULONG_MAX == 0xFFFFFFFFUL
-        typedef unsigned long   uint32_t;
-        typedef signed long     int32_t;
-#   elif USHRT_MAX == 0xFFFFFFFFUL
-        typedef unsigned short  uint32_t;
-        typedef signed short    int32_t;
-#   else
-#       error cannot find 32-bit integer type
-#   endif
-#   if defined(__INT64_TYPE__) && defined(__UINT64_TYPE__)
-        typedef __INT64_TYPE__  int64_t;
-        typedef __UINT64_TYPE__ uint64_t;
-#   elif defined(__GNUC__) || defined(__clang__)
-#       if !defined(_SYS_TYPES_H) && !defined(__int8_t_defined)
-        __extension__ typedef long long             int64_t;
-#       endif
-        __extension__ typedef unsigned long long    uint64_t;
-#   elif defined(_LONG_LONG) || defined(__MWERKS__) || defined(_CRAYC) || \
-        defined(__SUNPRO_C) || defined(__SUNPRO_CC)
-        typedef long long           int64_t;
-        typedef unsigned long long  uint64_t;
-#   elif (defined(__BORLANDC__) && __BORLANDC__ > 0x460) || \
-        defined(__WATCOM_INT64__) || defined (__alpha) || defined (__DECC)
-        typedef __int64             int64_t;
-        typedef unsigned __int64    uint64_t;
-#   else
-#       error cannot find 64-bit integer type
-#   endif
+typedef signed __int8 int8_t;
+typedef signed __int16 int16_t;
+typedef signed __int32 int32_t;
+typedef unsigned __int8 uint8_t;
+typedef unsigned __int16 uint16_t;
+typedef unsigned __int32 uint32_t;
+typedef signed __int64 int64_t;
+typedef unsigned __int64 uint64_t;
+#endif
+#else
+#if UCHAR_MAX == 0xFFU
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+#else
+#error cannot find 8-bit integer type
+#endif
+#if USHRT_MAX == 0xFFFFU
+typedef unsigned short uint16_t;
+typedef signed short int16_t;
+#elif UINT_MAX == 0xFFFFU
+typedef unsigned int uint16_t;
+typedef signed int int16_t;
+#else
+#error cannot find 16-bit integer type
+#endif
+#if UINT_MAX == 0xFFFFFFFFUL
+typedef unsigned int uint32_t;
+typedef signed int int32_t;
+#elif ULONG_MAX == 0xFFFFFFFFUL
+typedef unsigned long uint32_t;
+typedef signed long int32_t;
+#elif USHRT_MAX == 0xFFFFFFFFUL
+typedef unsigned short uint32_t;
+typedef signed short int32_t;
+#else
+#error cannot find 32-bit integer type
+#endif
+#if defined(__INT64_TYPE__) && defined(__UINT64_TYPE__)
+typedef __INT64_TYPE__ int64_t;
+typedef __UINT64_TYPE__ uint64_t;
+#elif defined(__GNUC__) || defined(__clang__)
+#if !defined(_SYS_TYPES_H) && !defined(__int8_t_defined)
+__extension__ typedef long long int64_t;
+#endif
+__extension__ typedef unsigned long long uint64_t;
+#elif defined(_LONG_LONG) || defined(__MWERKS__) || defined(_CRAYC) || \
+    defined(__SUNPRO_C) || defined(__SUNPRO_CC)
+typedef long long int64_t;
+typedef unsigned long long uint64_t;
+#elif (defined(__BORLANDC__) && __BORLANDC__ > 0x460) || \
+    defined(__WATCOM_INT64__) || defined(__alpha) || defined(__DECC)
+typedef __int64 int64_t;
+typedef unsigned __int64 uint64_t;
+#else
+#error cannot find 64-bit integer type
+#endif
 #endif
 
 /** stdbool (C89 compatible) */
-#if (defined(YYJSON_HAS_STDBOOL_H) && YYJSON_HAS_STDBOOL_H) || \
+#if (defined(YYJSON_HAS_STDBOOL_H) && YYJSON_HAS_STDBOOL_H) ||        \
     (yyjson_has_include(<stdbool.h>) && !defined(__STRICT_ANSI__)) || \
     YYJSON_MSC_VER >= 1800 || YYJSON_STDC_VER >= 199901L
-#   include <stdbool.h>
+#include <stdbool.h>
 #elif !defined(__bool_true_false_are_defined)
-#   define __bool_true_false_are_defined 1
-#   if defined(__cplusplus)
-#       if defined(__GNUC__) && !defined(__STRICT_ANSI__)
-#           define _Bool bool
-#           if __cplusplus < 201103L
-#               define bool bool
-#               define false false
-#               define true true
-#           endif
-#       endif
-#   else
-#       define bool unsigned char
-#       define true 1
-#       define false 0
-#   endif
+#define __bool_true_false_are_defined 1
+#if defined(__cplusplus)
+#if defined(__GNUC__) && !defined(__STRICT_ANSI__)
+#define _Bool bool
+#if __cplusplus < 201103L
+#define bool bool
+#define false false
+#define true true
+#endif
+#endif
+#else
+#define bool unsigned char
+#define true 1
+#define false 0
+#endif
 #endif
 
 /** char bit check */
 #if defined(CHAR_BIT)
-#   if CHAR_BIT != 8
-#       error non 8-bit char is not supported
-#   endif
+#if CHAR_BIT != 8
+#error non 8-bit char is not supported
+#endif
 #endif
 
 /**
@@ -379,14 +373,12 @@
  error C2520: conversion from unsigned __int64 to double not implemented.
  */
 #ifndef YYJSON_U64_TO_F64_NO_IMPL
-#   if (0 < YYJSON_MSC_VER) && (YYJSON_MSC_VER <= 1200)
-#       define YYJSON_U64_TO_F64_NO_IMPL 1
-#   else
-#       define YYJSON_U64_TO_F64_NO_IMPL 0
-#   endif
+#if (0 < YYJSON_MSC_VER) && (YYJSON_MSC_VER <= 1200)
+#define YYJSON_U64_TO_F64_NO_IMPL 1
+#else
+#define YYJSON_U64_TO_F64_NO_IMPL 0
 #endif
-
-
+#endif
 
 /*==============================================================================
  * Compile Hint Begin
@@ -394,411 +386,402 @@
 
 /* extern "C" begin */
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 /* warning suppress begin */
 #if defined(__clang__)
-#   pragma clang diagnostic push
-#   pragma clang diagnostic ignored "-Wunused-function"
-#   pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunused-parameter"
 #elif defined(__GNUC__)
-#   if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
-#   pragma GCC diagnostic push
-#   endif
-#   pragma GCC diagnostic ignored "-Wunused-function"
-#   pragma GCC diagnostic ignored "-Wunused-parameter"
-#elif defined(_MSC_VER)
-#   pragma warning(push)
-#   pragma warning(disable:4800) /* 'int': forcing value to 'true' or 'false' */
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+#pragma GCC diagnostic push
 #endif
-
-
+#pragma GCC diagnostic ignored "-Wunused-function"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4800) /* 'int': forcing value to 'true' or 'false' */
+#endif
 
 /*==============================================================================
  * Version
  *============================================================================*/
 
 /** The major version of yyjson. */
-#define YYJSON_VERSION_MAJOR  0
+#define YYJSON_VERSION_MAJOR 0
 
 /** The minor version of yyjson. */
-#define YYJSON_VERSION_MINOR  6
+#define YYJSON_VERSION_MINOR 6
 
 /** The patch version of yyjson. */
-#define YYJSON_VERSION_PATCH  0
+#define YYJSON_VERSION_PATCH 0
 
 /** The version of yyjson in hex: `(major << 16) | (minor << 8) | (patch)`. */
-#define YYJSON_VERSION_HEX    0x000600
+#define YYJSON_VERSION_HEX 0x000600
 
 /** The version string of yyjson. */
 #define YYJSON_VERSION_STRING "0.6.0"
 
-/** The version of yyjson in hex, same as `YYJSON_VERSION_HEX`. */
-yyjson_api uint32_t yyjson_version(void);
+  /** The version of yyjson in hex, same as `YYJSON_VERSION_HEX`. */
+  yyjson_api uint32_t yyjson_version (void);
 
+  /*==============================================================================
+   * JSON Types
+   *============================================================================*/
 
+  /** Type of JSON value (3 bit). */
+  typedef uint8_t yyjson_type;
+#define YYJSON_TYPE_NONE ((uint8_t)0) /* _____000 */
+#define YYJSON_TYPE_RAW ((uint8_t)1)  /* _____001 */
+#define YYJSON_TYPE_NULL ((uint8_t)2) /* _____010 */
+#define YYJSON_TYPE_BOOL ((uint8_t)3) /* _____011 */
+#define YYJSON_TYPE_NUM ((uint8_t)4)  /* _____100 */
+#define YYJSON_TYPE_STR ((uint8_t)5)  /* _____101 */
+#define YYJSON_TYPE_ARR ((uint8_t)6)  /* _____110 */
+#define YYJSON_TYPE_OBJ ((uint8_t)7)  /* _____111 */
 
-/*==============================================================================
- * JSON Types
- *============================================================================*/
-
-/** Type of JSON value (3 bit). */
-typedef uint8_t yyjson_type;
-#define YYJSON_TYPE_NONE        ((uint8_t)0)        /* _____000 */
-#define YYJSON_TYPE_RAW         ((uint8_t)1)        /* _____001 */
-#define YYJSON_TYPE_NULL        ((uint8_t)2)        /* _____010 */
-#define YYJSON_TYPE_BOOL        ((uint8_t)3)        /* _____011 */
-#define YYJSON_TYPE_NUM         ((uint8_t)4)        /* _____100 */
-#define YYJSON_TYPE_STR         ((uint8_t)5)        /* _____101 */
-#define YYJSON_TYPE_ARR         ((uint8_t)6)        /* _____110 */
-#define YYJSON_TYPE_OBJ         ((uint8_t)7)        /* _____111 */
-
-/** Subtype of JSON value (2 bit). */
-typedef uint8_t yyjson_subtype;
-#define YYJSON_SUBTYPE_NONE     ((uint8_t)(0 << 3)) /* ___00___ */
-#define YYJSON_SUBTYPE_FALSE    ((uint8_t)(0 << 3)) /* ___00___ */
-#define YYJSON_SUBTYPE_TRUE     ((uint8_t)(1 << 3)) /* ___01___ */
-#define YYJSON_SUBTYPE_UINT     ((uint8_t)(0 << 3)) /* ___00___ */
-#define YYJSON_SUBTYPE_SINT     ((uint8_t)(1 << 3)) /* ___01___ */
-#define YYJSON_SUBTYPE_REAL     ((uint8_t)(2 << 3)) /* ___10___ */
+  /** Subtype of JSON value (2 bit). */
+  typedef uint8_t yyjson_subtype;
+#define YYJSON_SUBTYPE_NONE ((uint8_t)(0 << 3))  /* ___00___ */
+#define YYJSON_SUBTYPE_FALSE ((uint8_t)(0 << 3)) /* ___00___ */
+#define YYJSON_SUBTYPE_TRUE ((uint8_t)(1 << 3))  /* ___01___ */
+#define YYJSON_SUBTYPE_UINT ((uint8_t)(0 << 3))  /* ___00___ */
+#define YYJSON_SUBTYPE_SINT ((uint8_t)(1 << 3))  /* ___01___ */
+#define YYJSON_SUBTYPE_REAL ((uint8_t)(2 << 3))  /* ___10___ */
 
 /** Mask and bits of JSON value tag. */
-#define YYJSON_TYPE_MASK        ((uint8_t)0x07)     /* _____111 */
-#define YYJSON_TYPE_BIT         ((uint8_t)3)
-#define YYJSON_SUBTYPE_MASK     ((uint8_t)0x18)     /* ___11___ */
-#define YYJSON_SUBTYPE_BIT      ((uint8_t)2)
-#define YYJSON_RESERVED_MASK    ((uint8_t)0xE0)     /* 111_____ */
-#define YYJSON_RESERVED_BIT     ((uint8_t)3)
-#define YYJSON_TAG_MASK         ((uint8_t)0xFF)     /* 11111111 */
-#define YYJSON_TAG_BIT          ((uint8_t)8)
+#define YYJSON_TYPE_MASK ((uint8_t)0x07) /* _____111 */
+#define YYJSON_TYPE_BIT ((uint8_t)3)
+#define YYJSON_SUBTYPE_MASK ((uint8_t)0x18) /* ___11___ */
+#define YYJSON_SUBTYPE_BIT ((uint8_t)2)
+#define YYJSON_RESERVED_MASK ((uint8_t)0xE0) /* 111_____ */
+#define YYJSON_RESERVED_BIT ((uint8_t)3)
+#define YYJSON_TAG_MASK ((uint8_t)0xFF) /* 11111111 */
+#define YYJSON_TAG_BIT ((uint8_t)8)
 
 /** Padding size for JSON reader. */
-#define YYJSON_PADDING_SIZE     4
+#define YYJSON_PADDING_SIZE 4
 
+  /*==============================================================================
+   * Allocator
+   *============================================================================*/
 
+  /**
+   A memory allocator.
 
-/*==============================================================================
- * Allocator
- *============================================================================*/
-
-/**
- A memory allocator.
- 
- Typically you don't need to use it, unless you want to customize your own
- memory allocator.
- */
-typedef struct yyjson_alc {
+   Typically you don't need to use it, unless you want to customize your own
+   memory allocator.
+   */
+  typedef struct yyjson_alc
+  {
     /** Same as libc's malloc(size), should not be NULL. */
-    void *(*malloc)(void *ctx, size_t size);
+    void *(*malloc) (void *ctx, size_t size);
     /** Same as libc's realloc(ptr, size), should not be NULL. */
-    void *(*realloc)(void *ctx, void *ptr, size_t old_size, size_t size);
+    void *(*realloc) (void *ctx, void *ptr, size_t old_size, size_t size);
     /** Same as libc's free(ptr), should not be NULL. */
-    void (*free)(void *ctx, void *ptr);
+    void (*free) (void *ctx, void *ptr);
     /** A context for malloc/realloc/free, can be NULL. */
     void *ctx;
-} yyjson_alc;
+  } yyjson_alc;
 
-/**
- A pool allocator uses fixed length pre-allocated memory.
- 
- This allocator may used to avoid malloc/realloc calls. The pre-allocated memory
- should be held by the caller. The maximum amount of memory required to read a
- JSON can be calculated using the `yyjson_read_max_memory_usage()` function, but
- the amount of memory required to write a JSON cannot be directly calculated.
- 
- This is not a general-purpose allocator, and should only be used to read or
- write single JSON document.
- 
- @param alc The allocator to be initialized.
-    If this parameter is NULL, the function will fail and return false.
-    If `buf` or `size` is invalid, this will be set to an empty allocator.
- @param buf The buffer memory for this allocator.
-    If this parameter is NULL, the function will fail and return false.
- @param size The size of `buf`, in bytes.
-    If this parameter is less than 8 words (32/64 bytes on 32/64-bit OS), the
-    function will fail and return false.
- @return true if the `alc` has been successfully initialized.
- 
- @par Example
- @code
-    // parse JSON with stack memory
-    char buf[1024];
-    yyjson_alc alc;
-    yyjson_alc_pool_init(&alc, buf, 1024);
-    
-    const char *json = "{\"name\":\"Helvetica\",\"size\":16}"
-    yyjson_doc *doc = yyjson_read_opts(json, strlen(json), 0, &alc, NULL);
-    // the memory of `doc` is on the stack
- @endcode
- */
-yyjson_api bool yyjson_alc_pool_init(yyjson_alc *alc, void *buf, size_t size);
+  /**
+   A pool allocator uses fixed length pre-allocated memory.
 
+   This allocator may used to avoid malloc/realloc calls. The pre-allocated memory
+   should be held by the caller. The maximum amount of memory required to read a
+   JSON can be calculated using the `yyjson_read_max_memory_usage()` function, but
+   the amount of memory required to write a JSON cannot be directly calculated.
 
+   This is not a general-purpose allocator, and should only be used to read or
+   write single JSON document.
 
-/*==============================================================================
- * JSON Structure
- *============================================================================*/
+   @param alc The allocator to be initialized.
+      If this parameter is NULL, the function will fail and return false.
+      If `buf` or `size` is invalid, this will be set to an empty allocator.
+   @param buf The buffer memory for this allocator.
+      If this parameter is NULL, the function will fail and return false.
+   @param size The size of `buf`, in bytes.
+      If this parameter is less than 8 words (32/64 bytes on 32/64-bit OS), the
+      function will fail and return false.
+   @return true if the `alc` has been successfully initialized.
 
-/**
- An immutable document for reading JSON.
- This document holds memory for all its JSON values and strings. When it is no
- longer used, the user should call `yyjson_doc_free()` to free its memory.
- */
-typedef struct yyjson_doc yyjson_doc;
+   @par Example
+   @code
+      // parse JSON with stack memory
+      char buf[1024];
+      yyjson_alc alc;
+      yyjson_alc_pool_init(&alc, buf, 1024);
 
-/**
- An immutable value for reading JSON.
- A JSON Value has the same lifetime as its document. The memory is held by its
- document and and cannot be freed alone.
- */
-typedef struct yyjson_val yyjson_val;
+      const char *json = "{\"name\":\"Helvetica\",\"size\":16}"
+      yyjson_doc *doc = yyjson_read_opts(json, strlen(json), 0, &alc, NULL);
+      // the memory of `doc` is on the stack
+   @endcode
+   */
+  yyjson_api bool yyjson_alc_pool_init (yyjson_alc *alc, void *buf, size_t size);
 
-/**
- A mutable document for building JSON.
- This document holds memory for all its JSON values and strings. When it is no
- longer used, the user should call `yyjson_mut_doc_free()` to free its memory.
- */
-typedef struct yyjson_mut_doc yyjson_mut_doc;
+  /*==============================================================================
+   * JSON Structure
+   *============================================================================*/
 
-/**
- A mutable value for building JSON.
- A JSON Value has the same lifetime as its document. The memory is held by its
- document and and cannot be freed alone.
- */
-typedef struct yyjson_mut_val yyjson_mut_val;
+  /**
+   An immutable document for reading JSON.
+   This document holds memory for all its JSON values and strings. When it is no
+   longer used, the user should call `yyjson_doc_free()` to free its memory.
+   */
+  typedef struct yyjson_doc yyjson_doc;
 
+  /**
+   An immutable value for reading JSON.
+   A JSON Value has the same lifetime as its document. The memory is held by its
+   document and and cannot be freed alone.
+   */
+  typedef struct yyjson_val yyjson_val;
 
+  /**
+   A mutable document for building JSON.
+   This document holds memory for all its JSON values and strings. When it is no
+   longer used, the user should call `yyjson_mut_doc_free()` to free its memory.
+   */
+  typedef struct yyjson_mut_doc yyjson_mut_doc;
 
-/*==============================================================================
- * JSON Reader API
- *============================================================================*/
+  /**
+   A mutable value for building JSON.
+   A JSON Value has the same lifetime as its document. The memory is held by its
+   document and and cannot be freed alone.
+   */
+  typedef struct yyjson_mut_val yyjson_mut_val;
 
-/** Run-time options for JSON reader. */
-typedef uint32_t yyjson_read_flag;
+  /*==============================================================================
+   * JSON Reader API
+   *============================================================================*/
 
-/** Default option (RFC 8259 compliant):
-    - Read positive integer as uint64_t.
-    - Read negative integer as int64_t.
-    - Read floating-point number as double with round-to-nearest mode.
-    - Read integer which cannot fit in uint64_t or int64_t as double.
-    - Report error if real number is infinity.
-    - Report error if string contains invalid UTF-8 character or BOM.
-    - Report error on trailing commas, comments, inf and nan literals. */
-static const yyjson_read_flag YYJSON_READ_NOFLAG                = 0 << 0;
+  /** Run-time options for JSON reader. */
+  typedef uint32_t yyjson_read_flag;
 
-/** Read the input data in-situ.
-    This option allows the reader to modify and use input data to store string
-    values, which can increase reading speed slightly.
-    The caller should hold the input data before free the document.
-    The input data must be padded by at least `YYJSON_PADDING_SIZE` bytes.
-    For example: `[1,2]` should be `[1,2]\0\0\0\0`, input length should be 5. */
-static const yyjson_read_flag YYJSON_READ_INSITU                = 1 << 0;
+  /** Default option (RFC 8259 compliant):
+      - Read positive integer as uint64_t.
+      - Read negative integer as int64_t.
+      - Read floating-point number as double with round-to-nearest mode.
+      - Read integer which cannot fit in uint64_t or int64_t as double.
+      - Report error if real number is infinity.
+      - Report error if string contains invalid UTF-8 character or BOM.
+      - Report error on trailing commas, comments, inf and nan literals. */
+  static const yyjson_read_flag YYJSON_READ_NOFLAG = 0 << 0;
 
-/** Stop when done instead of issuing an error if there's additional content
-    after a JSON document. This option may be used to parse small pieces of JSON
-    in larger data, such as `NDJSON`. */
-static const yyjson_read_flag YYJSON_READ_STOP_WHEN_DONE        = 1 << 1;
+  /** Read the input data in-situ.
+      This option allows the reader to modify and use input data to store string
+      values, which can increase reading speed slightly.
+      The caller should hold the input data before free the document.
+      The input data must be padded by at least `YYJSON_PADDING_SIZE` bytes.
+      For example: `[1,2]` should be `[1,2]\0\0\0\0`, input length should be 5. */
+  static const yyjson_read_flag YYJSON_READ_INSITU = 1 << 0;
 
-/** Allow single trailing comma at the end of an object or array,
-    such as `[1,2,3,]`, `{"a":1,"b":2,}` (non-standard). */
-static const yyjson_read_flag YYJSON_READ_ALLOW_TRAILING_COMMAS = 1 << 2;
+  /** Stop when done instead of issuing an error if there's additional content
+      after a JSON document. This option may be used to parse small pieces of JSON
+      in larger data, such as `NDJSON`. */
+  static const yyjson_read_flag YYJSON_READ_STOP_WHEN_DONE = 1 << 1;
 
-/** Allow C-style single line and multiple line comments (non-standard). */
-static const yyjson_read_flag YYJSON_READ_ALLOW_COMMENTS        = 1 << 3;
+  /** Allow single trailing comma at the end of an object or array,
+      such as `[1,2,3,]`, `{"a":1,"b":2,}` (non-standard). */
+  static const yyjson_read_flag YYJSON_READ_ALLOW_TRAILING_COMMAS = 1 << 2;
 
-/** Allow inf/nan number and literal, case-insensitive,
-    such as 1e999, NaN, inf, -Infinity (non-standard). */
-static const yyjson_read_flag YYJSON_READ_ALLOW_INF_AND_NAN     = 1 << 4;
+  /** Allow C-style single line and multiple line comments (non-standard). */
+  static const yyjson_read_flag YYJSON_READ_ALLOW_COMMENTS = 1 << 3;
 
-/** Read number as raw string (value with `YYJSON_TYPE_RAW` type),
-    inf/nan literal is also read as raw with `ALLOW_INF_AND_NAN` flag. */
-static const yyjson_read_flag YYJSON_READ_NUMBER_AS_RAW         = 1 << 5;
+  /** Allow inf/nan number and literal, case-insensitive,
+      such as 1e999, NaN, inf, -Infinity (non-standard). */
+  static const yyjson_read_flag YYJSON_READ_ALLOW_INF_AND_NAN = 1 << 4;
 
-/** Allow reading invalid unicode when parsing string values (non-standard).
-    Invalid characters will be allowed to appear in the string values, but
-    invalid escape sequences will still be reported as errors.
-    This flag does not affect the performance of correctly encoded strings.
-    
-    @warning Strings in JSON values may contain incorrect encoding when this
-    option is used, you need to handle these strings carefully to avoid security
-    risks. */
-static const yyjson_read_flag YYJSON_READ_ALLOW_INVALID_UNICODE = 1 << 6;
+  /** Read number as raw string (value with `YYJSON_TYPE_RAW` type),
+      inf/nan literal is also read as raw with `ALLOW_INF_AND_NAN` flag. */
+  static const yyjson_read_flag YYJSON_READ_NUMBER_AS_RAW = 1 << 5;
 
+  /** Allow reading invalid unicode when parsing string values (non-standard).
+      Invalid characters will be allowed to appear in the string values, but
+      invalid escape sequences will still be reported as errors.
+      This flag does not affect the performance of correctly encoded strings.
 
+      @warning Strings in JSON values may contain incorrect encoding when this
+      option is used, you need to handle these strings carefully to avoid security
+      risks. */
+  static const yyjson_read_flag YYJSON_READ_ALLOW_INVALID_UNICODE = 1 << 6;
 
-/** Result code for JSON reader. */
-typedef uint32_t yyjson_read_code;
+  /** Result code for JSON reader. */
+  typedef uint32_t yyjson_read_code;
 
-/** Success, no error. */
-static const yyjson_read_code YYJSON_READ_SUCCESS                       = 0;
+  /** Success, no error. */
+  static const yyjson_read_code YYJSON_READ_SUCCESS = 0;
 
-/** Invalid parameter, such as NULL input string or 0 input length. */
-static const yyjson_read_code YYJSON_READ_ERROR_INVALID_PARAMETER       = 1;
+  /** Invalid parameter, such as NULL input string or 0 input length. */
+  static const yyjson_read_code YYJSON_READ_ERROR_INVALID_PARAMETER = 1;
 
-/** Memory allocation failure occurs. */
-static const yyjson_read_code YYJSON_READ_ERROR_MEMORY_ALLOCATION       = 2;
+  /** Memory allocation failure occurs. */
+  static const yyjson_read_code YYJSON_READ_ERROR_MEMORY_ALLOCATION = 2;
 
-/** Input JSON string is empty. */
-static const yyjson_read_code YYJSON_READ_ERROR_EMPTY_CONTENT           = 3;
+  /** Input JSON string is empty. */
+  static const yyjson_read_code YYJSON_READ_ERROR_EMPTY_CONTENT = 3;
 
-/** Unexpected content after document, such as `[123]abc`. */
-static const yyjson_read_code YYJSON_READ_ERROR_UNEXPECTED_CONTENT      = 4;
+  /** Unexpected content after document, such as `[123]abc`. */
+  static const yyjson_read_code YYJSON_READ_ERROR_UNEXPECTED_CONTENT = 4;
 
-/** Unexpected ending, such as `[123`. */
-static const yyjson_read_code YYJSON_READ_ERROR_UNEXPECTED_END          = 5;
+  /** Unexpected ending, such as `[123`. */
+  static const yyjson_read_code YYJSON_READ_ERROR_UNEXPECTED_END = 5;
 
-/** Unexpected character inside the document, such as `[abc]`. */
-static const yyjson_read_code YYJSON_READ_ERROR_UNEXPECTED_CHARACTER    = 6;
+  /** Unexpected character inside the document, such as `[abc]`. */
+  static const yyjson_read_code YYJSON_READ_ERROR_UNEXPECTED_CHARACTER = 6;
 
-/** Invalid JSON structure, such as `[1,]`. */
-static const yyjson_read_code YYJSON_READ_ERROR_JSON_STRUCTURE          = 7;
+  /** Invalid JSON structure, such as `[1,]`. */
+  static const yyjson_read_code YYJSON_READ_ERROR_JSON_STRUCTURE = 7;
 
-/** Invalid comment, such as unclosed multi-line comment. */
-static const yyjson_read_code YYJSON_READ_ERROR_INVALID_COMMENT         = 8;
+  /** Invalid comment, such as unclosed multi-line comment. */
+  static const yyjson_read_code YYJSON_READ_ERROR_INVALID_COMMENT = 8;
 
-/** Invalid number, such as `123.e12`, `000`. */
-static const yyjson_read_code YYJSON_READ_ERROR_INVALID_NUMBER          = 9;
+  /** Invalid number, such as `123.e12`, `000`. */
+  static const yyjson_read_code YYJSON_READ_ERROR_INVALID_NUMBER = 9;
 
-/** Invalid string, such as invalid escaped character inside a string. */
-static const yyjson_read_code YYJSON_READ_ERROR_INVALID_STRING          = 10;
+  /** Invalid string, such as invalid escaped character inside a string. */
+  static const yyjson_read_code YYJSON_READ_ERROR_INVALID_STRING = 10;
 
-/** Invalid JSON literal, such as `truu`. */
-static const yyjson_read_code YYJSON_READ_ERROR_LITERAL                 = 11;
+  /** Invalid JSON literal, such as `truu`. */
+  static const yyjson_read_code YYJSON_READ_ERROR_LITERAL = 11;
 
-/** Failed to open a file. */
-static const yyjson_read_code YYJSON_READ_ERROR_FILE_OPEN               = 12;
+  /** Failed to open a file. */
+  static const yyjson_read_code YYJSON_READ_ERROR_FILE_OPEN = 12;
 
-/** Failed to read a file. */
-static const yyjson_read_code YYJSON_READ_ERROR_FILE_READ               = 13;
+  /** Failed to read a file. */
+  static const yyjson_read_code YYJSON_READ_ERROR_FILE_READ = 13;
 
-/** Error information for JSON reader. */
-typedef struct yyjson_read_err {
+  /** Error information for JSON reader. */
+  typedef struct yyjson_read_err
+  {
     /** Error code, see `yyjson_read_code` for all possible values. */
     yyjson_read_code code;
     /** Error message, constant, no need to free (NULL if success). */
     const char *msg;
     /** Error byte position for input data (0 if success). */
     size_t pos;
-} yyjson_read_err;
+  } yyjson_read_err;
 
+  /**
+   Read JSON with options.
 
+   This function is thread-safe when:
+   1. The `dat` is not modified by other threads.
+   2. The `alc` is thread-safe or NULL.
 
-/**
- Read JSON with options.
- 
- This function is thread-safe when:
- 1. The `dat` is not modified by other threads.
- 2. The `alc` is thread-safe or NULL.
- 
- @param dat The JSON data (UTF-8 without BOM), null-terminator is not required.
-    If this parameter is NULL, the function will fail and return NULL.
-    The `dat` will not be modified without the flag `YYJSON_READ_INSITU`, so you
-    can pass a `const char *` string and case it to `char *` if you don't use
-    the `YYJSON_READ_INSITU` flag.
- @param len The length of JSON data in bytes.
-    If this parameter is 0, the function will fail and return NULL.
- @param flg The JSON read options.
-    Multiple options can be combined with `|` operator. 0 means no options.
- @param alc The memory allocator used by JSON reader.
-    Pass NULL to use the libc's default allocator.
- @param err A pointer to receive error information.
-    Pass NULL if you don't need error information.
- @return A new JSON document, or NULL if an error occurs.
-    When it's no longer needed, it should be freed with `yyjson_doc_free()`.
- */
-yyjson_api yyjson_doc *yyjson_read_opts(char *dat,
-                                        size_t len,
-                                        yyjson_read_flag flg,
-                                        const yyjson_alc *alc,
-                                        yyjson_read_err *err);
+   @param dat The JSON data (UTF-8 without BOM), null-terminator is not required.
+      If this parameter is NULL, the function will fail and return NULL.
+      The `dat` will not be modified without the flag `YYJSON_READ_INSITU`, so you
+      can pass a `const char *` string and case it to `char *` if you don't use
+      the `YYJSON_READ_INSITU` flag.
+   @param len The length of JSON data in bytes.
+      If this parameter is 0, the function will fail and return NULL.
+   @param flg The JSON read options.
+      Multiple options can be combined with `|` operator. 0 means no options.
+   @param alc The memory allocator used by JSON reader.
+      Pass NULL to use the libc's default allocator.
+   @param err A pointer to receive error information.
+      Pass NULL if you don't need error information.
+   @return A new JSON document, or NULL if an error occurs.
+      When it's no longer needed, it should be freed with `yyjson_doc_free()`.
+   */
+  yyjson_api yyjson_doc *yyjson_read_opts (char *dat,
+                                           size_t len,
+                                           yyjson_read_flag flg,
+                                           const yyjson_alc *alc,
+                                           yyjson_read_err *err);
 
-/**
- Read a JSON file.
- 
- This function is thread-safe when:
- 1. The file is not modified by other threads.
- 2. The `alc` is thread-safe or NULL.
- 
- @param path The JSON file's path.
-    If this path is NULL or invalid, the function will fail and return NULL.
- @param flg The JSON read options.
-    Multiple options can be combined with `|` operator. 0 means no options.
- @param alc The memory allocator used by JSON reader.
-    Pass NULL to use the libc's default allocator.
- @param err A pointer to receive error information.
-    Pass NULL if you don't need error information.
- @return A new JSON document, or NULL if an error occurs.
-    When it's no longer needed, it should be freed with `yyjson_doc_free()`.
- 
- @warning On 32-bit operating system, files larger than 2GB may fail to read.
- */
-yyjson_api yyjson_doc *yyjson_read_file(const char *path,
-                                        yyjson_read_flag flg,
-                                        const yyjson_alc *alc,
-                                        yyjson_read_err *err);
+  /**
+   Read a JSON file.
 
-/**
- Read a JSON string.
- 
- This function is thread-safe.
- 
- @param dat The JSON data (UTF-8 without BOM), null-terminator is not required.
-    If this parameter is NULL, the function will fail and return NULL.
- @param len The length of JSON data in bytes.
-    If this parameter is 0, the function will fail and return NULL.
- @param flg The JSON read options.
-    Multiple options can be combined with `|` operator. 0 means no options.
- @return A new JSON document, or NULL if an error occurs.
-    When it's no longer needed, it should be freed with `yyjson_doc_free()`.
- */
-yyjson_api_inline yyjson_doc *yyjson_read(const char *dat,
-                                          size_t len,
-                                          yyjson_read_flag flg) {
+   This function is thread-safe when:
+   1. The file is not modified by other threads.
+   2. The `alc` is thread-safe or NULL.
+
+   @param path The JSON file's path.
+      If this path is NULL or invalid, the function will fail and return NULL.
+   @param flg The JSON read options.
+      Multiple options can be combined with `|` operator. 0 means no options.
+   @param alc The memory allocator used by JSON reader.
+      Pass NULL to use the libc's default allocator.
+   @param err A pointer to receive error information.
+      Pass NULL if you don't need error information.
+   @return A new JSON document, or NULL if an error occurs.
+      When it's no longer needed, it should be freed with `yyjson_doc_free()`.
+
+   @warning On 32-bit operating system, files larger than 2GB may fail to read.
+   */
+  yyjson_api yyjson_doc *yyjson_read_file (const char *path,
+                                           yyjson_read_flag flg,
+                                           const yyjson_alc *alc,
+                                           yyjson_read_err *err);
+
+  /**
+   Read a JSON string.
+
+   This function is thread-safe.
+
+   @param dat The JSON data (UTF-8 without BOM), null-terminator is not required.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param len The length of JSON data in bytes.
+      If this parameter is 0, the function will fail and return NULL.
+   @param flg The JSON read options.
+      Multiple options can be combined with `|` operator. 0 means no options.
+   @return A new JSON document, or NULL if an error occurs.
+      When it's no longer needed, it should be freed with `yyjson_doc_free()`.
+   */
+  yyjson_api_inline yyjson_doc *yyjson_read (const char *dat,
+                                             size_t len,
+                                             yyjson_read_flag flg)
+  {
     flg &= ~YYJSON_READ_INSITU; /* const string cannot be modified */
-    return yyjson_read_opts((char *)(void *)(size_t)(const void *)dat, 
-                            len, flg, NULL, NULL);
-}
+    return yyjson_read_opts ((char *)(void *)(size_t)(const void *)dat,
+                             len, flg, NULL, NULL);
+  }
 
-/**
- Returns the size of maximum memory usage to read a JSON data.
- 
- You may use this value to avoid malloc() or calloc() call inside the reader
- to get better performance, or read multiple JSON with one piece of memory.
- 
- @param len The length of JSON data in bytes.
- @param flg The JSON read options.
- @return The maximum memory size to read this JSON, or 0 if overflow.
- 
- @par Example
- @code
-    // read multiple JSON with same pre-allocated memory
-    
-    char *dat1, *dat2, *dat3; // JSON data
-    size_t len1, len2, len3; // JSON length
-    size_t max_len = MAX(len1, MAX(len2, len3));
-    yyjson_doc *doc;
-    
-    // use one allocator for multiple JSON
-    size_t size = yyjson_read_max_memory_usage(max_len, 0);
-    void *buf = malloc(size);
-    yyjson_alc alc;
-    yyjson_alc_pool_init(&alc, buf, size);
-    
-    // no more alloc() or realloc() call during reading
-    doc = yyjson_read_opts(dat1, len1, 0, &alc, NULL);
-    yyjson_doc_free(doc);
-    doc = yyjson_read_opts(dat2, len2, 0, &alc, NULL);
-    yyjson_doc_free(doc);
-    doc = yyjson_read_opts(dat3, len3, 0, &alc, NULL);
-    yyjson_doc_free(doc);
-    
-    free(buf);
- @endcode
- @see yyjson_alc_pool_init()
- */
-yyjson_api_inline size_t yyjson_read_max_memory_usage(size_t len,
-                                                      yyjson_read_flag flg) {
+  /**
+   Returns the size of maximum memory usage to read a JSON data.
+
+   You may use this value to avoid malloc() or calloc() call inside the reader
+   to get better performance, or read multiple JSON with one piece of memory.
+
+   @param len The length of JSON data in bytes.
+   @param flg The JSON read options.
+   @return The maximum memory size to read this JSON, or 0 if overflow.
+
+   @par Example
+   @code
+      // read multiple JSON with same pre-allocated memory
+
+      char *dat1, *dat2, *dat3; // JSON data
+      size_t len1, len2, len3; // JSON length
+      size_t max_len = MAX(len1, MAX(len2, len3));
+      yyjson_doc *doc;
+
+      // use one allocator for multiple JSON
+      size_t size = yyjson_read_max_memory_usage(max_len, 0);
+      void *buf = malloc(size);
+      yyjson_alc alc;
+      yyjson_alc_pool_init(&alc, buf, size);
+
+      // no more alloc() or realloc() call during reading
+      doc = yyjson_read_opts(dat1, len1, 0, &alc, NULL);
+      yyjson_doc_free(doc);
+      doc = yyjson_read_opts(dat2, len2, 0, &alc, NULL);
+      yyjson_doc_free(doc);
+      doc = yyjson_read_opts(dat3, len3, 0, &alc, NULL);
+      yyjson_doc_free(doc);
+
+      free(buf);
+   @endcode
+   @see yyjson_alc_pool_init()
+   */
+  yyjson_api_inline size_t yyjson_read_max_memory_usage (size_t len,
+                                                         yyjson_read_flag flg)
+  {
     /*
      1. The max value count is (json_size / 2 + 1),
         for example: "[1,2,3,4]" size is 9, value count is 5.
@@ -806,770 +789,760 @@ yyjson_api_inline size_t yyjson_read_max_memory_usage(size_t len,
         for example: "[[[[[[[[".
      3. yyjson use 16 bytes per value, see struct yyjson_val.
      4. yyjson use dynamic memory with a growth factor of 1.5.
-     
+
      The max memory size is (json_size / 2 * 16 * 1.5 + padding).
      */
     size_t mul = (size_t)12 + !(flg & YYJSON_READ_INSITU);
     size_t pad = 256;
     size_t max = (size_t)(~(size_t)0);
-    if (flg & YYJSON_READ_STOP_WHEN_DONE) len = len < 256 ? 256 : len;
-    if (len >= (max - pad - mul) / mul) return 0;
+    if (flg & YYJSON_READ_STOP_WHEN_DONE)
+      len = len < 256 ? 256 : len;
+    if (len >= (max - pad - mul) / mul)
+      return 0;
     return len * mul + pad;
-}
+  }
 
-/**
- Read a JSON number.
+  /**
+   Read a JSON number.
 
- This function is thread-safe when data is not modified by other threads.
+   This function is thread-safe when data is not modified by other threads.
 
- @param dat The JSON data (UTF-8 without BOM), null-terminator is required.
-    If this parameter is NULL, the function will fail and return NULL.
- @param val The output value where result is stored.
-    If this parameter is NULL, the function will fail and return NULL.
-    The value will hold either UINT or SINT or REAL number;
- @param flg The JSON read options.
-    Multiple options can be combined with `|` operator. 0 means no options.
-    Suppors `YYJSON_READ_NUMBER_AS_RAW` and `YYJSON_READ_ALLOW_INF_AND_NAN`.
- @param alc The memory allocator used for long number.
-    It is only used when the built-in floating point reader is disabled.
-    Pass NULL to use the libc's default allocator.
- @param err A pointer to receive error information.
-    Pass NULL if you don't need error information.
- @return If successful, a pointer to the character after the last character
-    used in the conversion, NULL if an error occurs.
- */
-yyjson_api const char *yyjson_read_number(const char *dat,
-                                          yyjson_val *val,
-                                          yyjson_read_flag flg,
-                                          const yyjson_alc *alc,
-                                          yyjson_read_err *err);
+   @param dat The JSON data (UTF-8 without BOM), null-terminator is required.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param val The output value where result is stored.
+      If this parameter is NULL, the function will fail and return NULL.
+      The value will hold either UINT or SINT or REAL number;
+   @param flg The JSON read options.
+      Multiple options can be combined with `|` operator. 0 means no options.
+      Suppors `YYJSON_READ_NUMBER_AS_RAW` and `YYJSON_READ_ALLOW_INF_AND_NAN`.
+   @param alc The memory allocator used for long number.
+      It is only used when the built-in floating point reader is disabled.
+      Pass NULL to use the libc's default allocator.
+   @param err A pointer to receive error information.
+      Pass NULL if you don't need error information.
+   @return If successful, a pointer to the character after the last character
+      used in the conversion, NULL if an error occurs.
+   */
+  yyjson_api const char *yyjson_read_number (const char *dat,
+                                             yyjson_val *val,
+                                             yyjson_read_flag flg,
+                                             const yyjson_alc *alc,
+                                             yyjson_read_err *err);
 
-/**
- Read a JSON number.
+  /**
+   Read a JSON number.
 
- This function is thread-safe when data is not modified by other threads.
+   This function is thread-safe when data is not modified by other threads.
 
- @param dat The JSON data (UTF-8 without BOM), null-terminator is required.
-    If this parameter is NULL, the function will fail and return NULL.
- @param val The output value where result is stored.
-    If this parameter is NULL, the function will fail and return NULL.
-    The value will hold either UINT or SINT or REAL number;
- @param flg The JSON read options.
-    Multiple options can be combined with `|` operator. 0 means no options.
-    Suppors `YYJSON_READ_NUMBER_AS_RAW` and `YYJSON_READ_ALLOW_INF_AND_NAN`.
- @param alc The memory allocator used for long number.
-    It is only used when the built-in floating point reader is disabled.
-    Pass NULL to use the libc's default allocator.
- @param err A pointer to receive error information.
-    Pass NULL if you don't need error information.
- @return If successful, a pointer to the character after the last character
-    used in the conversion, NULL if an error occurs.
- */
-yyjson_api_inline const char *yyjson_mut_read_number(const char *dat,
-                                                     yyjson_mut_val *val,
-                                                     yyjson_read_flag flg,
-                                                     const yyjson_alc *alc,
-                                                     yyjson_read_err *err) {
-    return yyjson_read_number(dat, (yyjson_val *)val, flg, alc, err);
-}
+   @param dat The JSON data (UTF-8 without BOM), null-terminator is required.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param val The output value where result is stored.
+      If this parameter is NULL, the function will fail and return NULL.
+      The value will hold either UINT or SINT or REAL number;
+   @param flg The JSON read options.
+      Multiple options can be combined with `|` operator. 0 means no options.
+      Suppors `YYJSON_READ_NUMBER_AS_RAW` and `YYJSON_READ_ALLOW_INF_AND_NAN`.
+   @param alc The memory allocator used for long number.
+      It is only used when the built-in floating point reader is disabled.
+      Pass NULL to use the libc's default allocator.
+   @param err A pointer to receive error information.
+      Pass NULL if you don't need error information.
+   @return If successful, a pointer to the character after the last character
+      used in the conversion, NULL if an error occurs.
+   */
+  yyjson_api_inline const char *yyjson_mut_read_number (const char *dat,
+                                                        yyjson_mut_val *val,
+                                                        yyjson_read_flag flg,
+                                                        const yyjson_alc *alc,
+                                                        yyjson_read_err *err)
+  {
+    return yyjson_read_number (dat, (yyjson_val *)val, flg, alc, err);
+  }
 
+  /*==============================================================================
+   * JSON Writer API
+   *============================================================================*/
 
-/*==============================================================================
- * JSON Writer API
- *============================================================================*/
+  /** Run-time options for JSON writer. */
+  typedef uint32_t yyjson_write_flag;
 
-/** Run-time options for JSON writer. */
-typedef uint32_t yyjson_write_flag;
+  /** Default option:
+      - Write JSON minify.
+      - Report error on inf or nan number.
+      - Report error on invalid UTF-8 string.
+      - Do not escape unicode or slash. */
+  static const yyjson_write_flag YYJSON_WRITE_NOFLAG = 0 << 0;
 
-/** Default option:
-    - Write JSON minify.
-    - Report error on inf or nan number.
-    - Report error on invalid UTF-8 string.
-    - Do not escape unicode or slash. */
-static const yyjson_write_flag YYJSON_WRITE_NOFLAG                  = 0 << 0;
+  /** Write JSON pretty with 4 space indent. */
+  static const yyjson_write_flag YYJSON_WRITE_PRETTY = 1 << 0;
 
-/** Write JSON pretty with 4 space indent. */
-static const yyjson_write_flag YYJSON_WRITE_PRETTY                  = 1 << 0;
+  /** Escape unicode as `uXXXX`, make the output ASCII only. */
+  static const yyjson_write_flag YYJSON_WRITE_ESCAPE_UNICODE = 1 << 1;
 
-/** Escape unicode as `uXXXX`, make the output ASCII only. */
-static const yyjson_write_flag YYJSON_WRITE_ESCAPE_UNICODE          = 1 << 1;
+  /** Escape '/' as '\/'. */
+  static const yyjson_write_flag YYJSON_WRITE_ESCAPE_SLASHES = 1 << 2;
 
-/** Escape '/' as '\/'. */
-static const yyjson_write_flag YYJSON_WRITE_ESCAPE_SLASHES          = 1 << 2;
+  /** Write inf and nan number as 'Infinity' and 'NaN' literal (non-standard). */
+  static const yyjson_write_flag YYJSON_WRITE_ALLOW_INF_AND_NAN = 1 << 3;
 
-/** Write inf and nan number as 'Infinity' and 'NaN' literal (non-standard). */
-static const yyjson_write_flag YYJSON_WRITE_ALLOW_INF_AND_NAN       = 1 << 3;
+  /** Write inf and nan number as null literal.
+      This flag will override `YYJSON_WRITE_ALLOW_INF_AND_NAN` flag. */
+  static const yyjson_write_flag YYJSON_WRITE_INF_AND_NAN_AS_NULL = 1 << 4;
 
-/** Write inf and nan number as null literal.
-    This flag will override `YYJSON_WRITE_ALLOW_INF_AND_NAN` flag. */
-static const yyjson_write_flag YYJSON_WRITE_INF_AND_NAN_AS_NULL     = 1 << 4;
+  /** Allow invalid unicode when encoding string values (non-standard).
+      Invalid characters in string value will be copied byte by byte.
+      If `YYJSON_WRITE_ESCAPE_UNICODE` flag is also set, invalid character will be
+      escaped as `U+FFFD` (replacement character).
+      This flag does not affect the performance of correctly encoded strings. */
+  static const yyjson_write_flag YYJSON_WRITE_ALLOW_INVALID_UNICODE = 1 << 5;
 
-/** Allow invalid unicode when encoding string values (non-standard).
-    Invalid characters in string value will be copied byte by byte.
-    If `YYJSON_WRITE_ESCAPE_UNICODE` flag is also set, invalid character will be
-    escaped as `U+FFFD` (replacement character).
-    This flag does not affect the performance of correctly encoded strings. */
-static const yyjson_write_flag YYJSON_WRITE_ALLOW_INVALID_UNICODE   = 1 << 5;
+  /** Write JSON pretty with 2 space indent.
+      This flag will override `YYJSON_WRITE_PRETTY` flag. */
+  static const yyjson_write_flag YYJSON_WRITE_PRETTY_TWO_SPACES = 1 << 6;
 
-/** Write JSON pretty with 2 space indent.
-    This flag will override `YYJSON_WRITE_PRETTY` flag. */
-static const yyjson_write_flag YYJSON_WRITE_PRETTY_TWO_SPACES       = 1 << 6;
+  /** Result code for JSON writer */
+  typedef uint32_t yyjson_write_code;
 
+  /** Success, no error. */
+  static const yyjson_write_code YYJSON_WRITE_SUCCESS = 0;
 
+  /** Invalid parameter, such as NULL document. */
+  static const yyjson_write_code YYJSON_WRITE_ERROR_INVALID_PARAMETER = 1;
 
-/** Result code for JSON writer */
-typedef uint32_t yyjson_write_code;
+  /** Memory allocation failure occurs. */
+  static const yyjson_write_code YYJSON_WRITE_ERROR_MEMORY_ALLOCATION = 2;
 
-/** Success, no error. */
-static const yyjson_write_code YYJSON_WRITE_SUCCESS                     = 0;
+  /** Invalid value type in JSON document. */
+  static const yyjson_write_code YYJSON_WRITE_ERROR_INVALID_VALUE_TYPE = 3;
 
-/** Invalid parameter, such as NULL document. */
-static const yyjson_write_code YYJSON_WRITE_ERROR_INVALID_PARAMETER     = 1;
+  /** NaN or Infinity number occurs. */
+  static const yyjson_write_code YYJSON_WRITE_ERROR_NAN_OR_INF = 4;
 
-/** Memory allocation failure occurs. */
-static const yyjson_write_code YYJSON_WRITE_ERROR_MEMORY_ALLOCATION     = 2;
+  /** Failed to open a file. */
+  static const yyjson_write_code YYJSON_WRITE_ERROR_FILE_OPEN = 5;
 
-/** Invalid value type in JSON document. */
-static const yyjson_write_code YYJSON_WRITE_ERROR_INVALID_VALUE_TYPE    = 3;
+  /** Failed to write a file. */
+  static const yyjson_write_code YYJSON_WRITE_ERROR_FILE_WRITE = 6;
 
-/** NaN or Infinity number occurs. */
-static const yyjson_write_code YYJSON_WRITE_ERROR_NAN_OR_INF            = 4;
+  /** Invalid unicode in string. */
+  static const yyjson_write_code YYJSON_WRITE_ERROR_INVALID_STRING = 7;
 
-/** Failed to open a file. */
-static const yyjson_write_code YYJSON_WRITE_ERROR_FILE_OPEN             = 5;
-
-/** Failed to write a file. */
-static const yyjson_write_code YYJSON_WRITE_ERROR_FILE_WRITE            = 6;
-
-/** Invalid unicode in string. */
-static const yyjson_write_code YYJSON_WRITE_ERROR_INVALID_STRING        = 7;
-
-/** Error information for JSON writer. */
-typedef struct yyjson_write_err {
+  /** Error information for JSON writer. */
+  typedef struct yyjson_write_err
+  {
     /** Error code, see `yyjson_write_code` for all possible values. */
     yyjson_write_code code;
     /** Error message, constant, no need to free (NULL if success). */
     const char *msg;
-} yyjson_write_err;
+  } yyjson_write_err;
 
+  /*==============================================================================
+   * JSON Document Writer API
+   *============================================================================*/
 
+  /**
+   Write a document to JSON string with options.
 
-/*==============================================================================
- * JSON Document Writer API
- *============================================================================*/
+   This function is thread-safe when:
+   The `alc` is thread-safe or NULL.
 
-/**
- Write a document to JSON string with options.
- 
- This function is thread-safe when:
- The `alc` is thread-safe or NULL.
- 
- @param doc The JSON document.
-    If this doc is NULL or has no root, the function will fail and return false.
- @param flg The JSON write options.
-    Multiple options can be combined with `|` operator. 0 means no options.
- @param alc The memory allocator used by JSON writer.
-    Pass NULL to use the libc's default allocator.
- @param len A pointer to receive output length in bytes (not including the
-    null-terminator). Pass NULL if you don't need length information.
- @param err A pointer to receive error information.
-    Pass NULL if you don't need error information.
- @return A new JSON string, or NULL if an error occurs.
-    This string is encoded as UTF-8 with a null-terminator.
-    When it's no longer needed, it should be freed with free() or alc->free().
- */
-yyjson_api char *yyjson_write_opts(const yyjson_doc *doc,
-                                   yyjson_write_flag flg,
-                                   const yyjson_alc *alc,
-                                   size_t *len,
-                                   yyjson_write_err *err);
+   @param doc The JSON document.
+      If this doc is NULL or has no root, the function will fail and return false.
+   @param flg The JSON write options.
+      Multiple options can be combined with `|` operator. 0 means no options.
+   @param alc The memory allocator used by JSON writer.
+      Pass NULL to use the libc's default allocator.
+   @param len A pointer to receive output length in bytes (not including the
+      null-terminator). Pass NULL if you don't need length information.
+   @param err A pointer to receive error information.
+      Pass NULL if you don't need error information.
+   @return A new JSON string, or NULL if an error occurs.
+      This string is encoded as UTF-8 with a null-terminator.
+      When it's no longer needed, it should be freed with free() or alc->free().
+   */
+  yyjson_api char *yyjson_write_opts (const yyjson_doc *doc,
+                                      yyjson_write_flag flg,
+                                      const yyjson_alc *alc,
+                                      size_t *len,
+                                      yyjson_write_err *err);
 
-/**
- Write a document to JSON file with options.
- 
- This function is thread-safe when:
- 1. The file is not accessed by other threads.
- 2. The `alc` is thread-safe or NULL.
+  /**
+   Write a document to JSON file with options.
 
- @param path The JSON file's path.
-    If this path is NULL or invalid, the function will fail and return false.
-    If this file is not empty, the content will be discarded.
- @param doc The JSON document.
-    If this doc is NULL or has no root, the function will fail and return false.
- @param flg The JSON write options.
-    Multiple options can be combined with `|` operator. 0 means no options.
- @param alc The memory allocator used by JSON writer.
-    Pass NULL to use the libc's default allocator.
- @param err A pointer to receive error information.
-    Pass NULL if you don't need error information.
- @return true if successful, false if an error occurs.
- 
- @warning On 32-bit operating system, files larger than 2GB may fail to write.
- */
-yyjson_api bool yyjson_write_file(const char *path,
-                                  const yyjson_doc *doc,
-                                  yyjson_write_flag flg,
-                                  const yyjson_alc *alc,
-                                  yyjson_write_err *err);
+   This function is thread-safe when:
+   1. The file is not accessed by other threads.
+   2. The `alc` is thread-safe or NULL.
 
-/**
- Write a document to JSON string.
- 
- This function is thread-safe.
- 
- @param doc The JSON document.
-    If this doc is NULL or has no root, the function will fail and return false.
- @param flg The JSON write options.
-    Multiple options can be combined with `|` operator. 0 means no options.
- @param len A pointer to receive output length in bytes (not including the
-    null-terminator). Pass NULL if you don't need length information.
- @return A new JSON string, or NULL if an error occurs.
-    This string is encoded as UTF-8 with a null-terminator.
-    When it's no longer needed, it should be freed with free().
- */
-yyjson_api_inline char *yyjson_write(const yyjson_doc *doc,
+   @param path The JSON file's path.
+      If this path is NULL or invalid, the function will fail and return false.
+      If this file is not empty, the content will be discarded.
+   @param doc The JSON document.
+      If this doc is NULL or has no root, the function will fail and return false.
+   @param flg The JSON write options.
+      Multiple options can be combined with `|` operator. 0 means no options.
+   @param alc The memory allocator used by JSON writer.
+      Pass NULL to use the libc's default allocator.
+   @param err A pointer to receive error information.
+      Pass NULL if you don't need error information.
+   @return true if successful, false if an error occurs.
+
+   @warning On 32-bit operating system, files larger than 2GB may fail to write.
+   */
+  yyjson_api bool yyjson_write_file (const char *path,
+                                     const yyjson_doc *doc,
                                      yyjson_write_flag flg,
-                                     size_t *len) {
-    return yyjson_write_opts(doc, flg, NULL, len, NULL);
-}
+                                     const yyjson_alc *alc,
+                                     yyjson_write_err *err);
 
+  /**
+   Write a document to JSON string.
 
+   This function is thread-safe.
 
-/**
- Write a document to JSON string with options.
- 
- This function is thread-safe when:
- 1. The `doc` is not modified by other threads.
- 2. The `alc` is thread-safe or NULL.
+   @param doc The JSON document.
+      If this doc is NULL or has no root, the function will fail and return false.
+   @param flg The JSON write options.
+      Multiple options can be combined with `|` operator. 0 means no options.
+   @param len A pointer to receive output length in bytes (not including the
+      null-terminator). Pass NULL if you don't need length information.
+   @return A new JSON string, or NULL if an error occurs.
+      This string is encoded as UTF-8 with a null-terminator.
+      When it's no longer needed, it should be freed with free().
+   */
+  yyjson_api_inline char *yyjson_write (const yyjson_doc *doc,
+                                        yyjson_write_flag flg,
+                                        size_t *len)
+  {
+    return yyjson_write_opts (doc, flg, NULL, len, NULL);
+  }
 
- @param doc The mutable JSON document.
-    If this doc is NULL or has no root, the function will fail and return false.
- @param flg The JSON write options.
-    Multiple options can be combined with `|` operator. 0 means no options.
- @param alc The memory allocator used by JSON writer.
-    Pass NULL to use the libc's default allocator.
- @param len A pointer to receive output length in bytes (not including the
-    null-terminator). Pass NULL if you don't need length information.
- @param err A pointer to receive error information.
-    Pass NULL if you don't need error information.
- @return A new JSON string, or NULL if an error occurs.
-    This string is encoded as UTF-8 with a null-terminator.
-    When it's no longer needed, it should be freed with free() or alc->free().
- */
-yyjson_api char *yyjson_mut_write_opts(const yyjson_mut_doc *doc,
-                                       yyjson_write_flag flg,
-                                       const yyjson_alc *alc,
-                                       size_t *len,
-                                       yyjson_write_err *err);
+  /**
+   Write a document to JSON string with options.
 
-/**
- Write a document to JSON file with options.
- 
- This function is thread-safe when:
- 1. The file is not accessed by other threads.
- 2. The `doc` is not modified by other threads.
- 3. The `alc` is thread-safe or NULL.
- 
- @param path The JSON file's path.
-    If this path is NULL or invalid, the function will fail and return false.
-    If this file is not empty, the content will be discarded.
- @param doc The mutable JSON document.
-    If this doc is NULL or has no root, the function will fail and return false.
- @param flg The JSON write options.
-    Multiple options can be combined with `|` operator. 0 means no options.
- @param alc The memory allocator used by JSON writer.
-    Pass NULL to use the libc's default allocator.
- @param err A pointer to receive error information.
-    Pass NULL if you don't need error information.
- @return true if successful, false if an error occurs.
- 
- @warning On 32-bit operating system, files larger than 2GB may fail to write.
- */
-yyjson_api bool yyjson_mut_write_file(const char *path,
-                                      const yyjson_mut_doc *doc,
-                                      yyjson_write_flag flg,
-                                      const yyjson_alc *alc,
-                                      yyjson_write_err *err);
+   This function is thread-safe when:
+   1. The `doc` is not modified by other threads.
+   2. The `alc` is thread-safe or NULL.
 
-/**
- Write a document to JSON string.
- 
- This function is thread-safe when:
- The `doc` is not modified by other threads.
- 
- @param doc The JSON document.
-    If this doc is NULL or has no root, the function will fail and return false.
- @param flg The JSON write options.
-    Multiple options can be combined with `|` operator. 0 means no options.
- @param len A pointer to receive output length in bytes (not including the
-    null-terminator). Pass NULL if you don't need length information.
- @return A new JSON string, or NULL if an error occurs.
-    This string is encoded as UTF-8 with a null-terminator.
-    When it's no longer needed, it should be freed with free().
- */
-yyjson_api_inline char *yyjson_mut_write(const yyjson_mut_doc *doc,
-                                         yyjson_write_flag flg,
-                                         size_t *len) {
-    return yyjson_mut_write_opts(doc, flg, NULL, len, NULL);
-}
-
-
-
-/*==============================================================================
- * JSON Value Writer API
- *============================================================================*/
-
-/**
- Write a value to JSON string with options.
- 
- This function is thread-safe when:
- The `alc` is thread-safe or NULL.
- 
- @param val The JSON root value.
-    If this parameter is NULL, the function will fail and return NULL.
- @param flg The JSON write options.
-    Multiple options can be combined with `|` operator. 0 means no options.
- @param alc The memory allocator used by JSON writer.
-    Pass NULL to use the libc's default allocator.
- @param len A pointer to receive output length in bytes (not including the
-    null-terminator). Pass NULL if you don't need length information.
- @param err A pointer to receive error information.
-    Pass NULL if you don't need error information.
- @return A new JSON string, or NULL if an error occurs.
-    This string is encoded as UTF-8 with a null-terminator.
-    When it's no longer needed, it should be freed with free() or alc->free().
- */
-yyjson_api char *yyjson_val_write_opts(const yyjson_val *val,
-                                       yyjson_write_flag flg,
-                                       const yyjson_alc *alc,
-                                       size_t *len,
-                                       yyjson_write_err *err);
-
-/**
- Write a value to JSON file with options.
- 
- This function is thread-safe when:
- 1. The file is not accessed by other threads.
- 2. The `alc` is thread-safe or NULL.
- 
- @param path The JSON file's path.
-    If this path is NULL or invalid, the function will fail and return false.
-    If this file is not empty, the content will be discarded.
- @param val The JSON root value.
-    If this parameter is NULL, the function will fail and return NULL.
- @param flg The JSON write options.
-    Multiple options can be combined with `|` operator. 0 means no options.
- @param alc The memory allocator used by JSON writer.
-    Pass NULL to use the libc's default allocator.
- @param err A pointer to receive error information.
-    Pass NULL if you don't need error information.
- @return true if successful, false if an error occurs.
- 
- @warning On 32-bit operating system, files larger than 2GB may fail to write.
- */
-yyjson_api bool yyjson_val_write_file(const char *path,
-                                      const yyjson_val *val,
-                                      yyjson_write_flag flg,
-                                      const yyjson_alc *alc,
-                                      yyjson_write_err *err);
-
-/**
- Write a value to JSON string.
- 
- This function is thread-safe.
- 
- @param val The JSON root value.
-    If this parameter is NULL, the function will fail and return NULL.
- @param flg The JSON write options.
-    Multiple options can be combined with `|` operator. 0 means no options.
- @param len A pointer to receive output length in bytes (not including the
-    null-terminator). Pass NULL if you don't need length information.
- @return A new JSON string, or NULL if an error occurs.
-    This string is encoded as UTF-8 with a null-terminator.
-    When it's no longer needed, it should be freed with free().
- */
-yyjson_api_inline char *yyjson_val_write(const yyjson_val *val,
-                                         yyjson_write_flag flg,
-                                         size_t *len) {
-    return yyjson_val_write_opts(val, flg, NULL, len, NULL);
-}
-
-/**
- Write a value to JSON string with options.
- 
- This function is thread-safe when:
- 1. The `val` is not modified by other threads.
- 2. The `alc` is thread-safe or NULL.
- 
- @param val The mutable JSON root value.
-    If this parameter is NULL, the function will fail and return NULL.
- @param flg The JSON write options.
-    Multiple options can be combined with `|` operator. 0 means no options.
- @param alc The memory allocator used by JSON writer.
-    Pass NULL to use the libc's default allocator.
- @param len A pointer to receive output length in bytes (not including the
-    null-terminator). Pass NULL if you don't need length information.
- @param err A pointer to receive error information.
-    Pass NULL if you don't need error information.
- @return  A new JSON string, or NULL if an error occurs.
-    This string is encoded as UTF-8 with a null-terminator.
-    When it's no longer needed, it should be freed with free() or alc->free().
- */
-yyjson_api char *yyjson_mut_val_write_opts(const yyjson_mut_val *val,
-                                           yyjson_write_flag flg,
-                                           const yyjson_alc *alc,
-                                           size_t *len,
-                                           yyjson_write_err *err);
-
-/**
- Write a value to JSON file with options.
- 
- This function is thread-safe when:
- 1. The file is not accessed by other threads.
- 2. The `val` is not modified by other threads.
- 3. The `alc` is thread-safe or NULL.
- 
- @param path The JSON file's path.
-    If this path is NULL or invalid, the function will fail and return false.
-    If this file is not empty, the content will be discarded.
- @param val The mutable JSON root value.
-    If this parameter is NULL, the function will fail and return NULL.
- @param flg The JSON write options.
-    Multiple options can be combined with `|` operator. 0 means no options.
- @param alc The memory allocator used by JSON writer.
-    Pass NULL to use the libc's default allocator.
- @param err A pointer to receive error information.
-    Pass NULL if you don't need error information.
- @return true if successful, false if an error occurs.
- 
- @warning On 32-bit operating system, files larger than 2GB may fail to write.
- */
-yyjson_api bool yyjson_mut_val_write_file(const char *path,
-                                          const yyjson_mut_val *val,
+   @param doc The mutable JSON document.
+      If this doc is NULL or has no root, the function will fail and return false.
+   @param flg The JSON write options.
+      Multiple options can be combined with `|` operator. 0 means no options.
+   @param alc The memory allocator used by JSON writer.
+      Pass NULL to use the libc's default allocator.
+   @param len A pointer to receive output length in bytes (not including the
+      null-terminator). Pass NULL if you don't need length information.
+   @param err A pointer to receive error information.
+      Pass NULL if you don't need error information.
+   @return A new JSON string, or NULL if an error occurs.
+      This string is encoded as UTF-8 with a null-terminator.
+      When it's no longer needed, it should be freed with free() or alc->free().
+   */
+  yyjson_api char *yyjson_mut_write_opts (const yyjson_mut_doc *doc,
                                           yyjson_write_flag flg,
                                           const yyjson_alc *alc,
+                                          size_t *len,
                                           yyjson_write_err *err);
 
-/**
- Write a value to JSON string.
- 
- This function is thread-safe when:
- The `val` is not modified by other threads.
- 
- @param val The JSON root value.
-    If this parameter is NULL, the function will fail and return NULL.
- @param flg The JSON write options.
-    Multiple options can be combined with `|` operator. 0 means no options.
- @param len A pointer to receive output length in bytes (not including the
-    null-terminator). Pass NULL if you don't need length information.
- @return A new JSON string, or NULL if an error occurs.
-    This string is encoded as UTF-8 with a null-terminator.
-    When it's no longer needed, it should be freed with free().
- */
-yyjson_api_inline char *yyjson_mut_val_write(const yyjson_mut_val *val,
+  /**
+   Write a document to JSON file with options.
+
+   This function is thread-safe when:
+   1. The file is not accessed by other threads.
+   2. The `doc` is not modified by other threads.
+   3. The `alc` is thread-safe or NULL.
+
+   @param path The JSON file's path.
+      If this path is NULL or invalid, the function will fail and return false.
+      If this file is not empty, the content will be discarded.
+   @param doc The mutable JSON document.
+      If this doc is NULL or has no root, the function will fail and return false.
+   @param flg The JSON write options.
+      Multiple options can be combined with `|` operator. 0 means no options.
+   @param alc The memory allocator used by JSON writer.
+      Pass NULL to use the libc's default allocator.
+   @param err A pointer to receive error information.
+      Pass NULL if you don't need error information.
+   @return true if successful, false if an error occurs.
+
+   @warning On 32-bit operating system, files larger than 2GB may fail to write.
+   */
+  yyjson_api bool yyjson_mut_write_file (const char *path,
+                                         const yyjson_mut_doc *doc,
+                                         yyjson_write_flag flg,
+                                         const yyjson_alc *alc,
+                                         yyjson_write_err *err);
+
+  /**
+   Write a document to JSON string.
+
+   This function is thread-safe when:
+   The `doc` is not modified by other threads.
+
+   @param doc The JSON document.
+      If this doc is NULL or has no root, the function will fail and return false.
+   @param flg The JSON write options.
+      Multiple options can be combined with `|` operator. 0 means no options.
+   @param len A pointer to receive output length in bytes (not including the
+      null-terminator). Pass NULL if you don't need length information.
+   @return A new JSON string, or NULL if an error occurs.
+      This string is encoded as UTF-8 with a null-terminator.
+      When it's no longer needed, it should be freed with free().
+   */
+  yyjson_api_inline char *yyjson_mut_write (const yyjson_mut_doc *doc,
+                                            yyjson_write_flag flg,
+                                            size_t *len)
+  {
+    return yyjson_mut_write_opts (doc, flg, NULL, len, NULL);
+  }
+
+  /*==============================================================================
+   * JSON Value Writer API
+   *============================================================================*/
+
+  /**
+   Write a value to JSON string with options.
+
+   This function is thread-safe when:
+   The `alc` is thread-safe or NULL.
+
+   @param val The JSON root value.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param flg The JSON write options.
+      Multiple options can be combined with `|` operator. 0 means no options.
+   @param alc The memory allocator used by JSON writer.
+      Pass NULL to use the libc's default allocator.
+   @param len A pointer to receive output length in bytes (not including the
+      null-terminator). Pass NULL if you don't need length information.
+   @param err A pointer to receive error information.
+      Pass NULL if you don't need error information.
+   @return A new JSON string, or NULL if an error occurs.
+      This string is encoded as UTF-8 with a null-terminator.
+      When it's no longer needed, it should be freed with free() or alc->free().
+   */
+  yyjson_api char *yyjson_val_write_opts (const yyjson_val *val,
+                                          yyjson_write_flag flg,
+                                          const yyjson_alc *alc,
+                                          size_t *len,
+                                          yyjson_write_err *err);
+
+  /**
+   Write a value to JSON file with options.
+
+   This function is thread-safe when:
+   1. The file is not accessed by other threads.
+   2. The `alc` is thread-safe or NULL.
+
+   @param path The JSON file's path.
+      If this path is NULL or invalid, the function will fail and return false.
+      If this file is not empty, the content will be discarded.
+   @param val The JSON root value.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param flg The JSON write options.
+      Multiple options can be combined with `|` operator. 0 means no options.
+   @param alc The memory allocator used by JSON writer.
+      Pass NULL to use the libc's default allocator.
+   @param err A pointer to receive error information.
+      Pass NULL if you don't need error information.
+   @return true if successful, false if an error occurs.
+
+   @warning On 32-bit operating system, files larger than 2GB may fail to write.
+   */
+  yyjson_api bool yyjson_val_write_file (const char *path,
+                                         const yyjson_val *val,
+                                         yyjson_write_flag flg,
+                                         const yyjson_alc *alc,
+                                         yyjson_write_err *err);
+
+  /**
+   Write a value to JSON string.
+
+   This function is thread-safe.
+
+   @param val The JSON root value.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param flg The JSON write options.
+      Multiple options can be combined with `|` operator. 0 means no options.
+   @param len A pointer to receive output length in bytes (not including the
+      null-terminator). Pass NULL if you don't need length information.
+   @return A new JSON string, or NULL if an error occurs.
+      This string is encoded as UTF-8 with a null-terminator.
+      When it's no longer needed, it should be freed with free().
+   */
+  yyjson_api_inline char *yyjson_val_write (const yyjson_val *val,
+                                            yyjson_write_flag flg,
+                                            size_t *len)
+  {
+    return yyjson_val_write_opts (val, flg, NULL, len, NULL);
+  }
+
+  /**
+   Write a value to JSON string with options.
+
+   This function is thread-safe when:
+   1. The `val` is not modified by other threads.
+   2. The `alc` is thread-safe or NULL.
+
+   @param val The mutable JSON root value.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param flg The JSON write options.
+      Multiple options can be combined with `|` operator. 0 means no options.
+   @param alc The memory allocator used by JSON writer.
+      Pass NULL to use the libc's default allocator.
+   @param len A pointer to receive output length in bytes (not including the
+      null-terminator). Pass NULL if you don't need length information.
+   @param err A pointer to receive error information.
+      Pass NULL if you don't need error information.
+   @return  A new JSON string, or NULL if an error occurs.
+      This string is encoded as UTF-8 with a null-terminator.
+      When it's no longer needed, it should be freed with free() or alc->free().
+   */
+  yyjson_api char *yyjson_mut_val_write_opts (const yyjson_mut_val *val,
+                                              yyjson_write_flag flg,
+                                              const yyjson_alc *alc,
+                                              size_t *len,
+                                              yyjson_write_err *err);
+
+  /**
+   Write a value to JSON file with options.
+
+   This function is thread-safe when:
+   1. The file is not accessed by other threads.
+   2. The `val` is not modified by other threads.
+   3. The `alc` is thread-safe or NULL.
+
+   @param path The JSON file's path.
+      If this path is NULL or invalid, the function will fail and return false.
+      If this file is not empty, the content will be discarded.
+   @param val The mutable JSON root value.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param flg The JSON write options.
+      Multiple options can be combined with `|` operator. 0 means no options.
+   @param alc The memory allocator used by JSON writer.
+      Pass NULL to use the libc's default allocator.
+   @param err A pointer to receive error information.
+      Pass NULL if you don't need error information.
+   @return true if successful, false if an error occurs.
+
+   @warning On 32-bit operating system, files larger than 2GB may fail to write.
+   */
+  yyjson_api bool yyjson_mut_val_write_file (const char *path,
+                                             const yyjson_mut_val *val,
                                              yyjson_write_flag flg,
-                                             size_t *len) {
-    return yyjson_mut_val_write_opts(val, flg, NULL, len, NULL);
-}
+                                             const yyjson_alc *alc,
+                                             yyjson_write_err *err);
 
+  /**
+   Write a value to JSON string.
 
+   This function is thread-safe when:
+   The `val` is not modified by other threads.
 
-/*==============================================================================
- * JSON Document API
- *============================================================================*/
+   @param val The JSON root value.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param flg The JSON write options.
+      Multiple options can be combined with `|` operator. 0 means no options.
+   @param len A pointer to receive output length in bytes (not including the
+      null-terminator). Pass NULL if you don't need length information.
+   @return A new JSON string, or NULL if an error occurs.
+      This string is encoded as UTF-8 with a null-terminator.
+      When it's no longer needed, it should be freed with free().
+   */
+  yyjson_api_inline char *yyjson_mut_val_write (const yyjson_mut_val *val,
+                                                yyjson_write_flag flg,
+                                                size_t *len)
+  {
+    return yyjson_mut_val_write_opts (val, flg, NULL, len, NULL);
+  }
 
-/** Returns the root value of this JSON document.
-    Returns NULL if `doc` is NULL. */
-yyjson_api_inline yyjson_val *yyjson_doc_get_root(yyjson_doc *doc);
+  /*==============================================================================
+   * JSON Document API
+   *============================================================================*/
 
-/** Returns read size of input JSON data.
-    Returns 0 if `doc` is NULL.
-    For example: the read size of `[1,2,3]` is 7 bytes.  */
-yyjson_api_inline size_t yyjson_doc_get_read_size(yyjson_doc *doc);
+  /** Returns the root value of this JSON document.
+      Returns NULL if `doc` is NULL. */
+  yyjson_api_inline yyjson_val *yyjson_doc_get_root (yyjson_doc *doc);
 
-/** Returns total value count in this JSON document.
-    Returns 0 if `doc` is NULL.
-    For example: the value count of `[1,2,3]` is 4. */
-yyjson_api_inline size_t yyjson_doc_get_val_count(yyjson_doc *doc);
+  /** Returns read size of input JSON data.
+      Returns 0 if `doc` is NULL.
+      For example: the read size of `[1,2,3]` is 7 bytes.  */
+  yyjson_api_inline size_t yyjson_doc_get_read_size (yyjson_doc *doc);
 
-/** Release the JSON document and free the memory.
-    After calling this function, the `doc` and all values from the `doc` are no
-    longer available. This function will do nothing if the `doc` is NULL. */
-yyjson_api_inline void yyjson_doc_free(yyjson_doc *doc);
+  /** Returns total value count in this JSON document.
+      Returns 0 if `doc` is NULL.
+      For example: the value count of `[1,2,3]` is 4. */
+  yyjson_api_inline size_t yyjson_doc_get_val_count (yyjson_doc *doc);
 
+  /** Release the JSON document and free the memory.
+      After calling this function, the `doc` and all values from the `doc` are no
+      longer available. This function will do nothing if the `doc` is NULL. */
+  yyjson_api_inline void yyjson_doc_free (yyjson_doc *doc);
 
+  /*==============================================================================
+   * JSON Value Type API
+   *============================================================================*/
 
-/*==============================================================================
- * JSON Value Type API
- *============================================================================*/
+  /** Returns whether the JSON value is raw.
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_is_raw (yyjson_val *val);
 
-/** Returns whether the JSON value is raw.
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_is_raw(yyjson_val *val);
+  /** Returns whether the JSON value is `null`.
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_is_null (yyjson_val *val);
 
-/** Returns whether the JSON value is `null`.
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_is_null(yyjson_val *val);
+  /** Returns whether the JSON value is `true`.
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_is_true (yyjson_val *val);
 
-/** Returns whether the JSON value is `true`.
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_is_true(yyjson_val *val);
+  /** Returns whether the JSON value is `false`.
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_is_false (yyjson_val *val);
 
-/** Returns whether the JSON value is `false`.
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_is_false(yyjson_val *val);
+  /** Returns whether the JSON value is bool (true/false).
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_is_bool (yyjson_val *val);
 
-/** Returns whether the JSON value is bool (true/false).
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_is_bool(yyjson_val *val);
+  /** Returns whether the JSON value is unsigned integer (uint64_t).
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_is_uint (yyjson_val *val);
 
-/** Returns whether the JSON value is unsigned integer (uint64_t).
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_is_uint(yyjson_val *val);
+  /** Returns whether the JSON value is signed integer (int64_t).
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_is_sint (yyjson_val *val);
 
-/** Returns whether the JSON value is signed integer (int64_t).
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_is_sint(yyjson_val *val);
+  /** Returns whether the JSON value is integer (uint64_t/int64_t).
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_is_int (yyjson_val *val);
 
-/** Returns whether the JSON value is integer (uint64_t/int64_t).
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_is_int(yyjson_val *val);
+  /** Returns whether the JSON value is real number (double).
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_is_real (yyjson_val *val);
 
-/** Returns whether the JSON value is real number (double).
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_is_real(yyjson_val *val);
+  /** Returns whether the JSON value is number (uint64_t/int64_t/double).
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_is_num (yyjson_val *val);
 
-/** Returns whether the JSON value is number (uint64_t/int64_t/double).
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_is_num(yyjson_val *val);
+  /** Returns whether the JSON value is string.
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_is_str (yyjson_val *val);
 
-/** Returns whether the JSON value is string.
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_is_str(yyjson_val *val);
+  /** Returns whether the JSON value is array.
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_is_arr (yyjson_val *val);
 
-/** Returns whether the JSON value is array.
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_is_arr(yyjson_val *val);
+  /** Returns whether the JSON value is object.
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_is_obj (yyjson_val *val);
 
-/** Returns whether the JSON value is object.
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_is_obj(yyjson_val *val);
+  /** Returns whether the JSON value is container (array/object).
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_is_ctn (yyjson_val *val);
 
-/** Returns whether the JSON value is container (array/object).
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_is_ctn(yyjson_val *val);
+  /*==============================================================================
+   * JSON Value Content API
+   *============================================================================*/
 
+  /** Returns the JSON value's type.
+      Returns YYJSON_TYPE_NONE if `val` is NULL. */
+  yyjson_api_inline yyjson_type yyjson_get_type (yyjson_val *val);
 
+  /** Returns the JSON value's subtype.
+      Returns YYJSON_SUBTYPE_NONE if `val` is NULL. */
+  yyjson_api_inline yyjson_subtype yyjson_get_subtype (yyjson_val *val);
 
-/*==============================================================================
- * JSON Value Content API
- *============================================================================*/
+  /** Returns the JSON value's tag.
+      Returns 0 if `val` is NULL. */
+  yyjson_api_inline uint8_t yyjson_get_tag (yyjson_val *val);
 
-/** Returns the JSON value's type.
-    Returns YYJSON_TYPE_NONE if `val` is NULL. */
-yyjson_api_inline yyjson_type yyjson_get_type(yyjson_val *val);
+  /** Returns the JSON value's type description.
+      The return value should be one of these strings: "raw", "null", "string",
+      "array", "object", "true", "false", "uint", "sint", "real", "unknown". */
+  yyjson_api_inline const char *yyjson_get_type_desc (yyjson_val *val);
 
-/** Returns the JSON value's subtype.
-    Returns YYJSON_SUBTYPE_NONE if `val` is NULL. */
-yyjson_api_inline yyjson_subtype yyjson_get_subtype(yyjson_val *val);
+  /** Returns the content if the value is raw.
+      Returns NULL if `val` is NULL or type is not raw. */
+  yyjson_api_inline const char *yyjson_get_raw (yyjson_val *val);
 
-/** Returns the JSON value's tag.
-    Returns 0 if `val` is NULL. */
-yyjson_api_inline uint8_t yyjson_get_tag(yyjson_val *val);
+  /** Returns the content if the value is bool.
+      Returns NULL if `val` is NULL or type is not bool. */
+  yyjson_api_inline bool yyjson_get_bool (yyjson_val *val);
 
-/** Returns the JSON value's type description.
-    The return value should be one of these strings: "raw", "null", "string",
-    "array", "object", "true", "false", "uint", "sint", "real", "unknown". */
-yyjson_api_inline const char *yyjson_get_type_desc(yyjson_val *val);
+  /** Returns the content and cast to uint64_t.
+      Returns 0 if `val` is NULL or type is not integer(sint/uint). */
+  yyjson_api_inline uint64_t yyjson_get_uint (yyjson_val *val);
 
-/** Returns the content if the value is raw.
-    Returns NULL if `val` is NULL or type is not raw. */
-yyjson_api_inline const char *yyjson_get_raw(yyjson_val *val);
+  /** Returns the content and cast to int64_t.
+      Returns 0 if `val` is NULL or type is not integer(sint/uint). */
+  yyjson_api_inline int64_t yyjson_get_sint (yyjson_val *val);
 
-/** Returns the content if the value is bool.
-    Returns NULL if `val` is NULL or type is not bool. */
-yyjson_api_inline bool yyjson_get_bool(yyjson_val *val);
+  /** Returns the content and cast to int.
+      Returns 0 if `val` is NULL or type is not integer(sint/uint). */
+  yyjson_api_inline int yyjson_get_int (yyjson_val *val);
 
-/** Returns the content and cast to uint64_t.
-    Returns 0 if `val` is NULL or type is not integer(sint/uint). */
-yyjson_api_inline uint64_t yyjson_get_uint(yyjson_val *val);
+  /** Returns the content if the value is real number, or 0.0 on error.
+      Returns 0.0 if `val` is NULL or type is not real(double). */
+  yyjson_api_inline double yyjson_get_real (yyjson_val *val);
 
-/** Returns the content and cast to int64_t.
-    Returns 0 if `val` is NULL or type is not integer(sint/uint). */
-yyjson_api_inline int64_t yyjson_get_sint(yyjson_val *val);
+  /** Returns the content and typecast to `double` if the value is number.
+      Returns 0.0 if `val` is NULL or type is not number(uint/sint/real). */
+  yyjson_api_inline double yyjson_get_num (yyjson_val *val);
 
-/** Returns the content and cast to int.
-    Returns 0 if `val` is NULL or type is not integer(sint/uint). */
-yyjson_api_inline int yyjson_get_int(yyjson_val *val);
+  /** Returns the content if the value is string.
+      Returns NULL if `val` is NULL or type is not string. */
+  yyjson_api_inline const char *yyjson_get_str (yyjson_val *val);
 
-/** Returns the content if the value is real number, or 0.0 on error.
-    Returns 0.0 if `val` is NULL or type is not real(double). */
-yyjson_api_inline double yyjson_get_real(yyjson_val *val);
+  /** Returns the content length (string length, array size, object size.
+      Returns 0 if `val` is NULL or type is not string/array/object. */
+  yyjson_api_inline size_t yyjson_get_len (yyjson_val *val);
 
-/** Returns the content and typecast to `double` if the value is number.
-    Returns 0.0 if `val` is NULL or type is not number(uint/sint/real). */
-yyjson_api_inline double yyjson_get_num(yyjson_val *val);
+  /** Returns whether the JSON value is equals to a string.
+      Returns false if input is NULL or type is not string. */
+  yyjson_api_inline bool yyjson_equals_str (yyjson_val *val, const char *str);
 
-/** Returns the content if the value is string.
-    Returns NULL if `val` is NULL or type is not string. */
-yyjson_api_inline const char *yyjson_get_str(yyjson_val *val);
+  /** Returns whether the JSON value is equals to a string.
+      The `str` should be a UTF-8 string, null-terminator is not required.
+      Returns false if input is NULL or type is not string. */
+  yyjson_api_inline bool yyjson_equals_strn (yyjson_val *val, const char *str,
+                                             size_t len);
 
-/** Returns the content length (string length, array size, object size.
-    Returns 0 if `val` is NULL or type is not string/array/object. */
-yyjson_api_inline size_t yyjson_get_len(yyjson_val *val);
+  /** Returns whether two JSON values are equal (deep compare).
+      Returns false if input is NULL. */
+  yyjson_api_inline bool yyjson_equals (yyjson_val *lhs, yyjson_val *rhs);
 
-/** Returns whether the JSON value is equals to a string.
-    Returns false if input is NULL or type is not string. */
-yyjson_api_inline bool yyjson_equals_str(yyjson_val *val, const char *str);
+  /** Set the value to raw.
+      Returns false if input is NULL or `val` is object or array.
+      @warning This will modify the `immutable` value, use with caution. */
+  yyjson_api_inline bool yyjson_set_raw (yyjson_val *val,
+                                         const char *raw, size_t len);
 
-/** Returns whether the JSON value is equals to a string.
-    The `str` should be a UTF-8 string, null-terminator is not required.
-    Returns false if input is NULL or type is not string. */
-yyjson_api_inline bool yyjson_equals_strn(yyjson_val *val, const char *str,
-                                          size_t len);
+  /** Set the value to null.
+      Returns false if input is NULL or `val` is object or array.
+      @warning This will modify the `immutable` value, use with caution. */
+  yyjson_api_inline bool yyjson_set_null (yyjson_val *val);
 
-/** Returns whether two JSON values are equal (deep compare).
-    Returns false if input is NULL. */
-yyjson_api_inline bool yyjson_equals(yyjson_val *lhs, yyjson_val *rhs);
+  /** Set the value to bool.
+      Returns false if input is NULL or `val` is object or array.
+      @warning This will modify the `immutable` value, use with caution. */
+  yyjson_api_inline bool yyjson_set_bool (yyjson_val *val, bool num);
 
-/** Set the value to raw.
-    Returns false if input is NULL or `val` is object or array.
-    @warning This will modify the `immutable` value, use with caution. */
-yyjson_api_inline bool yyjson_set_raw(yyjson_val *val,
-                                      const char *raw, size_t len);
+  /** Set the value to uint.
+      Returns false if input is NULL or `val` is object or array.
+      @warning This will modify the `immutable` value, use with caution. */
+  yyjson_api_inline bool yyjson_set_uint (yyjson_val *val, uint64_t num);
 
-/** Set the value to null.
-    Returns false if input is NULL or `val` is object or array.
-    @warning This will modify the `immutable` value, use with caution. */
-yyjson_api_inline bool yyjson_set_null(yyjson_val *val);
+  /** Set the value to sint.
+      Returns false if input is NULL or `val` is object or array.
+      @warning This will modify the `immutable` value, use with caution. */
+  yyjson_api_inline bool yyjson_set_sint (yyjson_val *val, int64_t num);
 
-/** Set the value to bool.
-    Returns false if input is NULL or `val` is object or array.
-    @warning This will modify the `immutable` value, use with caution. */
-yyjson_api_inline bool yyjson_set_bool(yyjson_val *val, bool num);
+  /** Set the value to int.
+      Returns false if input is NULL or `val` is object or array.
+      @warning This will modify the `immutable` value, use with caution. */
+  yyjson_api_inline bool yyjson_set_int (yyjson_val *val, int num);
 
-/** Set the value to uint.
-    Returns false if input is NULL or `val` is object or array.
-    @warning This will modify the `immutable` value, use with caution. */
-yyjson_api_inline bool yyjson_set_uint(yyjson_val *val, uint64_t num);
+  /** Set the value to real.
+      Returns false if input is NULL or `val` is object or array.
+      @warning This will modify the `immutable` value, use with caution. */
+  yyjson_api_inline bool yyjson_set_real (yyjson_val *val, double num);
 
-/** Set the value to sint.
-    Returns false if input is NULL or `val` is object or array.
-    @warning This will modify the `immutable` value, use with caution. */
-yyjson_api_inline bool yyjson_set_sint(yyjson_val *val, int64_t num);
+  /** Set the value to string (null-terminated).
+      Returns false if input is NULL or `val` is object or array.
+      @warning This will modify the `immutable` value, use with caution. */
+  yyjson_api_inline bool yyjson_set_str (yyjson_val *val, const char *str);
 
-/** Set the value to int.
-    Returns false if input is NULL or `val` is object or array.
-    @warning This will modify the `immutable` value, use with caution. */
-yyjson_api_inline bool yyjson_set_int(yyjson_val *val, int num);
+  /** Set the value to string (with length).
+      Returns false if input is NULL or `val` is object or array.
+      @warning This will modify the `immutable` value, use with caution. */
+  yyjson_api_inline bool yyjson_set_strn (yyjson_val *val,
+                                          const char *str, size_t len);
 
-/** Set the value to real.
-    Returns false if input is NULL or `val` is object or array.
-    @warning This will modify the `immutable` value, use with caution. */
-yyjson_api_inline bool yyjson_set_real(yyjson_val *val, double num);
+  /*==============================================================================
+   * JSON Array API
+   *============================================================================*/
 
-/** Set the value to string (null-terminated).
-    Returns false if input is NULL or `val` is object or array.
-    @warning This will modify the `immutable` value, use with caution. */
-yyjson_api_inline bool yyjson_set_str(yyjson_val *val, const char *str);
+  /** Returns the number of elements in this array.
+      Returns 0 if `arr` is NULL or type is not array. */
+  yyjson_api_inline size_t yyjson_arr_size (yyjson_val *arr);
 
-/** Set the value to string (with length).
-    Returns false if input is NULL or `val` is object or array.
-    @warning This will modify the `immutable` value, use with caution. */
-yyjson_api_inline bool yyjson_set_strn(yyjson_val *val,
-                                       const char *str, size_t len);
+  /** Returns the element at the specified position in this array.
+      Returns NULL if array is NULL/empty or the index is out of bounds.
+      @warning This function takes a linear search time if array is not flat.
+          For example: `[1,{},3]` is flat, `[1,[2],3]` is not flat. */
+  yyjson_api_inline yyjson_val *yyjson_arr_get (yyjson_val *arr, size_t idx);
 
+  /** Returns the first element of this array.
+      Returns NULL if `arr` is NULL/empty or type is not array. */
+  yyjson_api_inline yyjson_val *yyjson_arr_get_first (yyjson_val *arr);
 
+  /** Returns the last element of this array.
+      Returns NULL if `arr` is NULL/empty or type is not array.
+      @warning This function takes a linear search time if array is not flat.
+          For example: `[1,{},3]` is flat, `[1,[2],3]` is not flat.*/
+  yyjson_api_inline yyjson_val *yyjson_arr_get_last (yyjson_val *arr);
 
-/*==============================================================================
- * JSON Array API
- *============================================================================*/
+  /*==============================================================================
+   * JSON Array Iterator API
+   *============================================================================*/
 
-/** Returns the number of elements in this array.
-    Returns 0 if `arr` is NULL or type is not array. */
-yyjson_api_inline size_t yyjson_arr_size(yyjson_val *arr);
+  /**
+   A JSON array iterator.
 
-/** Returns the element at the specified position in this array.
-    Returns NULL if array is NULL/empty or the index is out of bounds.
-    @warning This function takes a linear search time if array is not flat.
-        For example: `[1,{},3]` is flat, `[1,[2],3]` is not flat. */
-yyjson_api_inline yyjson_val *yyjson_arr_get(yyjson_val *arr, size_t idx);
-
-/** Returns the first element of this array.
-    Returns NULL if `arr` is NULL/empty or type is not array. */
-yyjson_api_inline yyjson_val *yyjson_arr_get_first(yyjson_val *arr);
-
-/** Returns the last element of this array.
-    Returns NULL if `arr` is NULL/empty or type is not array.
-    @warning This function takes a linear search time if array is not flat.
-        For example: `[1,{},3]` is flat, `[1,[2],3]` is not flat.*/
-yyjson_api_inline yyjson_val *yyjson_arr_get_last(yyjson_val *arr);
-
-
-
-/*==============================================================================
- * JSON Array Iterator API
- *============================================================================*/
-
-/**
- A JSON array iterator.
- 
- @par Example
- @code
-    yyjson_val *val;
-    yyjson_arr_iter iter = yyjson_arr_iter_with(arr);
-    while ((val = yyjson_arr_iter_next(&iter))) {
-        your_func(val);
-    }
- @endcode
- */
-typedef struct yyjson_arr_iter {
-    size_t idx; /**< current index, from 0 */
-    size_t max; /**< maximum index, `idx < max` */
+   @par Example
+   @code
+      yyjson_val *val;
+      yyjson_arr_iter iter = yyjson_arr_iter_with(arr);
+      while ((val = yyjson_arr_iter_next(&iter))) {
+          your_func(val);
+      }
+   @endcode
+   */
+  typedef struct yyjson_arr_iter
+  {
+    size_t idx;      /**< current index, from 0 */
+    size_t max;      /**< maximum index, `idx < max` */
     yyjson_val *cur; /**< current value */
-} yyjson_arr_iter;
+  } yyjson_arr_iter;
 
-/**
- Initialize an iterator for this array.
- 
- @param arr The array to be iterated over.
-    If this parameter is NULL or not an array, `iter` will be set to empty.
- @param iter The iterator to be initialized.
-    If this parameter is NULL, the function will fail and return false.
- @return true if the `iter` has been successfully initialized.
- 
- @note The iterator does not need to be destroyed.
- */
-yyjson_api_inline bool yyjson_arr_iter_init(yyjson_val *arr,
-                                            yyjson_arr_iter *iter);
+  /**
+   Initialize an iterator for this array.
 
-/**
- Create an iterator with an array , same as `yyjson_arr_iter_init()`.
- 
- @param arr The array to be iterated over.
-    If this parameter is NULL or not an array, an empty iterator will returned.
- @return A new iterator for the array.
- 
- @note The iterator does not need to be destroyed.
- */
-yyjson_api_inline yyjson_arr_iter yyjson_arr_iter_with(yyjson_val *arr);
+   @param arr The array to be iterated over.
+      If this parameter is NULL or not an array, `iter` will be set to empty.
+   @param iter The iterator to be initialized.
+      If this parameter is NULL, the function will fail and return false.
+   @return true if the `iter` has been successfully initialized.
 
-/**
- Returns whether the iteration has more elements.
- If `iter` is NULL, this function will return false.
- */
-yyjson_api_inline bool yyjson_arr_iter_has_next(yyjson_arr_iter *iter);
+   @note The iterator does not need to be destroyed.
+   */
+  yyjson_api_inline bool yyjson_arr_iter_init (yyjson_val *arr,
+                                               yyjson_arr_iter *iter);
 
-/**
- Returns the next element in the iteration, or NULL on end.
- If `iter` is NULL, this function will return NULL.
- */
-yyjson_api_inline yyjson_val *yyjson_arr_iter_next(yyjson_arr_iter *iter);
+  /**
+   Create an iterator with an array , same as `yyjson_arr_iter_init()`.
+
+   @param arr The array to be iterated over.
+      If this parameter is NULL or not an array, an empty iterator will returned.
+   @return A new iterator for the array.
+
+   @note The iterator does not need to be destroyed.
+   */
+  yyjson_api_inline yyjson_arr_iter yyjson_arr_iter_with (yyjson_val *arr);
+
+  /**
+   Returns whether the iteration has more elements.
+   If `iter` is NULL, this function will return false.
+   */
+  yyjson_api_inline bool yyjson_arr_iter_has_next (yyjson_arr_iter *iter);
+
+  /**
+   Returns the next element in the iteration, or NULL on end.
+   If `iter` is NULL, this function will return NULL.
+   */
+  yyjson_api_inline yyjson_val *yyjson_arr_iter_next (yyjson_arr_iter *iter);
 
 /**
  Macro for iterating over an array.
  It works like iterator, but with a more intuitive API.
- 
+
  @par Example
  @code
     size_t idx, max;
@@ -1580,167 +1553,164 @@ yyjson_api_inline yyjson_val *yyjson_arr_iter_next(yyjson_arr_iter *iter);
  @endcode
  */
 #define yyjson_arr_foreach(arr, idx, max, val) \
-    for ((idx) = 0, \
-        (max) = yyjson_arr_size(arr), \
-        (val) = yyjson_arr_get_first(arr); \
-        (idx) < (max); \
-        (idx)++, \
-        (val) = unsafe_yyjson_get_next(val))
+  for ((idx) = 0,                              \
+      (max)  = yyjson_arr_size (arr),          \
+      (val)  = yyjson_arr_get_first (arr);     \
+       (idx) < (max);                          \
+       (idx)++,                                \
+      (val) = unsafe_yyjson_get_next (val))
 
+  /*==============================================================================
+   * JSON Object API
+   *============================================================================*/
 
+  /** Returns the number of key-value pairs in this object.
+      Returns 0 if `obj` is NULL or type is not object. */
+  yyjson_api_inline size_t yyjson_obj_size (yyjson_val *obj);
 
-/*==============================================================================
- * JSON Object API
- *============================================================================*/
+  /** Returns the value to which the specified key is mapped.
+      Returns NULL if this object contains no mapping for the key.
+      Returns NULL if `obj/key` is NULL, or type is not object.
 
-/** Returns the number of key-value pairs in this object.
-    Returns 0 if `obj` is NULL or type is not object. */
-yyjson_api_inline size_t yyjson_obj_size(yyjson_val *obj);
+      The `key` should be a null-terminated UTF-8 string.
 
-/** Returns the value to which the specified key is mapped.
-    Returns NULL if this object contains no mapping for the key.
-    Returns NULL if `obj/key` is NULL, or type is not object.
-    
-    The `key` should be a null-terminated UTF-8 string.
-    
-    @warning This function takes a linear search time. */
-yyjson_api_inline yyjson_val *yyjson_obj_get(yyjson_val *obj, const char *key);
+      @warning This function takes a linear search time. */
+  yyjson_api_inline yyjson_val *yyjson_obj_get (yyjson_val *obj, const char *key);
 
-/** Returns the value to which the specified key is mapped.
-    Returns NULL if this object contains no mapping for the key.
-    Returns NULL if `obj/key` is NULL, or type is not object.
-    
-    The `key` should be a UTF-8 string, null-terminator is not required.
-    The `key_len` should be the length of the key, in bytes.
-    
-    @warning This function takes a linear search time. */
-yyjson_api_inline yyjson_val *yyjson_obj_getn(yyjson_val *obj, const char *key,
-                                              size_t key_len);
+  /** Returns the value to which the specified key is mapped.
+      Returns NULL if this object contains no mapping for the key.
+      Returns NULL if `obj/key` is NULL, or type is not object.
 
+      The `key` should be a UTF-8 string, null-terminator is not required.
+      The `key_len` should be the length of the key, in bytes.
 
+      @warning This function takes a linear search time. */
+  yyjson_api_inline yyjson_val *yyjson_obj_getn (yyjson_val *obj, const char *key,
+                                                 size_t key_len);
 
-/*==============================================================================
- * JSON Object Iterator API
- *============================================================================*/
+  /*==============================================================================
+   * JSON Object Iterator API
+   *============================================================================*/
 
-/**
- A JSON object iterator.
- 
- @par Example
- @code
-    yyjson_val *key, *val;
-    yyjson_obj_iter iter = yyjson_obj_iter_with(obj);
-    while ((key = yyjson_obj_iter_next(&iter))) {
-        val = yyjson_obj_iter_get_val(key);
-        your_func(key, val);
-    }
- @endcode
- 
- If the ordering of the keys is known at compile-time, you can use this method
- to speed up value lookups:
- @code
-    // {"k1":1, "k2": 3, "k3": 3}
-    yyjson_val *key, *val;
-    yyjson_obj_iter iter = yyjson_obj_iter_with(obj);
-    yyjson_val *v1 = yyjson_obj_iter_get(&iter, "k1");
-    yyjson_val *v3 = yyjson_obj_iter_get(&iter, "k3");
- @endcode
- @see yyjson_obj_iter_get() and yyjson_obj_iter_getn()
- */
-typedef struct yyjson_obj_iter {
-    size_t idx; /**< current key index, from 0 */
-    size_t max; /**< maximum key index, `idx < max` */
+  /**
+   A JSON object iterator.
+
+   @par Example
+   @code
+      yyjson_val *key, *val;
+      yyjson_obj_iter iter = yyjson_obj_iter_with(obj);
+      while ((key = yyjson_obj_iter_next(&iter))) {
+          val = yyjson_obj_iter_get_val(key);
+          your_func(key, val);
+      }
+   @endcode
+
+   If the ordering of the keys is known at compile-time, you can use this method
+   to speed up value lookups:
+   @code
+      // {"k1":1, "k2": 3, "k3": 3}
+      yyjson_val *key, *val;
+      yyjson_obj_iter iter = yyjson_obj_iter_with(obj);
+      yyjson_val *v1 = yyjson_obj_iter_get(&iter, "k1");
+      yyjson_val *v3 = yyjson_obj_iter_get(&iter, "k3");
+   @endcode
+   @see yyjson_obj_iter_get() and yyjson_obj_iter_getn()
+   */
+  typedef struct yyjson_obj_iter
+  {
+    size_t idx;      /**< current key index, from 0 */
+    size_t max;      /**< maximum key index, `idx < max` */
     yyjson_val *cur; /**< current key */
     yyjson_val *obj; /**< the object being iterated */
-} yyjson_obj_iter;
+  } yyjson_obj_iter;
 
-/**
- Initialize an iterator for this object.
- 
- @param obj The object to be iterated over.
-    If this parameter is NULL or not an object, `iter` will be set to empty.
- @param iter The iterator to be initialized.
-    If this parameter is NULL, the function will fail and return false.
- @return true if the `iter` has been successfully initialized.
- 
- @note The iterator does not need to be destroyed.
- */
-yyjson_api_inline bool yyjson_obj_iter_init(yyjson_val *obj,
-                                            yyjson_obj_iter *iter);
+  /**
+   Initialize an iterator for this object.
 
-/**
- Create an iterator with an object, same as `yyjson_obj_iter_init()`.
- 
- @param obj The object to be iterated over.
-    If this parameter is NULL or not an object, an empty iterator will returned.
- @return A new iterator for the object.
- 
- @note The iterator does not need to be destroyed.
- */
-yyjson_api_inline yyjson_obj_iter yyjson_obj_iter_with(yyjson_val *obj);
+   @param obj The object to be iterated over.
+      If this parameter is NULL or not an object, `iter` will be set to empty.
+   @param iter The iterator to be initialized.
+      If this parameter is NULL, the function will fail and return false.
+   @return true if the `iter` has been successfully initialized.
 
-/**
- Returns whether the iteration has more elements.
- If `iter` is NULL, this function will return false.
- */
-yyjson_api_inline bool yyjson_obj_iter_has_next(yyjson_obj_iter *iter);
+   @note The iterator does not need to be destroyed.
+   */
+  yyjson_api_inline bool yyjson_obj_iter_init (yyjson_val *obj,
+                                               yyjson_obj_iter *iter);
 
-/**
- Returns the next key in the iteration, or NULL on end.
- If `iter` is NULL, this function will return NULL.
- */
-yyjson_api_inline yyjson_val *yyjson_obj_iter_next(yyjson_obj_iter *iter);
+  /**
+   Create an iterator with an object, same as `yyjson_obj_iter_init()`.
 
-/**
- Returns the value for key inside the iteration.
- If `iter` is NULL, this function will return NULL.
- */
-yyjson_api_inline yyjson_val *yyjson_obj_iter_get_val(yyjson_val *key);
+   @param obj The object to be iterated over.
+      If this parameter is NULL or not an object, an empty iterator will returned.
+   @return A new iterator for the object.
 
-/**
- Iterates to a specified key and returns the value.
- 
- This function does the same thing as `yyjson_obj_get()`, but is much faster
- if the ordering of the keys is known at compile-time and you are using the same
- order to look up the values. If the key exists in this object, then the
- iterator will stop at the next key, otherwise the iterator will not change and
- NULL is returned.
- 
- @param iter The object iterator, should not be NULL.
- @param key The key, should be a UTF-8 string with null-terminator.
- @return The value to which the specified key is mapped.
-    NULL if this object contains no mapping for the key or input is invalid.
- 
- @warning This function takes a linear search time if the key is not nearby.
- */
-yyjson_api_inline yyjson_val *yyjson_obj_iter_get(yyjson_obj_iter *iter,
-                                                  const char *key);
+   @note The iterator does not need to be destroyed.
+   */
+  yyjson_api_inline yyjson_obj_iter yyjson_obj_iter_with (yyjson_val *obj);
 
-/**
- Iterates to a specified key and returns the value.
+  /**
+   Returns whether the iteration has more elements.
+   If `iter` is NULL, this function will return false.
+   */
+  yyjson_api_inline bool yyjson_obj_iter_has_next (yyjson_obj_iter *iter);
 
- This function does the same thing as `yyjson_obj_getn()`, but is much faster
- if the ordering of the keys is known at compile-time and you are using the same
- order to look up the values. If the key exists in this object, then the
- iterator will stop at the next key, otherwise the iterator will not change and
- NULL is returned.
- 
- @param iter The object iterator, should not be NULL.
- @param key The key, should be a UTF-8 string, null-terminator is not required.
- @param key_len The the length of `key`, in bytes.
- @return The value to which the specified key is mapped.
-    NULL if this object contains no mapping for the key or input is invalid.
- 
- @warning This function takes a linear search time if the key is not nearby.
- */
-yyjson_api_inline yyjson_val *yyjson_obj_iter_getn(yyjson_obj_iter *iter,
-                                                   const char *key,
-                                                   size_t key_len);
+  /**
+   Returns the next key in the iteration, or NULL on end.
+   If `iter` is NULL, this function will return NULL.
+   */
+  yyjson_api_inline yyjson_val *yyjson_obj_iter_next (yyjson_obj_iter *iter);
+
+  /**
+   Returns the value for key inside the iteration.
+   If `iter` is NULL, this function will return NULL.
+   */
+  yyjson_api_inline yyjson_val *yyjson_obj_iter_get_val (yyjson_val *key);
+
+  /**
+   Iterates to a specified key and returns the value.
+
+   This function does the same thing as `yyjson_obj_get()`, but is much faster
+   if the ordering of the keys is known at compile-time and you are using the same
+   order to look up the values. If the key exists in this object, then the
+   iterator will stop at the next key, otherwise the iterator will not change and
+   NULL is returned.
+
+   @param iter The object iterator, should not be NULL.
+   @param key The key, should be a UTF-8 string with null-terminator.
+   @return The value to which the specified key is mapped.
+      NULL if this object contains no mapping for the key or input is invalid.
+
+   @warning This function takes a linear search time if the key is not nearby.
+   */
+  yyjson_api_inline yyjson_val *yyjson_obj_iter_get (yyjson_obj_iter *iter,
+                                                     const char *key);
+
+  /**
+   Iterates to a specified key and returns the value.
+
+   This function does the same thing as `yyjson_obj_getn()`, but is much faster
+   if the ordering of the keys is known at compile-time and you are using the same
+   order to look up the values. If the key exists in this object, then the
+   iterator will stop at the next key, otherwise the iterator will not change and
+   NULL is returned.
+
+   @param iter The object iterator, should not be NULL.
+   @param key The key, should be a UTF-8 string, null-terminator is not required.
+   @param key_len The the length of `key`, in bytes.
+   @return The value to which the specified key is mapped.
+      NULL if this object contains no mapping for the key or input is invalid.
+
+   @warning This function takes a linear search time if the key is not nearby.
+   */
+  yyjson_api_inline yyjson_val *yyjson_obj_iter_getn (yyjson_obj_iter *iter,
+                                                      const char *key,
+                                                      size_t key_len);
 
 /**
  Macro for iterating over an object.
  It works like iterator, but with a more intuitive API.
- 
+
  @par Example
  @code
     size_t idx, max;
@@ -1750,520 +1720,509 @@ yyjson_api_inline yyjson_val *yyjson_obj_iter_getn(yyjson_obj_iter *iter,
     }
  @endcode
  */
-#define yyjson_obj_foreach(obj, idx, max, key, val) \
-    for ((idx) = 0, \
-        (max) = yyjson_obj_size(obj), \
-        (key) = (obj) ? unsafe_yyjson_get_first(obj) : NULL, \
-        (val) = (key) + 1; \
-        (idx) < (max); \
-        (idx)++, \
-        (key) = unsafe_yyjson_get_next(val), \
-        (val) = (key) + 1)
+#define yyjson_obj_foreach(obj, idx, max, key, val)          \
+  for ((idx) = 0,                                            \
+      (max)  = yyjson_obj_size (obj),                        \
+      (key)  = (obj) ? unsafe_yyjson_get_first (obj) : NULL, \
+      (val)  = (key) + 1;                                    \
+       (idx) < (max);                                        \
+       (idx)++,                                              \
+      (key) = unsafe_yyjson_get_next (val),                  \
+      (val) = (key) + 1)
 
+  /*==============================================================================
+   * Mutable JSON Document API
+   *============================================================================*/
 
+  /** Returns the root value of this JSON document.
+      Returns NULL if `doc` is NULL. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_root (yyjson_mut_doc *doc);
 
-/*==============================================================================
- * Mutable JSON Document API
- *============================================================================*/
+  /** Sets the root value of this JSON document.
+      Pass NULL to clear root value of the document. */
+  yyjson_api_inline void yyjson_mut_doc_set_root (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *root);
 
-/** Returns the root value of this JSON document.
-    Returns NULL if `doc` is NULL. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_root(yyjson_mut_doc *doc);
+  /**
+   Set the string pool size for a mutable document.
+   This function does not allocate memory immediately, but uses the size when
+   the next memory allocation is needed.
 
-/** Sets the root value of this JSON document.
-    Pass NULL to clear root value of the document. */
-yyjson_api_inline void yyjson_mut_doc_set_root(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *root);
+   If the caller knows the approximate bytes of strings that the document needs to
+   store (e.g. copy string with `yyjson_mut_strcpy` function), setting a larger
+   size can avoid multiple memory allocations and improve performance.
 
-/**
- Set the string pool size for a mutable document.
- This function does not allocate memory immediately, but uses the size when
- the next memory allocation is needed.
- 
- If the caller knows the approximate bytes of strings that the document needs to
- store (e.g. copy string with `yyjson_mut_strcpy` function), setting a larger
- size can avoid multiple memory allocations and improve performance.
- 
- @param doc The mutable document.
- @param len The desired string pool size in bytes (total string length).
- @return true if successful, false if size is 0 or overflow.
- */
-yyjson_api bool yyjson_mut_doc_set_str_pool_size(yyjson_mut_doc *doc,
-                                                 size_t len);
+   @param doc The mutable document.
+   @param len The desired string pool size in bytes (total string length).
+   @return true if successful, false if size is 0 or overflow.
+   */
+  yyjson_api bool yyjson_mut_doc_set_str_pool_size (yyjson_mut_doc *doc,
+                                                    size_t len);
 
-/**
- Set the value pool size for a mutable document.
- This function does not allocate memory immediately, but uses the size when
- the next memory allocation is needed.
- 
- If the caller knows the approximate number of values that the document needs to
- store (e.g. create new value with `yyjson_mut_xxx` functions), setting a larger
- size can avoid multiple memory allocations and improve performance.
- 
- @param doc The mutable document.
- @param count The desired value pool size (number of `yyjson_mut_val`).
- @return true if successful, false if size is 0 or overflow.
- */
-yyjson_api bool yyjson_mut_doc_set_val_pool_size(yyjson_mut_doc *doc,
-                                                 size_t count);
+  /**
+   Set the value pool size for a mutable document.
+   This function does not allocate memory immediately, but uses the size when
+   the next memory allocation is needed.
 
-/** Release the JSON document and free the memory.
-    After calling this function, the `doc` and all values from the `doc` are no
-    longer available. This function will do nothing if the `doc` is NULL.  */
-yyjson_api void yyjson_mut_doc_free(yyjson_mut_doc *doc);
+   If the caller knows the approximate number of values that the document needs to
+   store (e.g. create new value with `yyjson_mut_xxx` functions), setting a larger
+   size can avoid multiple memory allocations and improve performance.
 
-/** Creates and returns a new mutable JSON document, returns NULL on error.
-    If allocator is NULL, the default allocator will be used. */
-yyjson_api yyjson_mut_doc *yyjson_mut_doc_new(const yyjson_alc *alc);
+   @param doc The mutable document.
+   @param count The desired value pool size (number of `yyjson_mut_val`).
+   @return true if successful, false if size is 0 or overflow.
+   */
+  yyjson_api bool yyjson_mut_doc_set_val_pool_size (yyjson_mut_doc *doc,
+                                                    size_t count);
 
-/** Copies and returns a new mutable document from input, returns NULL on error.
-    This makes a `deep-copy` on the immutable document.
-    If allocator is NULL, the default allocator will be used.
-    @note `imut_doc` -> `mut_doc`. */
-yyjson_api yyjson_mut_doc *yyjson_doc_mut_copy(yyjson_doc *doc,
-                                               const yyjson_alc *alc);
+  /** Release the JSON document and free the memory.
+      After calling this function, the `doc` and all values from the `doc` are no
+      longer available. This function will do nothing if the `doc` is NULL.  */
+  yyjson_api void yyjson_mut_doc_free (yyjson_mut_doc *doc);
 
-/** Copies and returns a new mutable document from input, returns NULL on error.
-    This makes a `deep-copy` on the mutable document.
-    If allocator is NULL, the default allocator will be used.
-    @note `mut_doc` -> `mut_doc`. */
-yyjson_api yyjson_mut_doc *yyjson_mut_doc_mut_copy(yyjson_mut_doc *doc,
+  /** Creates and returns a new mutable JSON document, returns NULL on error.
+      If allocator is NULL, the default allocator will be used. */
+  yyjson_api yyjson_mut_doc *yyjson_mut_doc_new (const yyjson_alc *alc);
+
+  /** Copies and returns a new mutable document from input, returns NULL on error.
+      This makes a `deep-copy` on the immutable document.
+      If allocator is NULL, the default allocator will be used.
+      @note `imut_doc` -> `mut_doc`. */
+  yyjson_api yyjson_mut_doc *yyjson_doc_mut_copy (yyjson_doc *doc,
+                                                  const yyjson_alc *alc);
+
+  /** Copies and returns a new mutable document from input, returns NULL on error.
+      This makes a `deep-copy` on the mutable document.
+      If allocator is NULL, the default allocator will be used.
+      @note `mut_doc` -> `mut_doc`. */
+  yyjson_api yyjson_mut_doc *yyjson_mut_doc_mut_copy (yyjson_mut_doc *doc,
+                                                      const yyjson_alc *alc);
+
+  /** Copies and returns a new mutable value from input, returns NULL on error.
+      This makes a `deep-copy` on the immutable value.
+      The memory was managed by mutable document.
+      @note `imut_val` -> `mut_val`. */
+  yyjson_api yyjson_mut_val *yyjson_val_mut_copy (yyjson_mut_doc *doc,
+                                                  yyjson_val *val);
+
+  /** Copies and returns a new mutable value from input, returns NULL on error.
+      This makes a `deep-copy` on the mutable value.
+      The memory was managed by mutable document.
+      @note `mut_val` -> `mut_val`.
+      @warning This function is recursive and may cause a stack overflow
+          if the object level is too deep. */
+  yyjson_api yyjson_mut_val *yyjson_mut_val_mut_copy (yyjson_mut_doc *doc,
+                                                      yyjson_mut_val *val);
+
+  /** Copies and returns a new immutable document from input,
+      returns NULL on error. This makes a `deep-copy` on the mutable document.
+      The returned document should be freed with `yyjson_doc_free()`.
+      @note `mut_doc` -> `imut_doc`.
+      @warning This function is recursive and may cause a stack overflow
+          if the object level is too deep. */
+  yyjson_api yyjson_doc *yyjson_mut_doc_imut_copy (yyjson_mut_doc *doc,
                                                    const yyjson_alc *alc);
 
-/** Copies and returns a new mutable value from input, returns NULL on error.
-    This makes a `deep-copy` on the immutable value.
-    The memory was managed by mutable document.
-    @note `imut_val` -> `mut_val`. */
-yyjson_api yyjson_mut_val *yyjson_val_mut_copy(yyjson_mut_doc *doc,
-                                               yyjson_val *val);
+  /** Copies and returns a new immutable document from input,
+      returns NULL on error. This makes a `deep-copy` on the mutable value.
+      The returned document should be freed with `yyjson_doc_free()`.
+      @note `mut_val` -> `imut_doc`.
+      @warning This function is recursive and may cause a stack overflow
+          if the object level is too deep. */
+  yyjson_api yyjson_doc *yyjson_mut_val_imut_copy (yyjson_mut_val *val,
+                                                   const yyjson_alc *alc);
 
-/** Copies and returns a new mutable value from input, returns NULL on error.
-    This makes a `deep-copy` on the mutable value.
-    The memory was managed by mutable document.
-    @note `mut_val` -> `mut_val`.
-    @warning This function is recursive and may cause a stack overflow
-        if the object level is too deep. */
-yyjson_api yyjson_mut_val *yyjson_mut_val_mut_copy(yyjson_mut_doc *doc,
-                                                   yyjson_mut_val *val);
+  /*==============================================================================
+   * Mutable JSON Value Type API
+   *============================================================================*/
 
-/** Copies and returns a new immutable document from input,
-    returns NULL on error. This makes a `deep-copy` on the mutable document.
-    The returned document should be freed with `yyjson_doc_free()`.
-    @note `mut_doc` -> `imut_doc`.
-    @warning This function is recursive and may cause a stack overflow
-        if the object level is too deep. */
-yyjson_api yyjson_doc *yyjson_mut_doc_imut_copy(yyjson_mut_doc *doc,
-                                                const yyjson_alc *alc);
+  /** Returns whether the JSON value is raw.
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_mut_is_raw (yyjson_mut_val *val);
 
-/** Copies and returns a new immutable document from input,
-    returns NULL on error. This makes a `deep-copy` on the mutable value.
-    The returned document should be freed with `yyjson_doc_free()`.
-    @note `mut_val` -> `imut_doc`.
-    @warning This function is recursive and may cause a stack overflow
-        if the object level is too deep. */
-yyjson_api yyjson_doc *yyjson_mut_val_imut_copy(yyjson_mut_val *val,
-                                                const yyjson_alc *alc);
+  /** Returns whether the JSON value is `null`.
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_mut_is_null (yyjson_mut_val *val);
 
+  /** Returns whether the JSON value is `true`.
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_mut_is_true (yyjson_mut_val *val);
 
+  /** Returns whether the JSON value is `false`.
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_mut_is_false (yyjson_mut_val *val);
 
-/*==============================================================================
- * Mutable JSON Value Type API
- *============================================================================*/
+  /** Returns whether the JSON value is bool (true/false).
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_mut_is_bool (yyjson_mut_val *val);
 
-/** Returns whether the JSON value is raw.
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_mut_is_raw(yyjson_mut_val *val);
+  /** Returns whether the JSON value is unsigned integer (uint64_t).
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_mut_is_uint (yyjson_mut_val *val);
 
-/** Returns whether the JSON value is `null`.
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_mut_is_null(yyjson_mut_val *val);
+  /** Returns whether the JSON value is signed integer (int64_t).
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_mut_is_sint (yyjson_mut_val *val);
 
-/** Returns whether the JSON value is `true`.
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_mut_is_true(yyjson_mut_val *val);
+  /** Returns whether the JSON value is integer (uint64_t/int64_t).
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_mut_is_int (yyjson_mut_val *val);
 
-/** Returns whether the JSON value is `false`.
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_mut_is_false(yyjson_mut_val *val);
+  /** Returns whether the JSON value is real number (double).
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_mut_is_real (yyjson_mut_val *val);
 
-/** Returns whether the JSON value is bool (true/false).
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_mut_is_bool(yyjson_mut_val *val);
+  /** Returns whether the JSON value is number (uint/sint/real).
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_mut_is_num (yyjson_mut_val *val);
 
-/** Returns whether the JSON value is unsigned integer (uint64_t).
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_mut_is_uint(yyjson_mut_val *val);
+  /** Returns whether the JSON value is string.
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_mut_is_str (yyjson_mut_val *val);
 
-/** Returns whether the JSON value is signed integer (int64_t).
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_mut_is_sint(yyjson_mut_val *val);
+  /** Returns whether the JSON value is array.
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_mut_is_arr (yyjson_mut_val *val);
 
-/** Returns whether the JSON value is integer (uint64_t/int64_t).
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_mut_is_int(yyjson_mut_val *val);
+  /** Returns whether the JSON value is object.
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_mut_is_obj (yyjson_mut_val *val);
 
-/** Returns whether the JSON value is real number (double).
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_mut_is_real(yyjson_mut_val *val);
+  /** Returns whether the JSON value is container (array/object).
+      Returns false if `val` is NULL. */
+  yyjson_api_inline bool yyjson_mut_is_ctn (yyjson_mut_val *val);
 
-/** Returns whether the JSON value is number (uint/sint/real).
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_mut_is_num(yyjson_mut_val *val);
+  /*==============================================================================
+   * Mutable JSON Value Content API
+   *============================================================================*/
 
-/** Returns whether the JSON value is string.
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_mut_is_str(yyjson_mut_val *val);
+  /** Returns the JSON value's type.
+      Returns `YYJSON_TYPE_NONE` if `val` is NULL. */
+  yyjson_api_inline yyjson_type yyjson_mut_get_type (yyjson_mut_val *val);
 
-/** Returns whether the JSON value is array.
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_mut_is_arr(yyjson_mut_val *val);
+  /** Returns the JSON value's subtype.
+      Returns `YYJSON_SUBTYPE_NONE` if `val` is NULL. */
+  yyjson_api_inline yyjson_subtype yyjson_mut_get_subtype (yyjson_mut_val *val);
 
-/** Returns whether the JSON value is object.
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_mut_is_obj(yyjson_mut_val *val);
+  /** Returns the JSON value's tag.
+      Returns 0 if `val` is NULL. */
+  yyjson_api_inline uint8_t yyjson_mut_get_tag (yyjson_mut_val *val);
 
-/** Returns whether the JSON value is container (array/object).
-    Returns false if `val` is NULL. */
-yyjson_api_inline bool yyjson_mut_is_ctn(yyjson_mut_val *val);
+  /** Returns the JSON value's type description.
+      The return value should be one of these strings: "raw", "null", "string",
+      "array", "object", "true", "false", "uint", "sint", "real", "unknown". */
+  yyjson_api_inline const char *yyjson_mut_get_type_desc (yyjson_mut_val *val);
 
+  /** Returns the content if the value is raw.
+      Returns NULL if `val` is NULL or type is not raw. */
+  yyjson_api_inline const char *yyjson_mut_get_raw (yyjson_mut_val *val);
 
+  /** Returns the content if the value is bool.
+      Returns NULL if `val` is NULL or type is not bool. */
+  yyjson_api_inline bool yyjson_mut_get_bool (yyjson_mut_val *val);
 
-/*==============================================================================
- * Mutable JSON Value Content API
- *============================================================================*/
+  /** Returns the content and cast to uint64_t.
+      Returns 0 if `val` is NULL or type is not integer(sint/uint). */
+  yyjson_api_inline uint64_t yyjson_mut_get_uint (yyjson_mut_val *val);
 
-/** Returns the JSON value's type.
-    Returns `YYJSON_TYPE_NONE` if `val` is NULL. */
-yyjson_api_inline yyjson_type yyjson_mut_get_type(yyjson_mut_val *val);
+  /** Returns the content and cast to int64_t.
+      Returns 0 if `val` is NULL or type is not integer(sint/uint). */
+  yyjson_api_inline int64_t yyjson_mut_get_sint (yyjson_mut_val *val);
 
-/** Returns the JSON value's subtype.
-    Returns `YYJSON_SUBTYPE_NONE` if `val` is NULL. */
-yyjson_api_inline yyjson_subtype yyjson_mut_get_subtype(yyjson_mut_val *val);
+  /** Returns the content and cast to int.
+      Returns 0 if `val` is NULL or type is not integer(sint/uint). */
+  yyjson_api_inline int yyjson_mut_get_int (yyjson_mut_val *val);
 
-/** Returns the JSON value's tag.
-    Returns 0 if `val` is NULL. */
-yyjson_api_inline uint8_t yyjson_mut_get_tag(yyjson_mut_val *val);
+  /** Returns the content if the value is real number.
+      Returns 0.0 if `val` is NULL or type is not real(double). */
+  yyjson_api_inline double yyjson_mut_get_real (yyjson_mut_val *val);
 
-/** Returns the JSON value's type description.
-    The return value should be one of these strings: "raw", "null", "string",
-    "array", "object", "true", "false", "uint", "sint", "real", "unknown". */
-yyjson_api_inline const char *yyjson_mut_get_type_desc(yyjson_mut_val *val);
+  /** Returns the content and typecast to `double` if the value is number.
+      Returns 0.0 if `val` is NULL or type is not number(uint/sint/real). */
+  yyjson_api_inline double yyjson_mut_get_num (yyjson_mut_val *val);
 
-/** Returns the content if the value is raw.
-    Returns NULL if `val` is NULL or type is not raw. */
-yyjson_api_inline const char *yyjson_mut_get_raw(yyjson_mut_val *val);
+  /** Returns the content if the value is string.
+      Returns NULL if `val` is NULL or type is not string. */
+  yyjson_api_inline const char *yyjson_mut_get_str (yyjson_mut_val *val);
 
-/** Returns the content if the value is bool.
-    Returns NULL if `val` is NULL or type is not bool. */
-yyjson_api_inline bool yyjson_mut_get_bool(yyjson_mut_val *val);
+  /** Returns the content length (string length, array size, object size.
+      Returns 0 if `val` is NULL or type is not string/array/object. */
+  yyjson_api_inline size_t yyjson_mut_get_len (yyjson_mut_val *val);
 
-/** Returns the content and cast to uint64_t.
-    Returns 0 if `val` is NULL or type is not integer(sint/uint). */
-yyjson_api_inline uint64_t yyjson_mut_get_uint(yyjson_mut_val *val);
+  /** Returns whether the JSON value is equals to a string.
+      The `str` should be a null-terminated UTF-8 string.
+      Returns false if input is NULL or type is not string. */
+  yyjson_api_inline bool yyjson_mut_equals_str (yyjson_mut_val *val,
+                                                const char *str);
 
-/** Returns the content and cast to int64_t.
-    Returns 0 if `val` is NULL or type is not integer(sint/uint). */
-yyjson_api_inline int64_t yyjson_mut_get_sint(yyjson_mut_val *val);
+  /** Returns whether the JSON value is equals to a string.
+      The `str` should be a UTF-8 string, null-terminator is not required.
+      Returns false if input is NULL or type is not string. */
+  yyjson_api_inline bool yyjson_mut_equals_strn (yyjson_mut_val *val,
+                                                 const char *str, size_t len);
 
-/** Returns the content and cast to int.
-    Returns 0 if `val` is NULL or type is not integer(sint/uint). */
-yyjson_api_inline int yyjson_mut_get_int(yyjson_mut_val *val);
+  /** Returns whether two JSON values are equal (deep compare).
+      Returns false if input is NULL.
 
-/** Returns the content if the value is real number.
-    Returns 0.0 if `val` is NULL or type is not real(double). */
-yyjson_api_inline double yyjson_mut_get_real(yyjson_mut_val *val);
+      @warning This function is recursive and may cause a stack overflow
+          if the object level is too deep. */
+  yyjson_api_inline bool yyjson_mut_equals (yyjson_mut_val *lhs,
+                                            yyjson_mut_val *rhs);
 
-/** Returns the content and typecast to `double` if the value is number.
-    Returns 0.0 if `val` is NULL or type is not number(uint/sint/real). */
-yyjson_api_inline double yyjson_mut_get_num(yyjson_mut_val *val);
+  /** Set the value to raw.
+      Returns false if input is NULL.
+      @warning This function should not be used on an existing object or array. */
+  yyjson_api_inline bool yyjson_mut_set_raw (yyjson_mut_val *val,
+                                             const char *raw, size_t len);
 
-/** Returns the content if the value is string.
-    Returns NULL if `val` is NULL or type is not string. */
-yyjson_api_inline const char *yyjson_mut_get_str(yyjson_mut_val *val);
+  /** Set the value to null.
+      Returns false if input is NULL.
+      @warning This function should not be used on an existing object or array. */
+  yyjson_api_inline bool yyjson_mut_set_null (yyjson_mut_val *val);
 
-/** Returns the content length (string length, array size, object size.
-    Returns 0 if `val` is NULL or type is not string/array/object. */
-yyjson_api_inline size_t yyjson_mut_get_len(yyjson_mut_val *val);
+  /** Set the value to bool.
+      Returns false if input is NULL.
+      @warning This function should not be used on an existing object or array. */
+  yyjson_api_inline bool yyjson_mut_set_bool (yyjson_mut_val *val, bool num);
 
-/** Returns whether the JSON value is equals to a string.
-    The `str` should be a null-terminated UTF-8 string.
-    Returns false if input is NULL or type is not string. */
-yyjson_api_inline bool yyjson_mut_equals_str(yyjson_mut_val *val,
-                                             const char *str);
+  /** Set the value to uint.
+      Returns false if input is NULL.
+      @warning This function should not be used on an existing object or array. */
+  yyjson_api_inline bool yyjson_mut_set_uint (yyjson_mut_val *val, uint64_t num);
 
-/** Returns whether the JSON value is equals to a string.
-    The `str` should be a UTF-8 string, null-terminator is not required.
-    Returns false if input is NULL or type is not string. */
-yyjson_api_inline bool yyjson_mut_equals_strn(yyjson_mut_val *val,
+  /** Set the value to sint.
+      Returns false if input is NULL.
+      @warning This function should not be used on an existing object or array. */
+  yyjson_api_inline bool yyjson_mut_set_sint (yyjson_mut_val *val, int64_t num);
+
+  /** Set the value to int.
+      Returns false if input is NULL.
+      @warning This function should not be used on an existing object or array. */
+  yyjson_api_inline bool yyjson_mut_set_int (yyjson_mut_val *val, int num);
+
+  /** Set the value to real.
+      Returns false if input is NULL.
+      @warning This function should not be used on an existing object or array. */
+  yyjson_api_inline bool yyjson_mut_set_real (yyjson_mut_val *val, double num);
+
+  /** Set the value to string (null-terminated).
+      Returns false if input is NULL.
+      @warning This function should not be used on an existing object or array. */
+  yyjson_api_inline bool yyjson_mut_set_str (yyjson_mut_val *val, const char *str);
+
+  /** Set the value to string (with length).
+      Returns false if input is NULL.
+      @warning This function should not be used on an existing object or array. */
+  yyjson_api_inline bool yyjson_mut_set_strn (yyjson_mut_val *val,
                                               const char *str, size_t len);
 
-/** Returns whether two JSON values are equal (deep compare).
-    Returns false if input is NULL.
-    
-    @warning This function is recursive and may cause a stack overflow
-        if the object level is too deep. */
-yyjson_api_inline bool yyjson_mut_equals(yyjson_mut_val *lhs,
-                                         yyjson_mut_val *rhs);
+  /** Set the value to array.
+      Returns false if input is NULL.
+      @warning This function should not be used on an existing object or array. */
+  yyjson_api_inline bool yyjson_mut_set_arr (yyjson_mut_val *val);
 
-/** Set the value to raw.
-    Returns false if input is NULL.
-    @warning This function should not be used on an existing object or array. */
-yyjson_api_inline bool yyjson_mut_set_raw(yyjson_mut_val *val,
-                                          const char *raw, size_t len);
+  /** Set the value to array.
+      Returns false if input is NULL.
+      @warning This function should not be used on an existing object or array. */
+  yyjson_api_inline bool yyjson_mut_set_obj (yyjson_mut_val *val);
 
-/** Set the value to null.
-    Returns false if input is NULL.
-    @warning This function should not be used on an existing object or array. */
-yyjson_api_inline bool yyjson_mut_set_null(yyjson_mut_val *val);
+  /*==============================================================================
+   * Mutable JSON Value Creation API
+   *============================================================================*/
 
-/** Set the value to bool.
-    Returns false if input is NULL.
-    @warning This function should not be used on an existing object or array. */
-yyjson_api_inline bool yyjson_mut_set_bool(yyjson_mut_val *val, bool num);
+  /** Creates and returns a raw value, returns NULL on error.
+      The `str` should be a null-terminated UTF-8 string.
 
-/** Set the value to uint.
-    Returns false if input is NULL.
-    @warning This function should not be used on an existing object or array. */
-yyjson_api_inline bool yyjson_mut_set_uint(yyjson_mut_val *val, uint64_t num);
-
-/** Set the value to sint.
-    Returns false if input is NULL.
-    @warning This function should not be used on an existing object or array. */
-yyjson_api_inline bool yyjson_mut_set_sint(yyjson_mut_val *val, int64_t num);
-
-/** Set the value to int.
-    Returns false if input is NULL.
-    @warning This function should not be used on an existing object or array. */
-yyjson_api_inline bool yyjson_mut_set_int(yyjson_mut_val *val, int num);
-
-/** Set the value to real.
-    Returns false if input is NULL.
-    @warning This function should not be used on an existing object or array. */
-yyjson_api_inline bool yyjson_mut_set_real(yyjson_mut_val *val, double num);
-
-/** Set the value to string (null-terminated).
-    Returns false if input is NULL.
-    @warning This function should not be used on an existing object or array. */
-yyjson_api_inline bool yyjson_mut_set_str(yyjson_mut_val *val, const char *str);
-
-/** Set the value to string (with length).
-    Returns false if input is NULL.
-    @warning This function should not be used on an existing object or array. */
-yyjson_api_inline bool yyjson_mut_set_strn(yyjson_mut_val *val,
-                                           const char *str, size_t len);
-
-/** Set the value to array.
-    Returns false if input is NULL.
-    @warning This function should not be used on an existing object or array. */
-yyjson_api_inline bool yyjson_mut_set_arr(yyjson_mut_val *val);
-
-/** Set the value to array.
-    Returns false if input is NULL.
-    @warning This function should not be used on an existing object or array. */
-yyjson_api_inline bool yyjson_mut_set_obj(yyjson_mut_val *val);
-
-
-
-/*==============================================================================
- * Mutable JSON Value Creation API
- *============================================================================*/
-
-/** Creates and returns a raw value, returns NULL on error.
-    The `str` should be a null-terminated UTF-8 string.
-    
-    @warning The input string is not copied, you should keep this string
-        unmodified for the lifetime of this JSON document. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_raw(yyjson_mut_doc *doc,
-                                                 const char *str);
-
-/** Creates and returns a raw value, returns NULL on error.
-    The `str` should be a UTF-8 string, null-terminator is not required.
-    
-    @warning The input string is not copied, you should keep this string
-        unmodified for the lifetime of this JSON document. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_rawn(yyjson_mut_doc *doc,
-                                                  const char *str,
-                                                  size_t len);
-
-/** Creates and returns a raw value, returns NULL on error.
-    The `str` should be a null-terminated UTF-8 string.
-    The input string is copied and held by the document. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_rawcpy(yyjson_mut_doc *doc,
+      @warning The input string is not copied, you should keep this string
+          unmodified for the lifetime of this JSON document. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_raw (yyjson_mut_doc *doc,
                                                     const char *str);
 
-/** Creates and returns a raw value, returns NULL on error.
-    The `str` should be a UTF-8 string, null-terminator is not required.
-    The input string is copied and held by the document. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_rawncpy(yyjson_mut_doc *doc,
+  /** Creates and returns a raw value, returns NULL on error.
+      The `str` should be a UTF-8 string, null-terminator is not required.
+
+      @warning The input string is not copied, you should keep this string
+          unmodified for the lifetime of this JSON document. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_rawn (yyjson_mut_doc *doc,
                                                      const char *str,
                                                      size_t len);
 
-/** Creates and returns a null value, returns NULL on error. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_null(yyjson_mut_doc *doc);
+  /** Creates and returns a raw value, returns NULL on error.
+      The `str` should be a null-terminated UTF-8 string.
+      The input string is copied and held by the document. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_rawcpy (yyjson_mut_doc *doc,
+                                                       const char *str);
 
-/** Creates and returns a true value, returns NULL on error. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_true(yyjson_mut_doc *doc);
+  /** Creates and returns a raw value, returns NULL on error.
+      The `str` should be a UTF-8 string, null-terminator is not required.
+      The input string is copied and held by the document. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_rawncpy (yyjson_mut_doc *doc,
+                                                        const char *str,
+                                                        size_t len);
 
-/** Creates and returns a false value, returns NULL on error. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_false(yyjson_mut_doc *doc);
+  /** Creates and returns a null value, returns NULL on error. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_null (yyjson_mut_doc *doc);
 
-/** Creates and returns a bool value, returns NULL on error. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_bool(yyjson_mut_doc *doc,
-                                                  bool val);
+  /** Creates and returns a true value, returns NULL on error. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_true (yyjson_mut_doc *doc);
 
-/** Creates and returns an unsigned integer value, returns NULL on error. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_uint(yyjson_mut_doc *doc,
-                                                  uint64_t num);
+  /** Creates and returns a false value, returns NULL on error. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_false (yyjson_mut_doc *doc);
 
-/** Creates and returns a signed integer value, returns NULL on error. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_sint(yyjson_mut_doc *doc,
-                                                  int64_t num);
+  /** Creates and returns a bool value, returns NULL on error. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_bool (yyjson_mut_doc *doc,
+                                                     bool val);
 
-/** Creates and returns a signed integer value, returns NULL on error. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_int(yyjson_mut_doc *doc,
-                                                 int64_t num);
+  /** Creates and returns an unsigned integer value, returns NULL on error. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_uint (yyjson_mut_doc *doc,
+                                                     uint64_t num);
 
-/** Creates and returns an real number value, returns NULL on error. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_real(yyjson_mut_doc *doc,
-                                                  double num);
+  /** Creates and returns a signed integer value, returns NULL on error. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_sint (yyjson_mut_doc *doc,
+                                                     int64_t num);
 
-/** Creates and returns a string value, returns NULL on error.
-    The `str` should be a null-terminated UTF-8 string.
-    @warning The input string is not copied, you should keep this string
-        unmodified for the lifetime of this JSON document. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_str(yyjson_mut_doc *doc,
-                                                 const char *str);
+  /** Creates and returns a signed integer value, returns NULL on error. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_int (yyjson_mut_doc *doc,
+                                                    int64_t num);
 
-/** Creates and returns a string value, returns NULL on error.
-    The `str` should be a UTF-8 string, null-terminator is not required.
-    @warning The input string is not copied, you should keep this string
-        unmodified for the lifetime of this JSON document. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_strn(yyjson_mut_doc *doc,
-                                                  const char *str,
-                                                  size_t len);
+  /** Creates and returns an real number value, returns NULL on error. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_real (yyjson_mut_doc *doc,
+                                                     double num);
 
-/** Creates and returns a string value, returns NULL on error.
-    The `str` should be a null-terminated UTF-8 string.
-    The input string is copied and held by the document. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_strcpy(yyjson_mut_doc *doc,
+  /** Creates and returns a string value, returns NULL on error.
+      The `str` should be a null-terminated UTF-8 string.
+      @warning The input string is not copied, you should keep this string
+          unmodified for the lifetime of this JSON document. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_str (yyjson_mut_doc *doc,
                                                     const char *str);
 
-/** Creates and returns a string value, returns NULL on error.
-    The `str` should be a UTF-8 string, null-terminator is not required.
-    The input string is copied and held by the document. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_strncpy(yyjson_mut_doc *doc,
+  /** Creates and returns a string value, returns NULL on error.
+      The `str` should be a UTF-8 string, null-terminator is not required.
+      @warning The input string is not copied, you should keep this string
+          unmodified for the lifetime of this JSON document. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_strn (yyjson_mut_doc *doc,
                                                      const char *str,
                                                      size_t len);
 
+  /** Creates and returns a string value, returns NULL on error.
+      The `str` should be a null-terminated UTF-8 string.
+      The input string is copied and held by the document. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_strcpy (yyjson_mut_doc *doc,
+                                                       const char *str);
 
+  /** Creates and returns a string value, returns NULL on error.
+      The `str` should be a UTF-8 string, null-terminator is not required.
+      The input string is copied and held by the document. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_strncpy (yyjson_mut_doc *doc,
+                                                        const char *str,
+                                                        size_t len);
 
-/*==============================================================================
- * Mutable JSON Array API
- *============================================================================*/
+  /*==============================================================================
+   * Mutable JSON Array API
+   *============================================================================*/
 
-/** Returns the number of elements in this array.
-    Returns 0 if `arr` is NULL or type is not array. */
-yyjson_api_inline size_t yyjson_mut_arr_size(yyjson_mut_val *arr);
+  /** Returns the number of elements in this array.
+      Returns 0 if `arr` is NULL or type is not array. */
+  yyjson_api_inline size_t yyjson_mut_arr_size (yyjson_mut_val *arr);
 
-/** Returns the element at the specified position in this array.
-    Returns NULL if array is NULL/empty or the index is out of bounds.
-    @warning This function takes a linear search time. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get(yyjson_mut_val *arr,
-                                                     size_t idx);
+  /** Returns the element at the specified position in this array.
+      Returns NULL if array is NULL/empty or the index is out of bounds.
+      @warning This function takes a linear search time. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get (yyjson_mut_val *arr,
+                                                        size_t idx);
 
-/** Returns the first element of this array.
-    Returns NULL if `arr` is NULL/empty or type is not array. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get_first(yyjson_mut_val *arr);
+  /** Returns the first element of this array.
+      Returns NULL if `arr` is NULL/empty or type is not array. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get_first (yyjson_mut_val *arr);
 
-/** Returns the last element of this array.
-    Returns NULL if `arr` is NULL/empty or type is not array. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get_last(yyjson_mut_val *arr);
+  /** Returns the last element of this array.
+      Returns NULL if `arr` is NULL/empty or type is not array. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get_last (yyjson_mut_val *arr);
 
+  /*==============================================================================
+   * Mutable JSON Array Iterator API
+   *============================================================================*/
 
+  /**
+   A mutable JSON array iterator.
 
-/*==============================================================================
- * Mutable JSON Array Iterator API
- *============================================================================*/
+   @warning You should not modify the array while iterating over it, but you can
+      use `yyjson_mut_arr_iter_remove()` to remove current value.
 
-/**
- A mutable JSON array iterator.
- 
- @warning You should not modify the array while iterating over it, but you can
-    use `yyjson_mut_arr_iter_remove()` to remove current value.
- 
- @par Example
- @code
-    yyjson_mut_val *val;
-    yyjson_mut_arr_iter iter = yyjson_mut_arr_iter_with(arr);
-    while ((val = yyjson_mut_arr_iter_next(&iter))) {
-        your_func(val);
-        if (your_val_is_unused(val)) {
-            yyjson_mut_arr_iter_remove(&iter);
-        }
-    }
- @endcode
- */
-typedef struct yyjson_mut_arr_iter {
-    size_t idx; /**< current index, from 0 */
-    size_t max; /**< maximum index, `idx < max` */
+   @par Example
+   @code
+      yyjson_mut_val *val;
+      yyjson_mut_arr_iter iter = yyjson_mut_arr_iter_with(arr);
+      while ((val = yyjson_mut_arr_iter_next(&iter))) {
+          your_func(val);
+          if (your_val_is_unused(val)) {
+              yyjson_mut_arr_iter_remove(&iter);
+          }
+      }
+   @endcode
+   */
+  typedef struct yyjson_mut_arr_iter
+  {
+    size_t idx;          /**< current index, from 0 */
+    size_t max;          /**< maximum index, `idx < max` */
     yyjson_mut_val *cur; /**< current value */
     yyjson_mut_val *pre; /**< previous value */
     yyjson_mut_val *arr; /**< the array being iterated */
-} yyjson_mut_arr_iter;
+  } yyjson_mut_arr_iter;
 
-/**
- Initialize an iterator for this array.
- 
- @param arr The array to be iterated over.
-    If this parameter is NULL or not an array, `iter` will be set to empty.
- @param iter The iterator to be initialized.
-    If this parameter is NULL, the function will fail and return false.
- @return true if the `iter` has been successfully initialized.
- 
- @note The iterator does not need to be destroyed.
- */
-yyjson_api_inline bool yyjson_mut_arr_iter_init(yyjson_mut_val *arr,
-    yyjson_mut_arr_iter *iter);
+  /**
+   Initialize an iterator for this array.
 
-/**
- Create an iterator with an array , same as `yyjson_mut_arr_iter_init()`.
- 
- @param arr The array to be iterated over.
-    If this parameter is NULL or not an array, an empty iterator will returned.
- @return A new iterator for the array.
- 
- @note The iterator does not need to be destroyed.
- */
-yyjson_api_inline yyjson_mut_arr_iter yyjson_mut_arr_iter_with(
-    yyjson_mut_val *arr);
+   @param arr The array to be iterated over.
+      If this parameter is NULL or not an array, `iter` will be set to empty.
+   @param iter The iterator to be initialized.
+      If this parameter is NULL, the function will fail and return false.
+   @return true if the `iter` has been successfully initialized.
 
-/**
- Returns whether the iteration has more elements.
- If `iter` is NULL, this function will return false.
- */
-yyjson_api_inline bool yyjson_mut_arr_iter_has_next(
-    yyjson_mut_arr_iter *iter);
+   @note The iterator does not need to be destroyed.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_iter_init (yyjson_mut_val *arr,
+                                                   yyjson_mut_arr_iter *iter);
 
-/**
- Returns the next element in the iteration, or NULL on end.
- If `iter` is NULL, this function will return NULL.
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_next(
-    yyjson_mut_arr_iter *iter);
+  /**
+   Create an iterator with an array , same as `yyjson_mut_arr_iter_init()`.
 
-/**
- Removes and returns current element in the iteration.
- If `iter` is NULL, this function will return NULL.
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_remove(
-    yyjson_mut_arr_iter *iter);
+   @param arr The array to be iterated over.
+      If this parameter is NULL or not an array, an empty iterator will returned.
+   @return A new iterator for the array.
+
+   @note The iterator does not need to be destroyed.
+   */
+  yyjson_api_inline yyjson_mut_arr_iter yyjson_mut_arr_iter_with (
+      yyjson_mut_val *arr);
+
+  /**
+   Returns whether the iteration has more elements.
+   If `iter` is NULL, this function will return false.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_iter_has_next (
+      yyjson_mut_arr_iter *iter);
+
+  /**
+   Returns the next element in the iteration, or NULL on end.
+   If `iter` is NULL, this function will return NULL.
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_next (
+      yyjson_mut_arr_iter *iter);
+
+  /**
+   Removes and returns current element in the iteration.
+   If `iter` is NULL, this function will return NULL.
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_remove (
+      yyjson_mut_arr_iter *iter);
 
 /**
  Macro for iterating over an array.
  It works like iterator, but with a more intuitive API.
- 
+
  @warning You should not modify the array while iterating over it.
- 
+
  @par Example
  @code
     size_t idx, max;
@@ -2274,844 +2233,835 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_remove(
  @endcode
  */
 #define yyjson_mut_arr_foreach(arr, idx, max, val) \
-    for ((idx) = 0, \
-        (max) = yyjson_mut_arr_size(arr), \
-        (val) = yyjson_mut_arr_get_first(arr); \
-        (idx) < (max); \
-        (idx)++, \
-        (val) = (val)->next)
+  for ((idx) = 0,                                  \
+      (max)  = yyjson_mut_arr_size (arr),          \
+      (val)  = yyjson_mut_arr_get_first (arr);     \
+       (idx) < (max);                              \
+       (idx)++,                                    \
+      (val) = (val)->next)
 
+  /*==============================================================================
+   * Mutable JSON Array Creation API
+   *============================================================================*/
 
+  /**
+   Creates and returns an empty mutable array.
+   @param doc A mutable document, used for memory allocation only.
+   @return The new array. NULL if input is NULL or memory allocation failed.
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr (yyjson_mut_doc *doc);
 
-/*==============================================================================
- * Mutable JSON Array Creation API
- *============================================================================*/
+  /**
+   Creates and returns a new mutable array with the given boolean values.
 
-/**
- Creates and returns an empty mutable array.
- @param doc A mutable document, used for memory allocation only.
- @return The new array. NULL if input is NULL or memory allocation failed.
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr(yyjson_mut_doc *doc);
+   @param doc A mutable document, used for memory allocation only.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param vals A C array of boolean values.
+   @param count The value count. If this value is 0, an empty array will return.
+   @return The new array. NULL if input is invalid or memory allocation failed.
 
-/**
- Creates and returns a new mutable array with the given boolean values.
- 
- @param doc A mutable document, used for memory allocation only.
-    If this parameter is NULL, the function will fail and return NULL.
- @param vals A C array of boolean values.
- @param count The value count. If this value is 0, an empty array will return.
- @return The new array. NULL if input is invalid or memory allocation failed.
- 
- @par Example
- @code
-    const bool vals[3] = { true, false, true };
-    yyjson_mut_val *arr = yyjson_mut_arr_with_bool(doc, vals, 3);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_bool(
-    yyjson_mut_doc *doc, const bool *vals, size_t count);
+   @par Example
+   @code
+      const bool vals[3] = { true, false, true };
+      yyjson_mut_val *arr = yyjson_mut_arr_with_bool(doc, vals, 3);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_bool (
+      yyjson_mut_doc *doc, const bool *vals, size_t count);
 
-/**
- Creates and returns a new mutable array with the given sint numbers.
- 
- @param doc A mutable document, used for memory allocation only.
-    If this parameter is NULL, the function will fail and return NULL.
- @param vals A C array of sint numbers.
- @param count The number count. If this value is 0, an empty array will return.
- @return The new array. NULL if input is invalid or memory allocation failed.
- 
- @par Example
- @code
-    const int64_t vals[3] = { -1, 0, 1 };
-    yyjson_mut_val *arr = yyjson_mut_arr_with_sint64(doc, vals, 3);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint(
-    yyjson_mut_doc *doc, const int64_t *vals, size_t count);
+  /**
+   Creates and returns a new mutable array with the given sint numbers.
 
-/**
- Creates and returns a new mutable array with the given uint numbers.
- 
- @param doc A mutable document, used for memory allocation only.
-    If this parameter is NULL, the function will fail and return NULL.
- @param vals A C array of uint numbers.
- @param count The number count. If this value is 0, an empty array will return.
- @return The new array. NULL if input is invalid or memory allocation failed.
- 
- @par Example
- @code
-    const uint64_t vals[3] = { 0, 1, 0 };
-    yyjson_mut_val *arr = yyjson_mut_arr_with_uint(doc, vals, 3);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint(
-    yyjson_mut_doc *doc, const uint64_t *vals, size_t count);
+   @param doc A mutable document, used for memory allocation only.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param vals A C array of sint numbers.
+   @param count The number count. If this value is 0, an empty array will return.
+   @return The new array. NULL if input is invalid or memory allocation failed.
 
-/**
- Creates and returns a new mutable array with the given real numbers.
- 
- @param doc A mutable document, used for memory allocation only.
-    If this parameter is NULL, the function will fail and return NULL.
- @param vals A C array of real numbers.
- @param count The number count. If this value is 0, an empty array will return.
- @return The new array. NULL if input is invalid or memory allocation failed.
- 
- @par Example
- @code
-    const double vals[3] = { 0.1, 0.2, 0.3 };
-    yyjson_mut_val *arr = yyjson_mut_arr_with_real(doc, vals, 3);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_real(
-    yyjson_mut_doc *doc, const double *vals, size_t count);
+   @par Example
+   @code
+      const int64_t vals[3] = { -1, 0, 1 };
+      yyjson_mut_val *arr = yyjson_mut_arr_with_sint64(doc, vals, 3);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint (
+      yyjson_mut_doc *doc, const int64_t *vals, size_t count);
 
-/**
- Creates and returns a new mutable array with the given int8 numbers.
- 
- @param doc A mutable document, used for memory allocation only.
-    If this parameter is NULL, the function will fail and return NULL.
- @param vals A C array of int8 numbers.
- @param count The number count. If this value is 0, an empty array will return.
- @return The new array. NULL if input is invalid or memory allocation failed.
- 
- @par Example
- @code
-    const int8_t vals[3] = { -1, 0, 1 };
-    yyjson_mut_val *arr = yyjson_mut_arr_with_sint8(doc, vals, 3);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint8(
-    yyjson_mut_doc *doc, const int8_t *vals, size_t count);
+  /**
+   Creates and returns a new mutable array with the given uint numbers.
 
-/**
- Creates and returns a new mutable array with the given int16 numbers.
- 
- @param doc A mutable document, used for memory allocation only.
-    If this parameter is NULL, the function will fail and return NULL.
- @param vals A C array of int16 numbers.
- @param count The number count. If this value is 0, an empty array will return.
- @return The new array. NULL if input is invalid or memory allocation failed.
- 
- @par Example
- @code
-    const int16_t vals[3] = { -1, 0, 1 };
-    yyjson_mut_val *arr = yyjson_mut_arr_with_sint16(doc, vals, 3);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint16(
-    yyjson_mut_doc *doc, const int16_t *vals, size_t count);
+   @param doc A mutable document, used for memory allocation only.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param vals A C array of uint numbers.
+   @param count The number count. If this value is 0, an empty array will return.
+   @return The new array. NULL if input is invalid or memory allocation failed.
 
-/**
- Creates and returns a new mutable array with the given int32 numbers.
- 
- @param doc A mutable document, used for memory allocation only.
-    If this parameter is NULL, the function will fail and return NULL.
- @param vals A C array of int32 numbers.
- @param count The number count. If this value is 0, an empty array will return.
- @return The new array. NULL if input is invalid or memory allocation failed.
- 
- @par Example
- @code
-    const int32_t vals[3] = { -1, 0, 1 };
-    yyjson_mut_val *arr = yyjson_mut_arr_with_sint32(doc, vals, 3);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint32(
-    yyjson_mut_doc *doc, const int32_t *vals, size_t count);
+   @par Example
+   @code
+      const uint64_t vals[3] = { 0, 1, 0 };
+      yyjson_mut_val *arr = yyjson_mut_arr_with_uint(doc, vals, 3);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint (
+      yyjson_mut_doc *doc, const uint64_t *vals, size_t count);
 
-/**
- Creates and returns a new mutable array with the given int64 numbers.
- 
- @param doc A mutable document, used for memory allocation only.
-    If this parameter is NULL, the function will fail and return NULL.
- @param vals A C array of int64 numbers.
- @param count The number count. If this value is 0, an empty array will return.
- @return The new array. NULL if input is invalid or memory allocation failed.
- 
- @par Example
- @code
-    const int64_t vals[3] = { -1, 0, 1 };
-    yyjson_mut_val *arr = yyjson_mut_arr_with_sint64(doc, vals, 3);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint64(
-    yyjson_mut_doc *doc, const int64_t *vals, size_t count);
+  /**
+   Creates and returns a new mutable array with the given real numbers.
 
-/**
- Creates and returns a new mutable array with the given uint8 numbers.
- 
- @param doc A mutable document, used for memory allocation only.
-    If this parameter is NULL, the function will fail and return NULL.
- @param vals A C array of uint8 numbers.
- @param count The number count. If this value is 0, an empty array will return.
- @return The new array. NULL if input is invalid or memory allocation failed.
- 
- @par Example
- @code
-    const uint8_t vals[3] = { 0, 1, 0 };
-    yyjson_mut_val *arr = yyjson_mut_arr_with_uint8(doc, vals, 3);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint8(
-    yyjson_mut_doc *doc, const uint8_t *vals, size_t count);
+   @param doc A mutable document, used for memory allocation only.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param vals A C array of real numbers.
+   @param count The number count. If this value is 0, an empty array will return.
+   @return The new array. NULL if input is invalid or memory allocation failed.
 
-/**
- Creates and returns a new mutable array with the given uint16 numbers.
- 
- @param doc A mutable document, used for memory allocation only.
-    If this parameter is NULL, the function will fail and return NULL.
- @param vals A C array of uint16 numbers.
- @param count The number count. If this value is 0, an empty array will return.
- @return The new array. NULL if input is invalid or memory allocation failed.
- 
- @par Example
- @code
-    const uint16_t vals[3] = { 0, 1, 0 };
-    yyjson_mut_val *arr = yyjson_mut_arr_with_uint16(doc, vals, 3);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint16(
-    yyjson_mut_doc *doc, const uint16_t *vals, size_t count);
+   @par Example
+   @code
+      const double vals[3] = { 0.1, 0.2, 0.3 };
+      yyjson_mut_val *arr = yyjson_mut_arr_with_real(doc, vals, 3);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_real (
+      yyjson_mut_doc *doc, const double *vals, size_t count);
 
-/**
- Creates and returns a new mutable array with the given uint32 numbers.
- 
- @param doc A mutable document, used for memory allocation only.
-    If this parameter is NULL, the function will fail and return NULL.
- @param vals A C array of uint32 numbers.
- @param count The number count. If this value is 0, an empty array will return.
- @return The new array. NULL if input is invalid or memory allocation failed.
- 
- @par Example
- @code
-    const uint32_t vals[3] = { 0, 1, 0 };
-    yyjson_mut_val *arr = yyjson_mut_arr_with_uint32(doc, vals, 3);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint32(
-    yyjson_mut_doc *doc, const uint32_t *vals, size_t count);
+  /**
+   Creates and returns a new mutable array with the given int8 numbers.
 
-/**
- Creates and returns a new mutable array with the given uint64 numbers.
- 
- @param doc A mutable document, used for memory allocation only.
-    If this parameter is NULL, the function will fail and return NULL.
- @param vals A C array of uint64 numbers.
- @param count The number count. If this value is 0, an empty array will return.
- @return The new array. NULL if input is invalid or memory allocation failed.
- 
- @par Example
- @code
-     const uint64_t vals[3] = { 0, 1, 0 };
-     yyjson_mut_val *arr = yyjson_mut_arr_with_uint64(doc, vals, 3);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint64(
-    yyjson_mut_doc *doc, const uint64_t *vals, size_t count);
+   @param doc A mutable document, used for memory allocation only.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param vals A C array of int8 numbers.
+   @param count The number count. If this value is 0, an empty array will return.
+   @return The new array. NULL if input is invalid or memory allocation failed.
 
-/**
- Creates and returns a new mutable array with the given float numbers.
- 
- @param doc A mutable document, used for memory allocation only.
-    If this parameter is NULL, the function will fail and return NULL.
- @param vals A C array of float numbers.
- @param count The number count. If this value is 0, an empty array will return.
- @return The new array. NULL if input is invalid or memory allocation failed.
- 
- @par Example
- @code
-    const float vals[3] = { -1.0f, 0.0f, 1.0f };
-    yyjson_mut_val *arr = yyjson_mut_arr_with_float(doc, vals, 3);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_float(
-    yyjson_mut_doc *doc, const float *vals, size_t count);
+   @par Example
+   @code
+      const int8_t vals[3] = { -1, 0, 1 };
+      yyjson_mut_val *arr = yyjson_mut_arr_with_sint8(doc, vals, 3);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint8 (
+      yyjson_mut_doc *doc, const int8_t *vals, size_t count);
 
-/**
- Creates and returns a new mutable array with the given double numbers.
- 
- @param doc A mutable document, used for memory allocation only.
-    If this parameter is NULL, the function will fail and return NULL.
- @param vals A C array of double numbers.
- @param count The number count. If this value is 0, an empty array will return.
- @return The new array. NULL if input is invalid or memory allocation failed.
- 
- @par Example
- @code
-    const double vals[3] = { -1.0, 0.0, 1.0 };
-    yyjson_mut_val *arr = yyjson_mut_arr_with_double(doc, vals, 3);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_double(
-    yyjson_mut_doc *doc, const double *vals, size_t count);
+  /**
+   Creates and returns a new mutable array with the given int16 numbers.
 
-/**
- Creates and returns a new mutable array with the given strings, these strings
- will not be copied.
- 
- @param doc A mutable document, used for memory allocation only.
-    If this parameter is NULL, the function will fail and return NULL.
- @param vals A C array of UTF-8 null-terminator strings.
-    If this array contains NULL, the function will fail and return NULL.
- @param count The number of values in `vals`.
-    If this value is 0, an empty array will return.
- @return The new array. NULL if input is invalid or memory allocation failed.
- 
- @warning The input strings are not copied, you should keep these strings
-    unmodified for the lifetime of this JSON document. If these strings will be
-    modified, you should use `yyjson_mut_arr_with_strcpy()` instead.
- 
- @par Example
- @code
-    const char *vals[3] = { "a", "b", "c" };
-    yyjson_mut_val *arr = yyjson_mut_arr_with_str(doc, vals, 3);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_str(
-    yyjson_mut_doc *doc, const char **vals, size_t count);
+   @param doc A mutable document, used for memory allocation only.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param vals A C array of int16 numbers.
+   @param count The number count. If this value is 0, an empty array will return.
+   @return The new array. NULL if input is invalid or memory allocation failed.
 
-/**
- Creates and returns a new mutable array with the given strings and string
- lengths, these strings will not be copied.
- 
- @param doc A mutable document, used for memory allocation only.
-    If this parameter is NULL, the function will fail and return NULL.
- @param vals A C array of UTF-8 strings, null-terminator is not required.
-    If this array contains NULL, the function will fail and return NULL.
- @param lens A C array of string lengths, in bytes.
- @param count The number of strings in `vals`.
-    If this value is 0, an empty array will return.
- @return The new array. NULL if input is invalid or memory allocation failed.
- 
- @warning The input strings are not copied, you should keep these strings
-    unmodified for the lifetime of this JSON document. If these strings will be
-    modified, you should use `yyjson_mut_arr_with_strncpy()` instead.
- 
- @par Example
- @code
-    const char *vals[3] = { "a", "bb", "c" };
-    const size_t lens[3] = { 1, 2, 1 };
-    yyjson_mut_val *arr = yyjson_mut_arr_with_strn(doc, vals, lens, 3);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strn(
-    yyjson_mut_doc *doc, const char **vals, const size_t *lens, size_t count);
+   @par Example
+   @code
+      const int16_t vals[3] = { -1, 0, 1 };
+      yyjson_mut_val *arr = yyjson_mut_arr_with_sint16(doc, vals, 3);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint16 (
+      yyjson_mut_doc *doc, const int16_t *vals, size_t count);
 
-/**
- Creates and returns a new mutable array with the given strings, these strings
- will be copied.
- 
- @param doc A mutable document, used for memory allocation only.
-    If this parameter is NULL, the function will fail and return NULL.
- @param vals A C array of UTF-8 null-terminator strings.
-    If this array contains NULL, the function will fail and return NULL.
- @param count The number of values in `vals`.
-    If this value is 0, an empty array will return.
- @return The new array. NULL if input is invalid or memory allocation failed.
- 
- @par Example
- @code
-    const char *vals[3] = { "a", "b", "c" };
-    yyjson_mut_val *arr = yyjson_mut_arr_with_strcpy(doc, vals, 3);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strcpy(
-    yyjson_mut_doc *doc, const char **vals, size_t count);
+  /**
+   Creates and returns a new mutable array with the given int32 numbers.
 
-/**
- Creates and returns a new mutable array with the given strings and string
- lengths, these strings will be copied.
- 
- @param doc A mutable document, used for memory allocation only.
-    If this parameter is NULL, the function will fail and return NULL.
- @param vals A C array of UTF-8 strings, null-terminator is not required.
-    If this array contains NULL, the function will fail and return NULL.
- @param lens A C array of string lengths, in bytes.
- @param count The number of strings in `vals`.
-    If this value is 0, an empty array will return.
- @return The new array. NULL if input is invalid or memory allocation failed.
- 
- @par Example
- @code
-    const char *vals[3] = { "a", "bb", "c" };
-    const size_t lens[3] = { 1, 2, 1 };
-    yyjson_mut_val *arr = yyjson_mut_arr_with_strn(doc, vals, lens, 3);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strncpy(
-    yyjson_mut_doc *doc, const char **vals, const size_t *lens, size_t count);
+   @param doc A mutable document, used for memory allocation only.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param vals A C array of int32 numbers.
+   @param count The number count. If this value is 0, an empty array will return.
+   @return The new array. NULL if input is invalid or memory allocation failed.
 
+   @par Example
+   @code
+      const int32_t vals[3] = { -1, 0, 1 };
+      yyjson_mut_val *arr = yyjson_mut_arr_with_sint32(doc, vals, 3);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint32 (
+      yyjson_mut_doc *doc, const int32_t *vals, size_t count);
 
+  /**
+   Creates and returns a new mutable array with the given int64 numbers.
 
-/*==============================================================================
- * Mutable JSON Array Modification API
- *============================================================================*/
+   @param doc A mutable document, used for memory allocation only.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param vals A C array of int64 numbers.
+   @param count The number count. If this value is 0, an empty array will return.
+   @return The new array. NULL if input is invalid or memory allocation failed.
 
-/**
- Inserts a value into an array at a given index.
- @param arr The array to which the value is to be inserted.
-    Returns false if it is NULL or not an array.
- @param val The value to be inserted. Returns false if it is NULL.
- @param idx The index to which to insert the new value.
-    Returns false if the index is out of range.
- @return Whether successful.
- @warning This function takes a linear search time.
- */
-yyjson_api_inline bool yyjson_mut_arr_insert(yyjson_mut_val *arr,
-                                             yyjson_mut_val *val, size_t idx);
+   @par Example
+   @code
+      const int64_t vals[3] = { -1, 0, 1 };
+      yyjson_mut_val *arr = yyjson_mut_arr_with_sint64(doc, vals, 3);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint64 (
+      yyjson_mut_doc *doc, const int64_t *vals, size_t count);
 
-/**
- Inserts a value at the end of the array.
- @param arr The array to which the value is to be inserted.
-    Returns false if it is NULL or not an array.
- @param val The value to be inserted. Returns false if it is NULL.
- @return Whether successful.
- */
-yyjson_api_inline bool yyjson_mut_arr_append(yyjson_mut_val *arr,
-                                             yyjson_mut_val *val);
+  /**
+   Creates and returns a new mutable array with the given uint8 numbers.
 
-/**
- Inserts a value at the head of the array.
- @param arr The array to which the value is to be inserted.
-    Returns false if it is NULL or not an array.
- @param val The value to be inserted. Returns false if it is NULL.
- @return    Whether successful.
- */
-yyjson_api_inline bool yyjson_mut_arr_prepend(yyjson_mut_val *arr,
-                                              yyjson_mut_val *val);
+   @param doc A mutable document, used for memory allocation only.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param vals A C array of uint8 numbers.
+   @param count The number count. If this value is 0, an empty array will return.
+   @return The new array. NULL if input is invalid or memory allocation failed.
 
-/**
- Replaces a value at index and returns old value.
- @param arr The array to which the value is to be replaced.
-    Returns false if it is NULL or not an array.
- @param idx The index to which to replace the value.
-    Returns false if the index is out of range.
- @param val The new value to replace. Returns false if it is NULL.
- @return Old value, or NULL on error.
- @warning This function takes a linear search time.
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_replace(yyjson_mut_val *arr,
-                                                         size_t idx,
-                                                         yyjson_mut_val *val);
+   @par Example
+   @code
+      const uint8_t vals[3] = { 0, 1, 0 };
+      yyjson_mut_val *arr = yyjson_mut_arr_with_uint8(doc, vals, 3);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint8 (
+      yyjson_mut_doc *doc, const uint8_t *vals, size_t count);
 
-/**
- Removes and returns a value at index.
- @param arr The array from which the value is to be removed.
-    Returns false if it is NULL or not an array.
- @param idx The index from which to remove the value.
-    Returns false if the index is out of range.
- @return Old value, or NULL on error.
- @warning This function takes a linear search time.
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove(yyjson_mut_val *arr,
-                                                        size_t idx);
+  /**
+   Creates and returns a new mutable array with the given uint16 numbers.
 
-/**
- Removes and returns the first value in this array.
- @param arr The array from which the value is to be removed.
-    Returns false if it is NULL or not an array.
- @return The first value, or NULL on error.
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_first(
-    yyjson_mut_val *arr);
+   @param doc A mutable document, used for memory allocation only.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param vals A C array of uint16 numbers.
+   @param count The number count. If this value is 0, an empty array will return.
+   @return The new array. NULL if input is invalid or memory allocation failed.
 
-/**
- Removes and returns the last value in this array.
- @param arr The array from which the value is to be removed.
-    Returns false if it is NULL or not an array.
- @return The last value, or NULL on error.
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_last(
-    yyjson_mut_val *arr);
+   @par Example
+   @code
+      const uint16_t vals[3] = { 0, 1, 0 };
+      yyjson_mut_val *arr = yyjson_mut_arr_with_uint16(doc, vals, 3);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint16 (
+      yyjson_mut_doc *doc, const uint16_t *vals, size_t count);
 
-/**
- Removes all values within a specified range in the array.
- @param arr The array from which the value is to be removed.
-    Returns false if it is NULL or not an array.
- @param idx The start index of the range (0 is the first).
- @param len The number of items in the range (can be 0).
- @return Whether successful.
- @warning This function takes a linear search time.
- */
-yyjson_api_inline bool yyjson_mut_arr_remove_range(yyjson_mut_val *arr,
-                                                   size_t idx, size_t len);
+  /**
+   Creates and returns a new mutable array with the given uint32 numbers.
 
-/**
- Removes all values in this array.
- @param arr The array from which all of the values are to be removed.
-    Returns false if it is NULL or not an array.
- @return Whether successful.
- */
-yyjson_api_inline bool yyjson_mut_arr_clear(yyjson_mut_val *arr);
+   @param doc A mutable document, used for memory allocation only.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param vals A C array of uint32 numbers.
+   @param count The number count. If this value is 0, an empty array will return.
+   @return The new array. NULL if input is invalid or memory allocation failed.
 
-/**
- Rotates values in this array for the given number of times.
- For example: `[1,2,3,4,5]` rotate 2 is `[3,4,5,1,2]`.
- @param arr The array to be rotated.
- @param idx Index (or times) to rotate.
- @warning This function takes a linear search time.
- */
-yyjson_api_inline bool yyjson_mut_arr_rotate(yyjson_mut_val *arr,
-                                             size_t idx);
+   @par Example
+   @code
+      const uint32_t vals[3] = { 0, 1, 0 };
+      yyjson_mut_val *arr = yyjson_mut_arr_with_uint32(doc, vals, 3);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint32 (
+      yyjson_mut_doc *doc, const uint32_t *vals, size_t count);
 
+  /**
+   Creates and returns a new mutable array with the given uint64 numbers.
 
+   @param doc A mutable document, used for memory allocation only.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param vals A C array of uint64 numbers.
+   @param count The number count. If this value is 0, an empty array will return.
+   @return The new array. NULL if input is invalid or memory allocation failed.
 
-/*==============================================================================
- * Mutable JSON Array Modification Convenience API
- *============================================================================*/
+   @par Example
+   @code
+       const uint64_t vals[3] = { 0, 1, 0 };
+       yyjson_mut_val *arr = yyjson_mut_arr_with_uint64(doc, vals, 3);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint64 (
+      yyjson_mut_doc *doc, const uint64_t *vals, size_t count);
 
-/**
- Adds a value at the end of the array.
- @param arr The array to which the value is to be inserted.
-    Returns false if it is NULL or not an array.
- @param val The value to be inserted. Returns false if it is NULL.
- @return Whether successful.
- */
-yyjson_api_inline bool yyjson_mut_arr_add_val(yyjson_mut_val *arr,
-                                              yyjson_mut_val *val);
+  /**
+   Creates and returns a new mutable array with the given float numbers.
 
-/**
- Adds a `null` value at the end of the array.
- @param doc The `doc` is only used for memory allocation.
- @param arr The array to which the value is to be inserted.
-    Returns false if it is NULL or not an array.
- @return Whether successful.
- */
-yyjson_api_inline bool yyjson_mut_arr_add_null(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *arr);
+   @param doc A mutable document, used for memory allocation only.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param vals A C array of float numbers.
+   @param count The number count. If this value is 0, an empty array will return.
+   @return The new array. NULL if input is invalid or memory allocation failed.
 
-/**
- Adds a `true` value at the end of the array.
- @param doc The `doc` is only used for memory allocation.
- @param arr The array to which the value is to be inserted.
-    Returns false if it is NULL or not an array.
- @return Whether successful.
- */
-yyjson_api_inline bool yyjson_mut_arr_add_true(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *arr);
+   @par Example
+   @code
+      const float vals[3] = { -1.0f, 0.0f, 1.0f };
+      yyjson_mut_val *arr = yyjson_mut_arr_with_float(doc, vals, 3);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_float (
+      yyjson_mut_doc *doc, const float *vals, size_t count);
 
-/**
- Adds a `false` value at the end of the array.
- @param doc The `doc` is only used for memory allocation.
- @param arr The array to which the value is to be inserted.
-    Returns false if it is NULL or not an array.
- @return Whether successful.
- */
-yyjson_api_inline bool yyjson_mut_arr_add_false(yyjson_mut_doc *doc,
-                                                yyjson_mut_val *arr);
+  /**
+   Creates and returns a new mutable array with the given double numbers.
 
-/**
- Adds a bool value at the end of the array.
- @param doc The `doc` is only used for memory allocation.
- @param arr The array to which the value is to be inserted.
-    Returns false if it is NULL or not an array.
- @param val The bool value to be added.
- @return Whether successful.
- */
-yyjson_api_inline bool yyjson_mut_arr_add_bool(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *arr,
-                                               bool val);
+   @param doc A mutable document, used for memory allocation only.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param vals A C array of double numbers.
+   @param count The number count. If this value is 0, an empty array will return.
+   @return The new array. NULL if input is invalid or memory allocation failed.
 
-/**
- Adds an unsigned integer value at the end of the array.
- @param doc The `doc` is only used for memory allocation.
- @param arr The array to which the value is to be inserted.
-    Returns false if it is NULL or not an array.
- @param num The number to be added.
- @return Whether successful.
- */
-yyjson_api_inline bool yyjson_mut_arr_add_uint(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *arr,
-                                               uint64_t num);
+   @par Example
+   @code
+      const double vals[3] = { -1.0, 0.0, 1.0 };
+      yyjson_mut_val *arr = yyjson_mut_arr_with_double(doc, vals, 3);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_double (
+      yyjson_mut_doc *doc, const double *vals, size_t count);
 
-/**
- Adds a signed integer value at the end of the array.
- @param doc The `doc` is only used for memory allocation.
- @param arr The array to which the value is to be inserted.
-    Returns false if it is NULL or not an array.
- @param num The number to be added.
- @return Whether successful.
- */
-yyjson_api_inline bool yyjson_mut_arr_add_sint(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *arr,
-                                               int64_t num);
+  /**
+   Creates and returns a new mutable array with the given strings, these strings
+   will not be copied.
 
-/**
- Adds a integer value at the end of the array.
- @param doc The `doc` is only used for memory allocation.
- @param arr The array to which the value is to be inserted.
-    Returns false if it is NULL or not an array.
- @param num The number to be added.
- @return Whether successful.
- */
-yyjson_api_inline bool yyjson_mut_arr_add_int(yyjson_mut_doc *doc,
-                                              yyjson_mut_val *arr,
-                                              int64_t num);
+   @param doc A mutable document, used for memory allocation only.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param vals A C array of UTF-8 null-terminator strings.
+      If this array contains NULL, the function will fail and return NULL.
+   @param count The number of values in `vals`.
+      If this value is 0, an empty array will return.
+   @return The new array. NULL if input is invalid or memory allocation failed.
 
-/**
- Adds a double value at the end of the array.
- @param doc The `doc` is only used for memory allocation.
- @param arr The array to which the value is to be inserted.
-    Returns false if it is NULL or not an array.
- @param num The number to be added.
- @return Whether successful.
- */
-yyjson_api_inline bool yyjson_mut_arr_add_real(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *arr,
-                                               double num);
+   @warning The input strings are not copied, you should keep these strings
+      unmodified for the lifetime of this JSON document. If these strings will be
+      modified, you should use `yyjson_mut_arr_with_strcpy()` instead.
 
-/**
- Adds a string value at the end of the array (no copy).
- @param doc The `doc` is only used for memory allocation.
- @param arr The array to which the value is to be inserted.
-    Returns false if it is NULL or not an array.
- @param str A null-terminated UTF-8 string.
- @return Whether successful.
- @warning The input string is not copied, you should keep this string unmodified
-    for the lifetime of this JSON document.
- */
-yyjson_api_inline bool yyjson_mut_arr_add_str(yyjson_mut_doc *doc,
-                                              yyjson_mut_val *arr,
-                                              const char *str);
+   @par Example
+   @code
+      const char *vals[3] = { "a", "b", "c" };
+      yyjson_mut_val *arr = yyjson_mut_arr_with_str(doc, vals, 3);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_str (
+      yyjson_mut_doc *doc, const char **vals, size_t count);
 
-/**
- Adds a string value at the end of the array (no copy).
- @param doc The `doc` is only used for memory allocation.
- @param arr The array to which the value is to be inserted.
-    Returns false if it is NULL or not an array.
- @param str A UTF-8 string, null-terminator is not required.
- @param len The length of the string, in bytes.
- @return Whether successful.
- @warning The input string is not copied, you should keep this string unmodified
-    for the lifetime of this JSON document.
- */
-yyjson_api_inline bool yyjson_mut_arr_add_strn(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *arr,
-                                               const char *str,
-                                               size_t len);
+  /**
+   Creates and returns a new mutable array with the given strings and string
+   lengths, these strings will not be copied.
 
-/**
- Adds a string value at the end of the array (copied).
- @param doc The `doc` is only used for memory allocation.
- @param arr The array to which the value is to be inserted.
-    Returns false if it is NULL or not an array.
- @param str A null-terminated UTF-8 string.
- @return Whether successful.
- */
-yyjson_api_inline bool yyjson_mut_arr_add_strcpy(yyjson_mut_doc *doc,
+   @param doc A mutable document, used for memory allocation only.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param vals A C array of UTF-8 strings, null-terminator is not required.
+      If this array contains NULL, the function will fail and return NULL.
+   @param lens A C array of string lengths, in bytes.
+   @param count The number of strings in `vals`.
+      If this value is 0, an empty array will return.
+   @return The new array. NULL if input is invalid or memory allocation failed.
+
+   @warning The input strings are not copied, you should keep these strings
+      unmodified for the lifetime of this JSON document. If these strings will be
+      modified, you should use `yyjson_mut_arr_with_strncpy()` instead.
+
+   @par Example
+   @code
+      const char *vals[3] = { "a", "bb", "c" };
+      const size_t lens[3] = { 1, 2, 1 };
+      yyjson_mut_val *arr = yyjson_mut_arr_with_strn(doc, vals, lens, 3);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strn (
+      yyjson_mut_doc *doc, const char **vals, const size_t *lens, size_t count);
+
+  /**
+   Creates and returns a new mutable array with the given strings, these strings
+   will be copied.
+
+   @param doc A mutable document, used for memory allocation only.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param vals A C array of UTF-8 null-terminator strings.
+      If this array contains NULL, the function will fail and return NULL.
+   @param count The number of values in `vals`.
+      If this value is 0, an empty array will return.
+   @return The new array. NULL if input is invalid or memory allocation failed.
+
+   @par Example
+   @code
+      const char *vals[3] = { "a", "b", "c" };
+      yyjson_mut_val *arr = yyjson_mut_arr_with_strcpy(doc, vals, 3);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strcpy (
+      yyjson_mut_doc *doc, const char **vals, size_t count);
+
+  /**
+   Creates and returns a new mutable array with the given strings and string
+   lengths, these strings will be copied.
+
+   @param doc A mutable document, used for memory allocation only.
+      If this parameter is NULL, the function will fail and return NULL.
+   @param vals A C array of UTF-8 strings, null-terminator is not required.
+      If this array contains NULL, the function will fail and return NULL.
+   @param lens A C array of string lengths, in bytes.
+   @param count The number of strings in `vals`.
+      If this value is 0, an empty array will return.
+   @return The new array. NULL if input is invalid or memory allocation failed.
+
+   @par Example
+   @code
+      const char *vals[3] = { "a", "bb", "c" };
+      const size_t lens[3] = { 1, 2, 1 };
+      yyjson_mut_val *arr = yyjson_mut_arr_with_strn(doc, vals, lens, 3);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strncpy (
+      yyjson_mut_doc *doc, const char **vals, const size_t *lens, size_t count);
+
+  /*==============================================================================
+   * Mutable JSON Array Modification API
+   *============================================================================*/
+
+  /**
+   Inserts a value into an array at a given index.
+   @param arr The array to which the value is to be inserted.
+      Returns false if it is NULL or not an array.
+   @param val The value to be inserted. Returns false if it is NULL.
+   @param idx The index to which to insert the new value.
+      Returns false if the index is out of range.
+   @return Whether successful.
+   @warning This function takes a linear search time.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_insert (yyjson_mut_val *arr,
+                                                yyjson_mut_val *val, size_t idx);
+
+  /**
+   Inserts a value at the end of the array.
+   @param arr The array to which the value is to be inserted.
+      Returns false if it is NULL or not an array.
+   @param val The value to be inserted. Returns false if it is NULL.
+   @return Whether successful.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_append (yyjson_mut_val *arr,
+                                                yyjson_mut_val *val);
+
+  /**
+   Inserts a value at the head of the array.
+   @param arr The array to which the value is to be inserted.
+      Returns false if it is NULL or not an array.
+   @param val The value to be inserted. Returns false if it is NULL.
+   @return    Whether successful.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_prepend (yyjson_mut_val *arr,
+                                                 yyjson_mut_val *val);
+
+  /**
+   Replaces a value at index and returns old value.
+   @param arr The array to which the value is to be replaced.
+      Returns false if it is NULL or not an array.
+   @param idx The index to which to replace the value.
+      Returns false if the index is out of range.
+   @param val The new value to replace. Returns false if it is NULL.
+   @return Old value, or NULL on error.
+   @warning This function takes a linear search time.
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_replace (yyjson_mut_val *arr,
+                                                            size_t idx,
+                                                            yyjson_mut_val *val);
+
+  /**
+   Removes and returns a value at index.
+   @param arr The array from which the value is to be removed.
+      Returns false if it is NULL or not an array.
+   @param idx The index from which to remove the value.
+      Returns false if the index is out of range.
+   @return Old value, or NULL on error.
+   @warning This function takes a linear search time.
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove (yyjson_mut_val *arr,
+                                                           size_t idx);
+
+  /**
+   Removes and returns the first value in this array.
+   @param arr The array from which the value is to be removed.
+      Returns false if it is NULL or not an array.
+   @return The first value, or NULL on error.
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_first (
+      yyjson_mut_val *arr);
+
+  /**
+   Removes and returns the last value in this array.
+   @param arr The array from which the value is to be removed.
+      Returns false if it is NULL or not an array.
+   @return The last value, or NULL on error.
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_last (
+      yyjson_mut_val *arr);
+
+  /**
+   Removes all values within a specified range in the array.
+   @param arr The array from which the value is to be removed.
+      Returns false if it is NULL or not an array.
+   @param idx The start index of the range (0 is the first).
+   @param len The number of items in the range (can be 0).
+   @return Whether successful.
+   @warning This function takes a linear search time.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_remove_range (yyjson_mut_val *arr,
+                                                      size_t idx, size_t len);
+
+  /**
+   Removes all values in this array.
+   @param arr The array from which all of the values are to be removed.
+      Returns false if it is NULL or not an array.
+   @return Whether successful.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_clear (yyjson_mut_val *arr);
+
+  /**
+   Rotates values in this array for the given number of times.
+   For example: `[1,2,3,4,5]` rotate 2 is `[3,4,5,1,2]`.
+   @param arr The array to be rotated.
+   @param idx Index (or times) to rotate.
+   @warning This function takes a linear search time.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_rotate (yyjson_mut_val *arr,
+                                                size_t idx);
+
+  /*==============================================================================
+   * Mutable JSON Array Modification Convenience API
+   *============================================================================*/
+
+  /**
+   Adds a value at the end of the array.
+   @param arr The array to which the value is to be inserted.
+      Returns false if it is NULL or not an array.
+   @param val The value to be inserted. Returns false if it is NULL.
+   @return Whether successful.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_add_val (yyjson_mut_val *arr,
+                                                 yyjson_mut_val *val);
+
+  /**
+   Adds a `null` value at the end of the array.
+   @param doc The `doc` is only used for memory allocation.
+   @param arr The array to which the value is to be inserted.
+      Returns false if it is NULL or not an array.
+   @return Whether successful.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_add_null (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *arr);
+
+  /**
+   Adds a `true` value at the end of the array.
+   @param doc The `doc` is only used for memory allocation.
+   @param arr The array to which the value is to be inserted.
+      Returns false if it is NULL or not an array.
+   @return Whether successful.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_add_true (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *arr);
+
+  /**
+   Adds a `false` value at the end of the array.
+   @param doc The `doc` is only used for memory allocation.
+   @param arr The array to which the value is to be inserted.
+      Returns false if it is NULL or not an array.
+   @return Whether successful.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_add_false (yyjson_mut_doc *doc,
+                                                   yyjson_mut_val *arr);
+
+  /**
+   Adds a bool value at the end of the array.
+   @param doc The `doc` is only used for memory allocation.
+   @param arr The array to which the value is to be inserted.
+      Returns false if it is NULL or not an array.
+   @param val The bool value to be added.
+   @return Whether successful.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_add_bool (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *arr,
+                                                  bool val);
+
+  /**
+   Adds an unsigned integer value at the end of the array.
+   @param doc The `doc` is only used for memory allocation.
+   @param arr The array to which the value is to be inserted.
+      Returns false if it is NULL or not an array.
+   @param num The number to be added.
+   @return Whether successful.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_add_uint (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *arr,
+                                                  uint64_t num);
+
+  /**
+   Adds a signed integer value at the end of the array.
+   @param doc The `doc` is only used for memory allocation.
+   @param arr The array to which the value is to be inserted.
+      Returns false if it is NULL or not an array.
+   @param num The number to be added.
+   @return Whether successful.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_add_sint (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *arr,
+                                                  int64_t num);
+
+  /**
+   Adds a integer value at the end of the array.
+   @param doc The `doc` is only used for memory allocation.
+   @param arr The array to which the value is to be inserted.
+      Returns false if it is NULL or not an array.
+   @param num The number to be added.
+   @return Whether successful.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_add_int (yyjson_mut_doc *doc,
+                                                 yyjson_mut_val *arr,
+                                                 int64_t num);
+
+  /**
+   Adds a double value at the end of the array.
+   @param doc The `doc` is only used for memory allocation.
+   @param arr The array to which the value is to be inserted.
+      Returns false if it is NULL or not an array.
+   @param num The number to be added.
+   @return Whether successful.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_add_real (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *arr,
+                                                  double num);
+
+  /**
+   Adds a string value at the end of the array (no copy).
+   @param doc The `doc` is only used for memory allocation.
+   @param arr The array to which the value is to be inserted.
+      Returns false if it is NULL or not an array.
+   @param str A null-terminated UTF-8 string.
+   @return Whether successful.
+   @warning The input string is not copied, you should keep this string unmodified
+      for the lifetime of this JSON document.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_add_str (yyjson_mut_doc *doc,
                                                  yyjson_mut_val *arr,
                                                  const char *str);
 
-/**
- Adds a string value at the end of the array (copied).
- @param doc The `doc` is only used for memory allocation.
- @param arr The array to which the value is to be inserted.
-    Returns false if it is NULL or not an array.
- @param str A UTF-8 string, null-terminator is not required.
- @param len The length of the string, in bytes.
- @return Whether successful.
- */
-yyjson_api_inline bool yyjson_mut_arr_add_strncpy(yyjson_mut_doc *doc,
+  /**
+   Adds a string value at the end of the array (no copy).
+   @param doc The `doc` is only used for memory allocation.
+   @param arr The array to which the value is to be inserted.
+      Returns false if it is NULL or not an array.
+   @param str A UTF-8 string, null-terminator is not required.
+   @param len The length of the string, in bytes.
+   @return Whether successful.
+   @warning The input string is not copied, you should keep this string unmodified
+      for the lifetime of this JSON document.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_add_strn (yyjson_mut_doc *doc,
                                                   yyjson_mut_val *arr,
                                                   const char *str,
                                                   size_t len);
 
-/**
- Creates and adds a new array at the end of the array.
- @param doc The `doc` is only used for memory allocation.
- @param arr The array to which the value is to be inserted.
-    Returns false if it is NULL or not an array.
- @return The new array, or NULL on error.
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_add_arr(yyjson_mut_doc *doc,
-                                                         yyjson_mut_val *arr);
+  /**
+   Adds a string value at the end of the array (copied).
+   @param doc The `doc` is only used for memory allocation.
+   @param arr The array to which the value is to be inserted.
+      Returns false if it is NULL or not an array.
+   @param str A null-terminated UTF-8 string.
+   @return Whether successful.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_add_strcpy (yyjson_mut_doc *doc,
+                                                    yyjson_mut_val *arr,
+                                                    const char *str);
 
-/**
- Creates and adds a new object at the end of the array.
- @param doc The `doc` is only used for memory allocation.
- @param arr The array to which the value is to be inserted.
-    Returns false if it is NULL or not an array.
- @return The new object, or NULL on error.
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_add_obj(yyjson_mut_doc *doc,
-                                                         yyjson_mut_val *arr);
+  /**
+   Adds a string value at the end of the array (copied).
+   @param doc The `doc` is only used for memory allocation.
+   @param arr The array to which the value is to be inserted.
+      Returns false if it is NULL or not an array.
+   @param str A UTF-8 string, null-terminator is not required.
+   @param len The length of the string, in bytes.
+   @return Whether successful.
+   */
+  yyjson_api_inline bool yyjson_mut_arr_add_strncpy (yyjson_mut_doc *doc,
+                                                     yyjson_mut_val *arr,
+                                                     const char *str,
+                                                     size_t len);
 
+  /**
+   Creates and adds a new array at the end of the array.
+   @param doc The `doc` is only used for memory allocation.
+   @param arr The array to which the value is to be inserted.
+      Returns false if it is NULL or not an array.
+   @return The new array, or NULL on error.
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_add_arr (yyjson_mut_doc *doc,
+                                                            yyjson_mut_val *arr);
 
+  /**
+   Creates and adds a new object at the end of the array.
+   @param doc The `doc` is only used for memory allocation.
+   @param arr The array to which the value is to be inserted.
+      Returns false if it is NULL or not an array.
+   @return The new object, or NULL on error.
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_add_obj (yyjson_mut_doc *doc,
+                                                            yyjson_mut_val *arr);
 
-/*==============================================================================
- * Mutable JSON Object API
- *============================================================================*/
+  /*==============================================================================
+   * Mutable JSON Object API
+   *============================================================================*/
 
-/** Returns the number of key-value pairs in this object.
-    Returns 0 if `obj` is NULL or type is not object. */
-yyjson_api_inline size_t yyjson_mut_obj_size(yyjson_mut_val *obj);
+  /** Returns the number of key-value pairs in this object.
+      Returns 0 if `obj` is NULL or type is not object. */
+  yyjson_api_inline size_t yyjson_mut_obj_size (yyjson_mut_val *obj);
 
-/** Returns the value to which the specified key is mapped.
-    Returns NULL if this object contains no mapping for the key.
-    Returns NULL if `obj/key` is NULL, or type is not object.
-    
-    The `key` should be a null-terminated UTF-8 string.
-    
-    @warning This function takes a linear search time. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_get(yyjson_mut_val *obj,
-                                                     const char *key);
+  /** Returns the value to which the specified key is mapped.
+      Returns NULL if this object contains no mapping for the key.
+      Returns NULL if `obj/key` is NULL, or type is not object.
 
-/** Returns the value to which the specified key is mapped.
-    Returns NULL if this object contains no mapping for the key.
-    Returns NULL if `obj/key` is NULL, or type is not object.
-    
-    The `key` should be a UTF-8 string, null-terminator is not required.
-    The `key_len` should be the length of the key, in bytes.
-    
-    @warning This function takes a linear search time. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_getn(yyjson_mut_val *obj,
-                                                      const char *key,
-                                                      size_t key_len);
+      The `key` should be a null-terminated UTF-8 string.
 
+      @warning This function takes a linear search time. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_get (yyjson_mut_val *obj,
+                                                        const char *key);
 
+  /** Returns the value to which the specified key is mapped.
+      Returns NULL if this object contains no mapping for the key.
+      Returns NULL if `obj/key` is NULL, or type is not object.
 
-/*==============================================================================
- * Mutable JSON Object Iterator API
- *============================================================================*/
+      The `key` should be a UTF-8 string, null-terminator is not required.
+      The `key_len` should be the length of the key, in bytes.
 
-/**
- A mutable JSON object iterator.
- 
- @warning You should not modify the object while iterating over it, but you can
-    use `yyjson_mut_obj_iter_remove()` to remove current value.
- 
- @par Example
- @code
-    yyjson_mut_val *key, *val;
-    yyjson_mut_obj_iter iter = yyjson_mut_obj_iter_with(obj);
-    while ((key = yyjson_mut_obj_iter_next(&iter))) {
-        val = yyjson_mut_obj_iter_get_val(key);
-        your_func(key, val);
-        if (your_val_is_unused(key, val)) {
-            yyjson_mut_obj_iter_remove(&iter);
-        }
-    }
- @endcode
- 
- If the ordering of the keys is known at compile-time, you can use this method
- to speed up value lookups:
- @code
-    // {"k1":1, "k2": 3, "k3": 3}
-    yyjson_mut_val *key, *val;
-    yyjson_mut_obj_iter iter = yyjson_mut_obj_iter_with(obj);
-    yyjson_mut_val *v1 = yyjson_mut_obj_iter_get(&iter, "k1");
-    yyjson_mut_val *v3 = yyjson_mut_obj_iter_get(&iter, "k3");
- @endcode
- @see `yyjson_mut_obj_iter_get()` and `yyjson_mut_obj_iter_getn()`
- */
-typedef struct yyjson_mut_obj_iter {
-    size_t idx; /**< current key index, from 0 */
-    size_t max; /**< maximum key index, `idx < max` */
+      @warning This function takes a linear search time. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_getn (yyjson_mut_val *obj,
+                                                         const char *key,
+                                                         size_t key_len);
+
+  /*==============================================================================
+   * Mutable JSON Object Iterator API
+   *============================================================================*/
+
+  /**
+   A mutable JSON object iterator.
+
+   @warning You should not modify the object while iterating over it, but you can
+      use `yyjson_mut_obj_iter_remove()` to remove current value.
+
+   @par Example
+   @code
+      yyjson_mut_val *key, *val;
+      yyjson_mut_obj_iter iter = yyjson_mut_obj_iter_with(obj);
+      while ((key = yyjson_mut_obj_iter_next(&iter))) {
+          val = yyjson_mut_obj_iter_get_val(key);
+          your_func(key, val);
+          if (your_val_is_unused(key, val)) {
+              yyjson_mut_obj_iter_remove(&iter);
+          }
+      }
+   @endcode
+
+   If the ordering of the keys is known at compile-time, you can use this method
+   to speed up value lookups:
+   @code
+      // {"k1":1, "k2": 3, "k3": 3}
+      yyjson_mut_val *key, *val;
+      yyjson_mut_obj_iter iter = yyjson_mut_obj_iter_with(obj);
+      yyjson_mut_val *v1 = yyjson_mut_obj_iter_get(&iter, "k1");
+      yyjson_mut_val *v3 = yyjson_mut_obj_iter_get(&iter, "k3");
+   @endcode
+   @see `yyjson_mut_obj_iter_get()` and `yyjson_mut_obj_iter_getn()`
+   */
+  typedef struct yyjson_mut_obj_iter
+  {
+    size_t idx;          /**< current key index, from 0 */
+    size_t max;          /**< maximum key index, `idx < max` */
     yyjson_mut_val *cur; /**< current key */
     yyjson_mut_val *pre; /**< previous key */
     yyjson_mut_val *obj; /**< the object being iterated */
-} yyjson_mut_obj_iter;
+  } yyjson_mut_obj_iter;
 
-/**
- Initialize an iterator for this object.
- 
- @param obj The object to be iterated over.
-    If this parameter is NULL or not an array, `iter` will be set to empty.
- @param iter The iterator to be initialized.
-    If this parameter is NULL, the function will fail and return false.
- @return true if the `iter` has been successfully initialized.
- 
- @note The iterator does not need to be destroyed.
- */
-yyjson_api_inline bool yyjson_mut_obj_iter_init(yyjson_mut_val *obj,
-    yyjson_mut_obj_iter *iter);
+  /**
+   Initialize an iterator for this object.
 
-/**
- Create an iterator with an object, same as `yyjson_obj_iter_init()`.
- 
- @param obj The object to be iterated over.
-    If this parameter is NULL or not an object, an empty iterator will returned.
- @return A new iterator for the object.
- 
- @note The iterator does not need to be destroyed.
- */
-yyjson_api_inline yyjson_mut_obj_iter yyjson_mut_obj_iter_with(
-    yyjson_mut_val *obj);
+   @param obj The object to be iterated over.
+      If this parameter is NULL or not an array, `iter` will be set to empty.
+   @param iter The iterator to be initialized.
+      If this parameter is NULL, the function will fail and return false.
+   @return true if the `iter` has been successfully initialized.
 
-/**
- Returns whether the iteration has more elements.
- If `iter` is NULL, this function will return false.
- */
-yyjson_api_inline bool yyjson_mut_obj_iter_has_next(
-    yyjson_mut_obj_iter *iter);
+   @note The iterator does not need to be destroyed.
+   */
+  yyjson_api_inline bool yyjson_mut_obj_iter_init (yyjson_mut_val *obj,
+                                                   yyjson_mut_obj_iter *iter);
 
-/**
- Returns the next key in the iteration, or NULL on end.
- If `iter` is NULL, this function will return NULL.
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_next(
-    yyjson_mut_obj_iter *iter);
+  /**
+   Create an iterator with an object, same as `yyjson_obj_iter_init()`.
 
-/**
- Returns the value for key inside the iteration.
- If `iter` is NULL, this function will return NULL.
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_get_val(
-    yyjson_mut_val *key);
+   @param obj The object to be iterated over.
+      If this parameter is NULL or not an object, an empty iterator will returned.
+   @return A new iterator for the object.
 
-/**
- Removes and returns current key-value pair in the iteration.
- If `iter` is NULL, this function will return NULL.
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_remove(
-    yyjson_mut_obj_iter *iter);
+   @note The iterator does not need to be destroyed.
+   */
+  yyjson_api_inline yyjson_mut_obj_iter yyjson_mut_obj_iter_with (
+      yyjson_mut_val *obj);
 
-/**
- Iterates to a specified key and returns the value.
- 
- This function does the same thing as `yyjson_mut_obj_get()`, but is much faster
- if the ordering of the keys is known at compile-time and you are using the same
- order to look up the values. If the key exists in this object, then the
- iterator will stop at the next key, otherwise the iterator will not change and
- NULL is returned.
- 
- @param iter The object iterator, should not be NULL.
- @param key The key, should be a UTF-8 string with null-terminator.
- @return The value to which the specified key is mapped.
-    NULL if this object contains no mapping for the key or input is invalid.
- 
- @warning This function takes a linear search time if the key is not nearby.
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_get(
-    yyjson_mut_obj_iter *iter, const char *key);
+  /**
+   Returns whether the iteration has more elements.
+   If `iter` is NULL, this function will return false.
+   */
+  yyjson_api_inline bool yyjson_mut_obj_iter_has_next (
+      yyjson_mut_obj_iter *iter);
 
-/**
- Iterates to a specified key and returns the value.
- 
- This function does the same thing as `yyjson_mut_obj_getn()` but is much faster
- if the ordering of the keys is known at compile-time and you are using the same
- order to look up the values. If the key exists in this object, then the
- iterator will stop at the next key, otherwise the iterator will not change and
- NULL is returned.
- 
- @param iter The object iterator, should not be NULL.
- @param key The key, should be a UTF-8 string, null-terminator is not required.
- @param key_len The the length of `key`, in bytes.
- @return The value to which the specified key is mapped.
-    NULL if this object contains no mapping for the key or input is invalid.
- 
- @warning This function takes a linear search time if the key is not nearby.
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_getn(
-    yyjson_mut_obj_iter *iter, const char *key, size_t key_len);
+  /**
+   Returns the next key in the iteration, or NULL on end.
+   If `iter` is NULL, this function will return NULL.
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_next (
+      yyjson_mut_obj_iter *iter);
+
+  /**
+   Returns the value for key inside the iteration.
+   If `iter` is NULL, this function will return NULL.
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_get_val (
+      yyjson_mut_val *key);
+
+  /**
+   Removes and returns current key-value pair in the iteration.
+   If `iter` is NULL, this function will return NULL.
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_remove (
+      yyjson_mut_obj_iter *iter);
+
+  /**
+   Iterates to a specified key and returns the value.
+
+   This function does the same thing as `yyjson_mut_obj_get()`, but is much faster
+   if the ordering of the keys is known at compile-time and you are using the same
+   order to look up the values. If the key exists in this object, then the
+   iterator will stop at the next key, otherwise the iterator will not change and
+   NULL is returned.
+
+   @param iter The object iterator, should not be NULL.
+   @param key The key, should be a UTF-8 string with null-terminator.
+   @return The value to which the specified key is mapped.
+      NULL if this object contains no mapping for the key or input is invalid.
+
+   @warning This function takes a linear search time if the key is not nearby.
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_get (
+      yyjson_mut_obj_iter *iter, const char *key);
+
+  /**
+   Iterates to a specified key and returns the value.
+
+   This function does the same thing as `yyjson_mut_obj_getn()` but is much faster
+   if the ordering of the keys is known at compile-time and you are using the same
+   order to look up the values. If the key exists in this object, then the
+   iterator will stop at the next key, otherwise the iterator will not change and
+   NULL is returned.
+
+   @param iter The object iterator, should not be NULL.
+   @param key The key, should be a UTF-8 string, null-terminator is not required.
+   @param key_len The the length of `key`, in bytes.
+   @return The value to which the specified key is mapped.
+      NULL if this object contains no mapping for the key or input is invalid.
+
+   @warning This function takes a linear search time if the key is not nearby.
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_getn (
+      yyjson_mut_obj_iter *iter, const char *key, size_t key_len);
 
 /**
  Macro for iterating over an object.
  It works like iterator, but with a more intuitive API.
- 
+
  @warning You should not modify the object while iterating over it.
- 
+
  @par Example
  @code
     size_t idx, max;
@@ -3121,489 +3071,480 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_getn(
     }
  @endcode
  */
-#define yyjson_mut_obj_foreach(obj, idx, max, key, val) \
-    for ((idx) = 0, \
-        (max) = yyjson_mut_obj_size(obj), \
-        (key) = (max) ? ((yyjson_mut_val *)(obj)->uni.ptr)->next->next : NULL, \
-        (val) = (key) ? (key)->next : NULL; \
-        (idx) < (max); \
-        (idx)++, \
-        (key) = (val)->next, \
-        (val) = (key)->next)
+#define yyjson_mut_obj_foreach(obj, idx, max, key, val)                       \
+  for ((idx) = 0,                                                             \
+      (max)  = yyjson_mut_obj_size (obj),                                     \
+      (key)  = (max) ? ((yyjson_mut_val *)(obj)->uni.ptr)->next->next : NULL, \
+      (val)  = (key) ? (key)->next : NULL;                                    \
+       (idx) < (max);                                                         \
+       (idx)++,                                                               \
+      (key) = (val)->next,                                                    \
+      (val) = (key)->next)
 
+  /*==============================================================================
+   * Mutable JSON Object Creation API
+   *============================================================================*/
 
+  /** Creates and returns a mutable object, returns NULL on error. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj (yyjson_mut_doc *doc);
 
-/*==============================================================================
- * Mutable JSON Object Creation API
- *============================================================================*/
+  /**
+   Creates and returns a mutable object with keys and values, returns NULL on
+   error. The keys and values are not copied. The strings should be a
+   null-terminated UTF-8 string.
 
-/** Creates and returns a mutable object, returns NULL on error. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj(yyjson_mut_doc *doc);
+   @warning The input string is not copied, you should keep this string
+      unmodified for the lifetime of this JSON document.
 
-/**
- Creates and returns a mutable object with keys and values, returns NULL on
- error. The keys and values are not copied. The strings should be a
- null-terminated UTF-8 string.
- 
- @warning The input string is not copied, you should keep this string
-    unmodified for the lifetime of this JSON document.
- 
- @par Example
- @code
-    const char *keys[2] = { "id", "name" };
-    const char *vals[2] = { "01", "Harry" };
-    yyjson_mut_val *obj = yyjson_mut_obj_with_str(doc, keys, vals, 2);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_str(yyjson_mut_doc *doc,
-                                                          const char **keys,
-                                                          const char **vals,
-                                                          size_t count);
+   @par Example
+   @code
+      const char *keys[2] = { "id", "name" };
+      const char *vals[2] = { "01", "Harry" };
+      yyjson_mut_val *obj = yyjson_mut_obj_with_str(doc, keys, vals, 2);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_str (yyjson_mut_doc *doc,
+                                                             const char **keys,
+                                                             const char **vals,
+                                                             size_t count);
 
-/**
- Creates and returns a mutable object with key-value pairs and pair count,
- returns NULL on error. The keys and values are not copied. The strings should
- be a null-terminated UTF-8 string.
- 
- @warning The input string is not copied, you should keep this string
-    unmodified for the lifetime of this JSON document.
- 
- @par Example
- @code
-    const char *kv_pairs[4] = { "id", "01", "name", "Harry" };
-    yyjson_mut_val *obj = yyjson_mut_obj_with_kv(doc, kv_pairs, 2);
- @endcode
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_kv(yyjson_mut_doc *doc,
-                                                         const char **kv_pairs,
-                                                         size_t pair_count);
+  /**
+   Creates and returns a mutable object with key-value pairs and pair count,
+   returns NULL on error. The keys and values are not copied. The strings should
+   be a null-terminated UTF-8 string.
 
+   @warning The input string is not copied, you should keep this string
+      unmodified for the lifetime of this JSON document.
 
+   @par Example
+   @code
+      const char *kv_pairs[4] = { "id", "01", "name", "Harry" };
+      yyjson_mut_val *obj = yyjson_mut_obj_with_kv(doc, kv_pairs, 2);
+   @endcode
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_kv (yyjson_mut_doc *doc,
+                                                            const char **kv_pairs,
+                                                            size_t pair_count);
 
-/*==============================================================================
- * Mutable JSON Object Modification API
- *============================================================================*/
+  /*==============================================================================
+   * Mutable JSON Object Modification API
+   *============================================================================*/
 
-/**
- Adds a key-value pair at the end of the object.
- This function allows duplicated key in one object.
- @param obj The object to which the new key-value pair is to be added.
- @param key The key, should be a string which is created by `yyjson_mut_str()`,
-    `yyjson_mut_strn()`, `yyjson_mut_strcpy()` or `yyjson_mut_strncpy()`.
- @param val The value to add to the object.
- @return Whether successful.
- */
-yyjson_api_inline bool yyjson_mut_obj_add(yyjson_mut_val *obj,
-                                          yyjson_mut_val *key,
-                                          yyjson_mut_val *val);
-/**
- Sets a key-value pair at the end of the object.
- This function may remove all key-value pairs for the given key before add.
- @param obj The object to which the new key-value pair is to be added.
- @param key The key, should be a string which is created by `yyjson_mut_str()`,
-    `yyjson_mut_strn()`, `yyjson_mut_strcpy()` or `yyjson_mut_strncpy()`.
- @param val The value to add to the object. If this value is null, the behavior
-    is same as `yyjson_mut_obj_remove()`.
- @return Whether successful.
- */
-yyjson_api_inline bool yyjson_mut_obj_put(yyjson_mut_val *obj,
-                                          yyjson_mut_val *key,
-                                          yyjson_mut_val *val);
-
-/**
- Inserts a key-value pair to the object at the given position.
- This function allows duplicated key in one object.
- @param obj The object to which the new key-value pair is to be added.
- @param key The key, should be a string which is created by `yyjson_mut_str()`,
-    `yyjson_mut_strn()`, `yyjson_mut_strcpy()` or `yyjson_mut_strncpy()`.
- @param val The value to add to the object.
- @param idx The index to which to insert the new pair.
- @return Whether successful.
- */
-yyjson_api_inline bool yyjson_mut_obj_insert(yyjson_mut_val *obj,
+  /**
+   Adds a key-value pair at the end of the object.
+   This function allows duplicated key in one object.
+   @param obj The object to which the new key-value pair is to be added.
+   @param key The key, should be a string which is created by `yyjson_mut_str()`,
+      `yyjson_mut_strn()`, `yyjson_mut_strcpy()` or `yyjson_mut_strncpy()`.
+   @param val The value to add to the object.
+   @return Whether successful.
+   */
+  yyjson_api_inline bool yyjson_mut_obj_add (yyjson_mut_val *obj,
                                              yyjson_mut_val *key,
-                                             yyjson_mut_val *val,
-                                             size_t idx);
+                                             yyjson_mut_val *val);
+  /**
+   Sets a key-value pair at the end of the object.
+   This function may remove all key-value pairs for the given key before add.
+   @param obj The object to which the new key-value pair is to be added.
+   @param key The key, should be a string which is created by `yyjson_mut_str()`,
+      `yyjson_mut_strn()`, `yyjson_mut_strcpy()` or `yyjson_mut_strncpy()`.
+   @param val The value to add to the object. If this value is null, the behavior
+      is same as `yyjson_mut_obj_remove()`.
+   @return Whether successful.
+   */
+  yyjson_api_inline bool yyjson_mut_obj_put (yyjson_mut_val *obj,
+                                             yyjson_mut_val *key,
+                                             yyjson_mut_val *val);
 
-/**
- Removes all key-value pair from the object with given key.
- @param obj The object from which the key-value pair is to be removed.
- @param key The key, should be a string value.
- @return The first matched value, or NULL if no matched value.
- @warning This function takes a linear search time.
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove(yyjson_mut_val *obj,
-                                                        yyjson_mut_val *key);
+  /**
+   Inserts a key-value pair to the object at the given position.
+   This function allows duplicated key in one object.
+   @param obj The object to which the new key-value pair is to be added.
+   @param key The key, should be a string which is created by `yyjson_mut_str()`,
+      `yyjson_mut_strn()`, `yyjson_mut_strcpy()` or `yyjson_mut_strncpy()`.
+   @param val The value to add to the object.
+   @param idx The index to which to insert the new pair.
+   @return Whether successful.
+   */
+  yyjson_api_inline bool yyjson_mut_obj_insert (yyjson_mut_val *obj,
+                                                yyjson_mut_val *key,
+                                                yyjson_mut_val *val,
+                                                size_t idx);
 
-/**
- Removes all key-value pair from the object with given key.
- @param obj The object from which the key-value pair is to be removed.
- @param key The key, should be a UTF-8 string with null-terminator.
- @return The first matched value, or NULL if no matched value.
- @warning This function takes a linear search time.
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_key(
-    yyjson_mut_val *obj, const char *key);
+  /**
+   Removes all key-value pair from the object with given key.
+   @param obj The object from which the key-value pair is to be removed.
+   @param key The key, should be a string value.
+   @return The first matched value, or NULL if no matched value.
+   @warning This function takes a linear search time.
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove (yyjson_mut_val *obj,
+                                                           yyjson_mut_val *key);
 
-/**
- Removes all key-value pair from the object with given key.
- @param obj The object from which the key-value pair is to be removed.
- @param key The key, should be a UTF-8 string, null-terminator is not required.
- @param key_len The length of the key.
- @return The first matched value, or NULL if no matched value.
- @warning This function takes a linear search time.
- */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_keyn(
-    yyjson_mut_val *obj, const char *key, size_t key_len);
+  /**
+   Removes all key-value pair from the object with given key.
+   @param obj The object from which the key-value pair is to be removed.
+   @param key The key, should be a UTF-8 string with null-terminator.
+   @return The first matched value, or NULL if no matched value.
+   @warning This function takes a linear search time.
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_key (
+      yyjson_mut_val *obj, const char *key);
 
-/**
- Removes all key-value pairs in this object.
- @param obj The object from which all of the values are to be removed.
- @return Whether successful.
- */
-yyjson_api_inline bool yyjson_mut_obj_clear(yyjson_mut_val *obj);
+  /**
+   Removes all key-value pair from the object with given key.
+   @param obj The object from which the key-value pair is to be removed.
+   @param key The key, should be a UTF-8 string, null-terminator is not required.
+   @param key_len The length of the key.
+   @return The first matched value, or NULL if no matched value.
+   @warning This function takes a linear search time.
+   */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_keyn (
+      yyjson_mut_val *obj, const char *key, size_t key_len);
 
-/**
- Replaces value from the object with given key.
- If the key is not exist, or the value is NULL, it will fail.
- @param obj The object to which the value is to be replaced.
- @param key The key, should be a string value.
- @param val The value to replace into the object.
- @return Whether successful.
- @warning This function takes a linear search time.
- */
-yyjson_api_inline bool yyjson_mut_obj_replace(yyjson_mut_val *obj,
-                                              yyjson_mut_val *key,
-                                              yyjson_mut_val *val);
+  /**
+   Removes all key-value pairs in this object.
+   @param obj The object from which all of the values are to be removed.
+   @return Whether successful.
+   */
+  yyjson_api_inline bool yyjson_mut_obj_clear (yyjson_mut_val *obj);
 
-/**
- Rotates key-value pairs in the object for the given number of times.
- For example: `{"a":1,"b":2,"c":3,"d":4}` rotate 1 is
- `{"b":2,"c":3,"d":4,"a":1}`.
- @param obj The object to be rotated.
- @param idx Index (or times) to rotate.
- @return Whether successful.
- @warning This function takes a linear search time.
- */
-yyjson_api_inline bool yyjson_mut_obj_rotate(yyjson_mut_val *obj,
-                                             size_t idx);
+  /**
+   Replaces value from the object with given key.
+   If the key is not exist, or the value is NULL, it will fail.
+   @param obj The object to which the value is to be replaced.
+   @param key The key, should be a string value.
+   @param val The value to replace into the object.
+   @return Whether successful.
+   @warning This function takes a linear search time.
+   */
+  yyjson_api_inline bool yyjson_mut_obj_replace (yyjson_mut_val *obj,
+                                                 yyjson_mut_val *key,
+                                                 yyjson_mut_val *val);
 
+  /**
+   Rotates key-value pairs in the object for the given number of times.
+   For example: `{"a":1,"b":2,"c":3,"d":4}` rotate 1 is
+   `{"b":2,"c":3,"d":4,"a":1}`.
+   @param obj The object to be rotated.
+   @param idx Index (or times) to rotate.
+   @return Whether successful.
+   @warning This function takes a linear search time.
+   */
+  yyjson_api_inline bool yyjson_mut_obj_rotate (yyjson_mut_val *obj,
+                                                size_t idx);
 
+  /*==============================================================================
+   * Mutable JSON Object Modification Convenience API
+   *============================================================================*/
 
-/*==============================================================================
- * Mutable JSON Object Modification Convenience API
- *============================================================================*/
+  /** Adds a `null` value at the end of the object.
+      The `key` should be a null-terminated UTF-8 string.
+      This function allows duplicated key in one object.
 
-/** Adds a `null` value at the end of the object.
-    The `key` should be a null-terminated UTF-8 string.
-    This function allows duplicated key in one object.
-    
-    @warning The key string are not copied, you should keep the string
-        unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_null(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *obj,
-                                               const char *key);
+      @warning The key string are not copied, you should keep the string
+          unmodified for the lifetime of this JSON document. */
+  yyjson_api_inline bool yyjson_mut_obj_add_null (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *obj,
+                                                  const char *key);
 
-/** Adds a `true` value at the end of the object.
-    The `key` should be a null-terminated UTF-8 string.
-    This function allows duplicated key in one object.
-    
-    @warning The key string are not copied, you should keep the string
-        unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_true(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *obj,
-                                               const char *key);
+  /** Adds a `true` value at the end of the object.
+      The `key` should be a null-terminated UTF-8 string.
+      This function allows duplicated key in one object.
 
-/** Adds a `false` value at the end of the object.
-    The `key` should be a null-terminated UTF-8 string.
-    This function allows duplicated key in one object.
-    
-    @warning The key string are not copied, you should keep the string
-        unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_false(yyjson_mut_doc *doc,
-                                                yyjson_mut_val *obj,
-                                                const char *key);
+      @warning The key string are not copied, you should keep the string
+          unmodified for the lifetime of this JSON document. */
+  yyjson_api_inline bool yyjson_mut_obj_add_true (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *obj,
+                                                  const char *key);
 
-/** Adds a bool value at the end of the object.
-    The `key` should be a null-terminated UTF-8 string.
-    This function allows duplicated key in one object.
-    
-    @warning The key string are not copied, you should keep the string
-        unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_bool(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *obj,
-                                               const char *key, bool val);
+  /** Adds a `false` value at the end of the object.
+      The `key` should be a null-terminated UTF-8 string.
+      This function allows duplicated key in one object.
 
-/** Adds an unsigned integer value at the end of the object.
-    The `key` should be a null-terminated UTF-8 string.
-    This function allows duplicated key in one object.
-    
-    @warning The key string are not copied, you should keep the string
-        unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_uint(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *obj,
-                                               const char *key, uint64_t val);
+      @warning The key string are not copied, you should keep the string
+          unmodified for the lifetime of this JSON document. */
+  yyjson_api_inline bool yyjson_mut_obj_add_false (yyjson_mut_doc *doc,
+                                                   yyjson_mut_val *obj,
+                                                   const char *key);
 
-/** Adds a signed integer value at the end of the object.
-    The `key` should be a null-terminated UTF-8 string.
-    This function allows duplicated key in one object.
-    
-    @warning The key string are not copied, you should keep the string
-        unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_sint(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *obj,
-                                               const char *key, int64_t val);
+  /** Adds a bool value at the end of the object.
+      The `key` should be a null-terminated UTF-8 string.
+      This function allows duplicated key in one object.
 
-/** Adds an int value at the end of the object.
-    The `key` should be a null-terminated UTF-8 string.
-    This function allows duplicated key in one object.
-    
-    @warning The key string are not copied, you should keep the string
-        unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_int(yyjson_mut_doc *doc,
-                                              yyjson_mut_val *obj,
-                                              const char *key, int64_t val);
+      @warning The key string are not copied, you should keep the string
+          unmodified for the lifetime of this JSON document. */
+  yyjson_api_inline bool yyjson_mut_obj_add_bool (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *obj,
+                                                  const char *key, bool val);
 
-/** Adds a double value at the end of the object.
-    The `key` should be a null-terminated UTF-8 string.
-    This function allows duplicated key in one object.
-    
-    @warning The key string are not copied, you should keep the string
-        unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_real(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *obj,
-                                               const char *key, double val);
+  /** Adds an unsigned integer value at the end of the object.
+      The `key` should be a null-terminated UTF-8 string.
+      This function allows duplicated key in one object.
 
-/** Adds a string value at the end of the object.
-    The `key` and `val` should be null-terminated UTF-8 strings.
-    This function allows duplicated key in one object.
-    
-    @warning The key/value string are not copied, you should keep these strings
-        unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_str(yyjson_mut_doc *doc,
-                                              yyjson_mut_val *obj,
-                                              const char *key, const char *val);
+      @warning The key string are not copied, you should keep the string
+          unmodified for the lifetime of this JSON document. */
+  yyjson_api_inline bool yyjson_mut_obj_add_uint (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *obj,
+                                                  const char *key, uint64_t val);
 
-/** Adds a string value at the end of the object.
-    The `key` should be a null-terminated UTF-8 string.
-    The `val` should be a UTF-8 string, null-terminator is not required.
-    The `len` should be the length of the `val`, in bytes.
-    This function allows duplicated key in one object.
-    
-    @warning The key/value string are not copied, you should keep these strings
-        unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_strn(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *obj,
-                                               const char *key,
-                                               const char *val, size_t len);
+  /** Adds a signed integer value at the end of the object.
+      The `key` should be a null-terminated UTF-8 string.
+      This function allows duplicated key in one object.
 
-/** Adds a string value at the end of the object.
-    The `key` and `val` should be null-terminated UTF-8 strings.
-    The value string is copied.
-    This function allows duplicated key in one object.
-    
-    @warning The key string are not copied, you should keep the string
-        unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_strcpy(yyjson_mut_doc *doc,
+      @warning The key string are not copied, you should keep the string
+          unmodified for the lifetime of this JSON document. */
+  yyjson_api_inline bool yyjson_mut_obj_add_sint (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *obj,
+                                                  const char *key, int64_t val);
+
+  /** Adds an int value at the end of the object.
+      The `key` should be a null-terminated UTF-8 string.
+      This function allows duplicated key in one object.
+
+      @warning The key string are not copied, you should keep the string
+          unmodified for the lifetime of this JSON document. */
+  yyjson_api_inline bool yyjson_mut_obj_add_int (yyjson_mut_doc *doc,
                                                  yyjson_mut_val *obj,
-                                                 const char *key,
-                                                 const char *val);
+                                                 const char *key, int64_t val);
 
-/** Adds a string value at the end of the object.
-    The `key` should be a null-terminated UTF-8 string.
-    The `val` should be a UTF-8 string, null-terminator is not required.
-    The `len` should be the length of the `val`, in bytes.
-    This function allows duplicated key in one object.
-    
-    @warning The key/value string are not copied, you should keep these strings
-        unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_strncpy(yyjson_mut_doc *doc,
+  /** Adds a double value at the end of the object.
+      The `key` should be a null-terminated UTF-8 string.
+      This function allows duplicated key in one object.
+
+      @warning The key string are not copied, you should keep the string
+          unmodified for the lifetime of this JSON document. */
+  yyjson_api_inline bool yyjson_mut_obj_add_real (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *obj,
+                                                  const char *key, double val);
+
+  /** Adds a string value at the end of the object.
+      The `key` and `val` should be null-terminated UTF-8 strings.
+      This function allows duplicated key in one object.
+
+      @warning The key/value string are not copied, you should keep these strings
+          unmodified for the lifetime of this JSON document. */
+  yyjson_api_inline bool yyjson_mut_obj_add_str (yyjson_mut_doc *doc,
+                                                 yyjson_mut_val *obj,
+                                                 const char *key, const char *val);
+
+  /** Adds a string value at the end of the object.
+      The `key` should be a null-terminated UTF-8 string.
+      The `val` should be a UTF-8 string, null-terminator is not required.
+      The `len` should be the length of the `val`, in bytes.
+      This function allows duplicated key in one object.
+
+      @warning The key/value string are not copied, you should keep these strings
+          unmodified for the lifetime of this JSON document. */
+  yyjson_api_inline bool yyjson_mut_obj_add_strn (yyjson_mut_doc *doc,
                                                   yyjson_mut_val *obj,
                                                   const char *key,
                                                   const char *val, size_t len);
 
-/** Adds a JSON value at the end of the object.
-    The `key` should be a null-terminated UTF-8 string.
-    This function allows duplicated key in one object.
-    
-    @warning The key string are not copied, you should keep the string
-        unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_val(yyjson_mut_doc *doc,
-                                              yyjson_mut_val *obj,
-                                              const char *key,
-                                              yyjson_mut_val *val);
+  /** Adds a string value at the end of the object.
+      The `key` and `val` should be null-terminated UTF-8 strings.
+      The value string is copied.
+      This function allows duplicated key in one object.
 
-/** Removes all key-value pairs for the given key.
-    Returns the first value to which the specified key is mapped or NULL if this
-    object contains no mapping for the key.
-    The `key` should be a null-terminated UTF-8 string.
-    
-    @warning This function takes a linear search time. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_str(
-    yyjson_mut_val *obj, const char *key);
+      @warning The key string are not copied, you should keep the string
+          unmodified for the lifetime of this JSON document. */
+  yyjson_api_inline bool yyjson_mut_obj_add_strcpy (yyjson_mut_doc *doc,
+                                                    yyjson_mut_val *obj,
+                                                    const char *key,
+                                                    const char *val);
 
-/** Removes all key-value pairs for the given key.
-    Returns the first value to which the specified key is mapped or NULL if this
-    object contains no mapping for the key.
-    The `key` should be a UTF-8 string, null-terminator is not required.
-    The `len` should be the length of the key, in bytes.
-    
-    @warning This function takes a linear search time. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_strn(
-    yyjson_mut_val *obj, const char *key, size_t len);
+  /** Adds a string value at the end of the object.
+      The `key` should be a null-terminated UTF-8 string.
+      The `val` should be a UTF-8 string, null-terminator is not required.
+      The `len` should be the length of the `val`, in bytes.
+      This function allows duplicated key in one object.
 
-/** Replaces all matching keys with the new key.
-    Returns true if at least one key was renamed.
-    The `key` and `new_key` should be a null-terminated UTF-8 string.
-    The `new_key` is copied and held by doc.
-    
-    @warning This function takes a linear search time.
-    If `new_key` already exists, it will cause duplicate keys.
- */
-yyjson_api_inline bool yyjson_mut_obj_rename_key(yyjson_mut_doc *doc,
+      @warning The key/value string are not copied, you should keep these strings
+          unmodified for the lifetime of this JSON document. */
+  yyjson_api_inline bool yyjson_mut_obj_add_strncpy (yyjson_mut_doc *doc,
+                                                     yyjson_mut_val *obj,
+                                                     const char *key,
+                                                     const char *val, size_t len);
+
+  /** Adds a JSON value at the end of the object.
+      The `key` should be a null-terminated UTF-8 string.
+      This function allows duplicated key in one object.
+
+      @warning The key string are not copied, you should keep the string
+          unmodified for the lifetime of this JSON document. */
+  yyjson_api_inline bool yyjson_mut_obj_add_val (yyjson_mut_doc *doc,
                                                  yyjson_mut_val *obj,
                                                  const char *key,
-                                                 const char *new_key);
+                                                 yyjson_mut_val *val);
 
-/** Replaces all matching keys with the new key.
-    Returns true if at least one key was renamed.
-    The `key` and `new_key` should be a UTF-8 string,
-    null-terminator is not required. The `new_key` is copied and held by doc.
-    
-    @warning This function takes a linear search time.
-    If `new_key` already exists, it will cause duplicate keys.
- */
-yyjson_api_inline bool yyjson_mut_obj_rename_keyn(yyjson_mut_doc *doc,
-                                                  yyjson_mut_val *obj,
-                                                  const char *key,
-                                                  size_t len,
-                                                  const char *new_key,
-                                                  size_t new_len);
+  /** Removes all key-value pairs for the given key.
+      Returns the first value to which the specified key is mapped or NULL if this
+      object contains no mapping for the key.
+      The `key` should be a null-terminated UTF-8 string.
 
+      @warning This function takes a linear search time. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_str (
+      yyjson_mut_val *obj, const char *key);
 
+  /** Removes all key-value pairs for the given key.
+      Returns the first value to which the specified key is mapped or NULL if this
+      object contains no mapping for the key.
+      The `key` should be a UTF-8 string, null-terminator is not required.
+      The `len` should be the length of the key, in bytes.
 
-/*==============================================================================
- * JSON Pointer API
- * https://tools.ietf.org/html/rfc6901
- *============================================================================*/
+      @warning This function takes a linear search time. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_strn (
+      yyjson_mut_val *obj, const char *key, size_t len);
 
-/** Get a JSON value with JSON Pointer (RFC 6901).
-    The `ptr` should be a null-terminated UTF-8 string.
-    
-    Returns NULL if there's no matched value.
-    Returns NULL if `val/ptr` is NULL or `val` is not object. */
-yyjson_api_inline yyjson_val *yyjson_get_pointer(yyjson_val *val,
-                                                 const char *ptr);
+  /** Replaces all matching keys with the new key.
+      Returns true if at least one key was renamed.
+      The `key` and `new_key` should be a null-terminated UTF-8 string.
+      The `new_key` is copied and held by doc.
 
-/** Get a JSON value with JSON Pointer (RFC 6901).
-    The `ptr` should be a UTF-8 string, null-terminator is not required.
-    The `len` should be the length of the `ptr`, in bytes.
-    
-    Returns NULL if there's no matched value.
-    Returns NULL if `val/ptr` is NULL or `val` is not object. */
-yyjson_api_inline yyjson_val *yyjson_get_pointern(yyjson_val *val,
-                                                  const char *ptr,
-                                                  size_t len);
+      @warning This function takes a linear search time.
+      If `new_key` already exists, it will cause duplicate keys.
+   */
+  yyjson_api_inline bool yyjson_mut_obj_rename_key (yyjson_mut_doc *doc,
+                                                    yyjson_mut_val *obj,
+                                                    const char *key,
+                                                    const char *new_key);
 
-/** Get a JSON value with JSON Pointer (RFC 6901).
-    The `ptr` should be a null-terminated UTF-8 string.
-    
-    Returns NULL if there's no matched value. */
-yyjson_api_inline yyjson_val *yyjson_doc_get_pointer(yyjson_doc *doc,
-                                                     const char *ptr);
+  /** Replaces all matching keys with the new key.
+      Returns true if at least one key was renamed.
+      The `key` and `new_key` should be a UTF-8 string,
+      null-terminator is not required. The `new_key` is copied and held by doc.
 
-/** Get a JSON value with JSON Pointer (RFC 6901).
-    The `ptr` should be a UTF-8 string, null-terminator is not required.
-    The `len` should be the length of the `ptr`, in bytes.
- 
-    Returns NULL if there's no matched value. */
-yyjson_api_inline yyjson_val *yyjson_doc_get_pointern(yyjson_doc *doc,
+      @warning This function takes a linear search time.
+      If `new_key` already exists, it will cause duplicate keys.
+   */
+  yyjson_api_inline bool yyjson_mut_obj_rename_keyn (yyjson_mut_doc *doc,
+                                                     yyjson_mut_val *obj,
+                                                     const char *key,
+                                                     size_t len,
+                                                     const char *new_key,
+                                                     size_t new_len);
+
+  /*==============================================================================
+   * JSON Pointer API
+   * https://tools.ietf.org/html/rfc6901
+   *============================================================================*/
+
+  /** Get a JSON value with JSON Pointer (RFC 6901).
+      The `ptr` should be a null-terminated UTF-8 string.
+
+      Returns NULL if there's no matched value.
+      Returns NULL if `val/ptr` is NULL or `val` is not object. */
+  yyjson_api_inline yyjson_val *yyjson_get_pointer (yyjson_val *val,
+                                                    const char *ptr);
+
+  /** Get a JSON value with JSON Pointer (RFC 6901).
+      The `ptr` should be a UTF-8 string, null-terminator is not required.
+      The `len` should be the length of the `ptr`, in bytes.
+
+      Returns NULL if there's no matched value.
+      Returns NULL if `val/ptr` is NULL or `val` is not object. */
+  yyjson_api_inline yyjson_val *yyjson_get_pointern (yyjson_val *val,
                                                      const char *ptr,
-                                                      size_t len);
+                                                     size_t len);
 
-/** Get a JSON value with JSON Pointer (RFC 6901).
-    The `ptr` should be a null-terminated UTF-8 string.
-    
-    Returns NULL if there's no matched value. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_get_pointer(yyjson_mut_val *val,
-                                                         const char *ptr);
+  /** Get a JSON value with JSON Pointer (RFC 6901).
+      The `ptr` should be a null-terminated UTF-8 string.
 
-/** Get a JSON value with JSON Pointer (RFC 6901).
-    The `ptr` should be a UTF-8 string, null-terminator is not required.
-    The `len` should be the length of the `ptr`, in bytes.
-    
-    Returns NULL if there's no matched value. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_get_pointern(yyjson_mut_val *val,
-                                                          const char *ptr,
-                                                          size_t len);
+      Returns NULL if there's no matched value. */
+  yyjson_api_inline yyjson_val *yyjson_doc_get_pointer (yyjson_doc *doc,
+                                                        const char *ptr);
 
-/** Get a JSON value with JSON Pointer (RFC 6901).
-    The `ptr` should be a null-terminated UTF-8 string.
-    
-    Returns NULL if there's no matched value. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_pointer(
-    yyjson_mut_doc *doc, const char *ptr);
+  /** Get a JSON value with JSON Pointer (RFC 6901).
+      The `ptr` should be a UTF-8 string, null-terminator is not required.
+      The `len` should be the length of the `ptr`, in bytes.
 
-/** Get a JSON value with JSON Pointer (RFC 6901).
-    The `ptr` should be a UTF-8 string, null-terminator is not required.
-    The `len` should be the length of the `ptr`, in bytes.
-    
-    Returns NULL if there's no matched value. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_pointern(
-    yyjson_mut_doc *doc, const char *ptr, size_t len);
+      Returns NULL if there's no matched value. */
+  yyjson_api_inline yyjson_val *yyjson_doc_get_pointern (yyjson_doc *doc,
+                                                         const char *ptr,
+                                                         size_t len);
 
+  /** Get a JSON value with JSON Pointer (RFC 6901).
+      The `ptr` should be a null-terminated UTF-8 string.
 
+      Returns NULL if there's no matched value. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_get_pointer (yyjson_mut_val *val,
+                                                            const char *ptr);
 
-/*==============================================================================
- * JSON Merge-Patch API
- * https://tools.ietf.org/html/rfc7386
- *============================================================================*/
+  /** Get a JSON value with JSON Pointer (RFC 6901).
+      The `ptr` should be a UTF-8 string, null-terminator is not required.
+      The `len` should be the length of the `ptr`, in bytes.
 
-/** Creates and returns a merge-patched JSON value (RFC 7386).
-    The memory of the returned value is allocated by the `doc`.
-    Returns NULL if the patch could not be applied.
-    
-    @warning This function is recursive and may cause a stack overflow if the
-        object level is too deep. */
-yyjson_api yyjson_mut_val *yyjson_merge_patch(yyjson_mut_doc *doc,
-                                              yyjson_val *orig,
-                                              yyjson_val *patch);
+      Returns NULL if there's no matched value. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_get_pointern (yyjson_mut_val *val,
+                                                             const char *ptr,
+                                                             size_t len);
 
-/** Creates and returns a merge-patched JSON value (RFC 7386).
-    The memory of the returned value is allocated by the `doc`.
-    Returns NULL if the patch could not be applied.
-    
-    @warning This function is recursive and may cause a stack overflow if the
-        object level is too deep. */
-yyjson_api yyjson_mut_val *yyjson_mut_merge_patch(yyjson_mut_doc *doc,
-                                                  yyjson_mut_val *orig,
-                                                  yyjson_mut_val *patch);
+  /** Get a JSON value with JSON Pointer (RFC 6901).
+      The `ptr` should be a null-terminated UTF-8 string.
 
+      Returns NULL if there's no matched value. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_pointer (
+      yyjson_mut_doc *doc, const char *ptr);
 
+  /** Get a JSON value with JSON Pointer (RFC 6901).
+      The `ptr` should be a UTF-8 string, null-terminator is not required.
+      The `len` should be the length of the `ptr`, in bytes.
 
-/*==============================================================================
- * JSON Structure (Implementation)
- *============================================================================*/
+      Returns NULL if there's no matched value. */
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_pointern (
+      yyjson_mut_doc *doc, const char *ptr, size_t len);
 
-/** Payload of a JSON value (8 bytes). */
-typedef union yyjson_val_uni {
-    uint64_t    u64;
-    int64_t     i64;
-    double      f64;
+  /*==============================================================================
+   * JSON Merge-Patch API
+   * https://tools.ietf.org/html/rfc7386
+   *============================================================================*/
+
+  /** Creates and returns a merge-patched JSON value (RFC 7386).
+      The memory of the returned value is allocated by the `doc`.
+      Returns NULL if the patch could not be applied.
+
+      @warning This function is recursive and may cause a stack overflow if the
+          object level is too deep. */
+  yyjson_api yyjson_mut_val *yyjson_merge_patch (yyjson_mut_doc *doc,
+                                                 yyjson_val *orig,
+                                                 yyjson_val *patch);
+
+  /** Creates and returns a merge-patched JSON value (RFC 7386).
+      The memory of the returned value is allocated by the `doc`.
+      Returns NULL if the patch could not be applied.
+
+      @warning This function is recursive and may cause a stack overflow if the
+          object level is too deep. */
+  yyjson_api yyjson_mut_val *yyjson_mut_merge_patch (yyjson_mut_doc *doc,
+                                                     yyjson_mut_val *orig,
+                                                     yyjson_mut_val *patch);
+
+  /*==============================================================================
+   * JSON Structure (Implementation)
+   *============================================================================*/
+
+  /** Payload of a JSON value (8 bytes). */
+  typedef union yyjson_val_uni
+  {
+    uint64_t u64;
+    int64_t i64;
+    double f64;
     const char *str;
-    void       *ptr;
-    size_t      ofs;
-} yyjson_val_uni;
+    void *ptr;
+    size_t ofs;
+  } yyjson_val_uni;
 
-/**
- Immutable JSON value, 16 bytes.
- */
-struct yyjson_val {
-    uint64_t tag; /**< type, subtype and length */
+  /**
+   Immutable JSON value, 16 bytes.
+   */
+  struct yyjson_val
+  {
+    uint64_t tag;       /**< type, subtype and length */
     yyjson_val_uni uni; /**< payload */
-};
+  };
 
-struct yyjson_doc {
+  struct yyjson_doc
+  {
     /** Root value of the document (nonnull). */
     yyjson_val *root;
     /** Allocator used by document (nonnull). */
@@ -3614,2628 +3555,3151 @@ struct yyjson_doc {
     size_t val_read;
     /** The string pool used by JSON values (nullable). */
     char *str_pool;
-};
+  };
 
+  /*==============================================================================
+   * Unsafe JSON Value API (Implementation)
+   *============================================================================*/
 
-
-/*==============================================================================
- * Unsafe JSON Value API (Implementation)
- *============================================================================*/
-
-yyjson_api_inline yyjson_type unsafe_yyjson_get_type(void *val) {
+  yyjson_api_inline yyjson_type unsafe_yyjson_get_type (void *val)
+  {
     uint8_t tag = (uint8_t)((yyjson_val *)val)->tag;
     return (yyjson_type)(tag & YYJSON_TYPE_MASK);
-}
+  }
 
-yyjson_api_inline yyjson_subtype unsafe_yyjson_get_subtype(void *val) {
+  yyjson_api_inline yyjson_subtype unsafe_yyjson_get_subtype (void *val)
+  {
     uint8_t tag = (uint8_t)((yyjson_val *)val)->tag;
     return (yyjson_subtype)(tag & YYJSON_SUBTYPE_MASK);
-}
+  }
 
-yyjson_api_inline uint8_t unsafe_yyjson_get_tag(void *val) {
+  yyjson_api_inline uint8_t unsafe_yyjson_get_tag (void *val)
+  {
     uint8_t tag = (uint8_t)((yyjson_val *)val)->tag;
     return (uint8_t)(tag & YYJSON_TAG_MASK);
-}
+  }
 
-yyjson_api_inline bool unsafe_yyjson_is_raw(void *val) {
-    return unsafe_yyjson_get_type(val) == YYJSON_TYPE_RAW;
-}
+  yyjson_api_inline bool unsafe_yyjson_is_raw (void *val)
+  {
+    return unsafe_yyjson_get_type (val) == YYJSON_TYPE_RAW;
+  }
 
-yyjson_api_inline bool unsafe_yyjson_is_null(void *val) {
-    return unsafe_yyjson_get_type(val) == YYJSON_TYPE_NULL;
-}
+  yyjson_api_inline bool unsafe_yyjson_is_null (void *val)
+  {
+    return unsafe_yyjson_get_type (val) == YYJSON_TYPE_NULL;
+  }
 
-yyjson_api_inline bool unsafe_yyjson_is_bool(void *val) {
-    return unsafe_yyjson_get_type(val) == YYJSON_TYPE_BOOL;
-}
+  yyjson_api_inline bool unsafe_yyjson_is_bool (void *val)
+  {
+    return unsafe_yyjson_get_type (val) == YYJSON_TYPE_BOOL;
+  }
 
-yyjson_api_inline bool unsafe_yyjson_is_num(void *val) {
-    return unsafe_yyjson_get_type(val) == YYJSON_TYPE_NUM;
-}
+  yyjson_api_inline bool unsafe_yyjson_is_num (void *val)
+  {
+    return unsafe_yyjson_get_type (val) == YYJSON_TYPE_NUM;
+  }
 
-yyjson_api_inline bool unsafe_yyjson_is_str(void *val) {
-    return unsafe_yyjson_get_type(val) == YYJSON_TYPE_STR;
-}
+  yyjson_api_inline bool unsafe_yyjson_is_str (void *val)
+  {
+    return unsafe_yyjson_get_type (val) == YYJSON_TYPE_STR;
+  }
 
-yyjson_api_inline bool unsafe_yyjson_is_arr(void *val) {
-    return unsafe_yyjson_get_type(val) == YYJSON_TYPE_ARR;
-}
+  yyjson_api_inline bool unsafe_yyjson_is_arr (void *val)
+  {
+    return unsafe_yyjson_get_type (val) == YYJSON_TYPE_ARR;
+  }
 
-yyjson_api_inline bool unsafe_yyjson_is_obj(void *val) {
-    return unsafe_yyjson_get_type(val) == YYJSON_TYPE_OBJ;
-}
+  yyjson_api_inline bool unsafe_yyjson_is_obj (void *val)
+  {
+    return unsafe_yyjson_get_type (val) == YYJSON_TYPE_OBJ;
+  }
 
-yyjson_api_inline bool unsafe_yyjson_is_ctn(void *val) {
+  yyjson_api_inline bool unsafe_yyjson_is_ctn (void *val)
+  {
     uint8_t mask = YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ;
-    return (unsafe_yyjson_get_tag(val) & mask) == mask;
-}
+    return (unsafe_yyjson_get_tag (val) & mask) == mask;
+  }
 
-yyjson_api_inline bool unsafe_yyjson_is_uint(void *val) {
+  yyjson_api_inline bool unsafe_yyjson_is_uint (void *val)
+  {
     const uint8_t patt = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
-    return unsafe_yyjson_get_tag(val) == patt;
-}
+    return unsafe_yyjson_get_tag (val) == patt;
+  }
 
-yyjson_api_inline bool unsafe_yyjson_is_sint(void *val) {
+  yyjson_api_inline bool unsafe_yyjson_is_sint (void *val)
+  {
     const uint8_t patt = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
-    return unsafe_yyjson_get_tag(val) == patt;
-}
+    return unsafe_yyjson_get_tag (val) == patt;
+  }
 
-yyjson_api_inline bool unsafe_yyjson_is_int(void *val) {
+  yyjson_api_inline bool unsafe_yyjson_is_int (void *val)
+  {
     const uint8_t mask = YYJSON_TAG_MASK & (~YYJSON_SUBTYPE_SINT);
     const uint8_t patt = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
-    return (unsafe_yyjson_get_tag(val) & mask) == patt;
-}
+    return (unsafe_yyjson_get_tag (val) & mask) == patt;
+  }
 
-yyjson_api_inline bool unsafe_yyjson_is_real(void *val) {
+  yyjson_api_inline bool unsafe_yyjson_is_real (void *val)
+  {
     const uint8_t patt = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
-    return unsafe_yyjson_get_tag(val) == patt;
-}
+    return unsafe_yyjson_get_tag (val) == patt;
+  }
 
-yyjson_api_inline bool unsafe_yyjson_is_true(void *val) {
+  yyjson_api_inline bool unsafe_yyjson_is_true (void *val)
+  {
     const uint8_t patt = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE;
-    return unsafe_yyjson_get_tag(val) == patt;
-}
+    return unsafe_yyjson_get_tag (val) == patt;
+  }
 
-yyjson_api_inline bool unsafe_yyjson_is_false(void *val) {
+  yyjson_api_inline bool unsafe_yyjson_is_false (void *val)
+  {
     const uint8_t patt = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE;
-    return unsafe_yyjson_get_tag(val) == patt;
-}
+    return unsafe_yyjson_get_tag (val) == patt;
+  }
 
-yyjson_api_inline bool unsafe_yyjson_arr_is_flat(yyjson_val *val) {
+  yyjson_api_inline bool unsafe_yyjson_arr_is_flat (yyjson_val *val)
+  {
     size_t ofs = val->uni.ofs;
     size_t len = (size_t)(val->tag >> YYJSON_TAG_BIT);
-    return len * sizeof(yyjson_val) + sizeof(yyjson_val) == ofs;
-}
+    return len * sizeof (yyjson_val) + sizeof (yyjson_val) == ofs;
+  }
 
-yyjson_api_inline const char *unsafe_yyjson_get_raw(void *val) {
+  yyjson_api_inline const char *unsafe_yyjson_get_raw (void *val)
+  {
     return ((yyjson_val *)val)->uni.str;
-}
+  }
 
-yyjson_api_inline bool unsafe_yyjson_get_bool(void *val) {
-    uint8_t tag = unsafe_yyjson_get_tag(val);
+  yyjson_api_inline bool unsafe_yyjson_get_bool (void *val)
+  {
+    uint8_t tag = unsafe_yyjson_get_tag (val);
     return (bool)((tag & YYJSON_SUBTYPE_MASK) >> YYJSON_TYPE_BIT);
-}
+  }
 
-yyjson_api_inline uint64_t unsafe_yyjson_get_uint(void *val) {
+  yyjson_api_inline uint64_t unsafe_yyjson_get_uint (void *val)
+  {
     return ((yyjson_val *)val)->uni.u64;
-}
+  }
 
-yyjson_api_inline int64_t unsafe_yyjson_get_sint(void *val) {
+  yyjson_api_inline int64_t unsafe_yyjson_get_sint (void *val)
+  {
     return ((yyjson_val *)val)->uni.i64;
-}
+  }
 
-yyjson_api_inline int unsafe_yyjson_get_int(void *val) {
+  yyjson_api_inline int unsafe_yyjson_get_int (void *val)
+  {
     return (int)((yyjson_val *)val)->uni.i64;
-}
+  }
 
-yyjson_api_inline double unsafe_yyjson_get_real(void *val) {
+  yyjson_api_inline double unsafe_yyjson_get_real (void *val)
+  {
     return ((yyjson_val *)val)->uni.f64;
-}
+  }
 
-yyjson_api_inline double unsafe_yyjson_get_num(void *val) {
-    uint8_t tag = unsafe_yyjson_get_tag(val);
-    if (tag == (YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL)) {
-        return ((yyjson_val *)val)->uni.f64;
-    } else if (tag == (YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT)) {
-        return (double)((yyjson_val *)val)->uni.i64;
-    } else if (tag == (YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT)) {
+  yyjson_api_inline double unsafe_yyjson_get_num (void *val)
+  {
+    uint8_t tag = unsafe_yyjson_get_tag (val);
+    if (tag == (YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL))
+    {
+      return ((yyjson_val *)val)->uni.f64;
+    }
+    else if (tag == (YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT))
+    {
+      return (double)((yyjson_val *)val)->uni.i64;
+    }
+    else if (tag == (YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT))
+    {
 #if YYJSON_U64_TO_F64_NO_IMPL
-        uint64_t msb = ((uint64_t)1) << 63;
-        uint64_t num = ((yyjson_val *)val)->uni.u64;
-        if ((num & msb) == 0) {
-            return (double)(int64_t)num;
-        } else {
-            return ((double)(int64_t)((num >> 1) | (num & 1))) * (double)2.0;
-        }
+      uint64_t msb = ((uint64_t)1) << 63;
+      uint64_t num = ((yyjson_val *)val)->uni.u64;
+      if ((num & msb) == 0)
+      {
+        return (double)(int64_t)num;
+      }
+      else
+      {
+        return ((double)(int64_t)((num >> 1) | (num & 1))) * (double)2.0;
+      }
 #else
-        return (double)((yyjson_val *)val)->uni.u64;
+    return (double)((yyjson_val *)val)->uni.u64;
 #endif
     }
     return 0.0;
-}
+  }
 
-yyjson_api_inline const char *unsafe_yyjson_get_str(void *val) {
+  yyjson_api_inline const char *unsafe_yyjson_get_str (void *val)
+  {
     return ((yyjson_val *)val)->uni.str;
-}
+  }
 
-yyjson_api_inline size_t unsafe_yyjson_get_len(void *val) {
+  yyjson_api_inline size_t unsafe_yyjson_get_len (void *val)
+  {
     return (size_t)(((yyjson_val *)val)->tag >> YYJSON_TAG_BIT);
-}
+  }
 
-yyjson_api_inline yyjson_val *unsafe_yyjson_get_first(yyjson_val *ctn) {
+  yyjson_api_inline yyjson_val *unsafe_yyjson_get_first (yyjson_val *ctn)
+  {
     return ctn + 1;
-}
+  }
 
-yyjson_api_inline yyjson_val *unsafe_yyjson_get_next(yyjson_val *val) {
-    bool is_ctn = unsafe_yyjson_is_ctn(val);
+  yyjson_api_inline yyjson_val *unsafe_yyjson_get_next (yyjson_val *val)
+  {
+    bool is_ctn    = unsafe_yyjson_is_ctn (val);
     size_t ctn_ofs = val->uni.ofs;
-    size_t ofs = (is_ctn ? ctn_ofs : sizeof(yyjson_val));
+    size_t ofs     = (is_ctn ? ctn_ofs : sizeof (yyjson_val));
     return (yyjson_val *)(void *)((uint8_t *)val + ofs);
-}
+  }
 
-yyjson_api_inline bool unsafe_yyjson_equals_strn(void *val, const char *str,
-                                                 size_t len) {
+  yyjson_api_inline bool unsafe_yyjson_equals_strn (void *val, const char *str,
+                                                    size_t len)
+  {
     uint64_t tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
     return ((yyjson_val *)val)->tag == tag &&
-    memcmp(((yyjson_val *)val)->uni.str, str, len) == 0;
-}
+           memcmp (((yyjson_val *)val)->uni.str, str, len) == 0;
+  }
 
-yyjson_api_inline bool unsafe_yyjson_equals_str(void *val, const char *str) {
-    return unsafe_yyjson_equals_strn(val, str, strlen(str));
-}
+  yyjson_api_inline bool unsafe_yyjson_equals_str (void *val, const char *str)
+  {
+    return unsafe_yyjson_equals_strn (val, str, strlen (str));
+  }
 
-yyjson_api_inline void unsafe_yyjson_set_type(void *val, yyjson_type type,
-                                              yyjson_subtype subtype) {
-    uint8_t tag = (type | subtype);
-    uint64_t new_tag = ((yyjson_val *)val)->tag;
-    new_tag = (new_tag & (~(uint64_t)YYJSON_TAG_MASK)) | (uint64_t)tag;
+  yyjson_api_inline void unsafe_yyjson_set_type (void *val, yyjson_type type,
+                                                 yyjson_subtype subtype)
+  {
+    uint8_t tag              = (type | subtype);
+    uint64_t new_tag         = ((yyjson_val *)val)->tag;
+    new_tag                  = (new_tag & (~(uint64_t)YYJSON_TAG_MASK)) | (uint64_t)tag;
     ((yyjson_val *)val)->tag = new_tag;
-}
+  }
 
-yyjson_api_inline void unsafe_yyjson_set_tag(void *val, uint8_t tag) {
-    uint64_t new_tag = ((yyjson_val *)val)->tag;
-    new_tag = (new_tag & (~(uint64_t)YYJSON_TAG_MASK)) | (uint64_t)tag;
+  yyjson_api_inline void unsafe_yyjson_set_tag (void *val, uint8_t tag)
+  {
+    uint64_t new_tag         = ((yyjson_val *)val)->tag;
+    new_tag                  = (new_tag & (~(uint64_t)YYJSON_TAG_MASK)) | (uint64_t)tag;
     ((yyjson_val *)val)->tag = new_tag;
-}
+  }
 
-yyjson_api_inline void unsafe_yyjson_set_len(void *val, size_t len) {
+  yyjson_api_inline void unsafe_yyjson_set_len (void *val, size_t len)
+  {
     uint64_t tag = ((yyjson_val *)val)->tag & YYJSON_TAG_MASK;
     tag |= (uint64_t)len << YYJSON_TAG_BIT;
     ((yyjson_val *)val)->tag = tag;
-}
+  }
 
-yyjson_api_inline void unsafe_yyjson_set_raw(void *val, const char *raw,
-                                             size_t len) {
-    unsafe_yyjson_set_type(val, YYJSON_TYPE_RAW, YYJSON_SUBTYPE_NONE);
-    unsafe_yyjson_set_len(val, len);
+  yyjson_api_inline void unsafe_yyjson_set_raw (void *val, const char *raw,
+                                                size_t len)
+  {
+    unsafe_yyjson_set_type (val, YYJSON_TYPE_RAW, YYJSON_SUBTYPE_NONE);
+    unsafe_yyjson_set_len (val, len);
     ((yyjson_val *)val)->uni.str = raw;
-}
+  }
 
-yyjson_api_inline void unsafe_yyjson_set_null(void *val) {
-    unsafe_yyjson_set_type(val, YYJSON_TYPE_NULL, YYJSON_SUBTYPE_NONE);
-    unsafe_yyjson_set_len(val, 0);
-}
+  yyjson_api_inline void unsafe_yyjson_set_null (void *val)
+  {
+    unsafe_yyjson_set_type (val, YYJSON_TYPE_NULL, YYJSON_SUBTYPE_NONE);
+    unsafe_yyjson_set_len (val, 0);
+  }
 
-yyjson_api_inline void unsafe_yyjson_set_bool(void *val, bool num) {
+  yyjson_api_inline void unsafe_yyjson_set_bool (void *val, bool num)
+  {
     yyjson_subtype subtype = num ? YYJSON_SUBTYPE_TRUE : YYJSON_SUBTYPE_FALSE;
-    unsafe_yyjson_set_type(val, YYJSON_TYPE_BOOL, subtype);
-    unsafe_yyjson_set_len(val, 0);
-}
+    unsafe_yyjson_set_type (val, YYJSON_TYPE_BOOL, subtype);
+    unsafe_yyjson_set_len (val, 0);
+  }
 
-yyjson_api_inline void unsafe_yyjson_set_uint(void *val, uint64_t num) {
-    unsafe_yyjson_set_type(val, YYJSON_TYPE_NUM, YYJSON_SUBTYPE_UINT);
-    unsafe_yyjson_set_len(val, 0);
+  yyjson_api_inline void unsafe_yyjson_set_uint (void *val, uint64_t num)
+  {
+    unsafe_yyjson_set_type (val, YYJSON_TYPE_NUM, YYJSON_SUBTYPE_UINT);
+    unsafe_yyjson_set_len (val, 0);
     ((yyjson_val *)val)->uni.u64 = num;
-}
+  }
 
-yyjson_api_inline void unsafe_yyjson_set_sint(void *val, int64_t num) {
-    unsafe_yyjson_set_type(val, YYJSON_TYPE_NUM, YYJSON_SUBTYPE_SINT);
-    unsafe_yyjson_set_len(val, 0);
+  yyjson_api_inline void unsafe_yyjson_set_sint (void *val, int64_t num)
+  {
+    unsafe_yyjson_set_type (val, YYJSON_TYPE_NUM, YYJSON_SUBTYPE_SINT);
+    unsafe_yyjson_set_len (val, 0);
     ((yyjson_val *)val)->uni.i64 = num;
-}
+  }
 
-yyjson_api_inline void unsafe_yyjson_set_real(void *val, double num) {
-    unsafe_yyjson_set_type(val, YYJSON_TYPE_NUM, YYJSON_SUBTYPE_REAL);
-    unsafe_yyjson_set_len(val, 0);
+  yyjson_api_inline void unsafe_yyjson_set_real (void *val, double num)
+  {
+    unsafe_yyjson_set_type (val, YYJSON_TYPE_NUM, YYJSON_SUBTYPE_REAL);
+    unsafe_yyjson_set_len (val, 0);
     ((yyjson_val *)val)->uni.f64 = num;
-}
+  }
 
-yyjson_api_inline void unsafe_yyjson_set_str(void *val, const char *str) {
-    unsafe_yyjson_set_type(val, YYJSON_TYPE_STR, YYJSON_SUBTYPE_NONE);
-    unsafe_yyjson_set_len(val, strlen(str));
+  yyjson_api_inline void unsafe_yyjson_set_str (void *val, const char *str)
+  {
+    unsafe_yyjson_set_type (val, YYJSON_TYPE_STR, YYJSON_SUBTYPE_NONE);
+    unsafe_yyjson_set_len (val, strlen (str));
     ((yyjson_val *)val)->uni.str = str;
-}
+  }
 
-yyjson_api_inline void unsafe_yyjson_set_strn(void *val, const char *str,
-                                             size_t len) {
-    unsafe_yyjson_set_type(val, YYJSON_TYPE_STR, YYJSON_SUBTYPE_NONE);
-    unsafe_yyjson_set_len(val, len);
+  yyjson_api_inline void unsafe_yyjson_set_strn (void *val, const char *str,
+                                                 size_t len)
+  {
+    unsafe_yyjson_set_type (val, YYJSON_TYPE_STR, YYJSON_SUBTYPE_NONE);
+    unsafe_yyjson_set_len (val, len);
     ((yyjson_val *)val)->uni.str = str;
-}
+  }
 
-yyjson_api_inline void unsafe_yyjson_set_arr(void *val, size_t size) {
-    unsafe_yyjson_set_type(val, YYJSON_TYPE_ARR, YYJSON_SUBTYPE_NONE);
-    unsafe_yyjson_set_len(val, size);
-}
+  yyjson_api_inline void unsafe_yyjson_set_arr (void *val, size_t size)
+  {
+    unsafe_yyjson_set_type (val, YYJSON_TYPE_ARR, YYJSON_SUBTYPE_NONE);
+    unsafe_yyjson_set_len (val, size);
+  }
 
-yyjson_api_inline void unsafe_yyjson_set_obj(void *val, size_t size) {
-    unsafe_yyjson_set_type(val, YYJSON_TYPE_OBJ, YYJSON_SUBTYPE_NONE);
-    unsafe_yyjson_set_len(val, size);
-}
+  yyjson_api_inline void unsafe_yyjson_set_obj (void *val, size_t size)
+  {
+    unsafe_yyjson_set_type (val, YYJSON_TYPE_OBJ, YYJSON_SUBTYPE_NONE);
+    unsafe_yyjson_set_len (val, size);
+  }
 
+  /*==============================================================================
+   * JSON Document API (Implementation)
+   *============================================================================*/
 
-
-/*==============================================================================
- * JSON Document API (Implementation)
- *============================================================================*/
-
-yyjson_api_inline yyjson_val *yyjson_doc_get_root(yyjson_doc *doc) {
+  yyjson_api_inline yyjson_val *yyjson_doc_get_root (yyjson_doc *doc)
+  {
     return doc ? doc->root : NULL;
-}
+  }
 
-yyjson_api_inline size_t yyjson_doc_get_read_size(yyjson_doc *doc) {
+  yyjson_api_inline size_t yyjson_doc_get_read_size (yyjson_doc *doc)
+  {
     return doc ? doc->dat_read : 0;
-}
+  }
 
-yyjson_api_inline size_t yyjson_doc_get_val_count(yyjson_doc *doc) {
+  yyjson_api_inline size_t yyjson_doc_get_val_count (yyjson_doc *doc)
+  {
     return doc ? doc->val_read : 0;
-}
+  }
 
-yyjson_api_inline void yyjson_doc_free(yyjson_doc *doc) {
-    if (doc) {
-        yyjson_alc alc = doc->alc;
-        if (doc->str_pool) alc.free(alc.ctx, doc->str_pool);
-        alc.free(alc.ctx, doc);
+  yyjson_api_inline void yyjson_doc_free (yyjson_doc *doc)
+  {
+    if (doc)
+    {
+      yyjson_alc alc = doc->alc;
+      if (doc->str_pool)
+        alc.free (alc.ctx, doc->str_pool);
+      alc.free (alc.ctx, doc);
     }
-}
+  }
 
+  /*==============================================================================
+   * JSON Value Type API (Implementation)
+   *============================================================================*/
 
+  yyjson_api_inline bool yyjson_is_raw (yyjson_val *val)
+  {
+    return val ? unsafe_yyjson_is_raw (val) : false;
+  }
 
-/*==============================================================================
- * JSON Value Type API (Implementation)
- *============================================================================*/
+  yyjson_api_inline bool yyjson_is_null (yyjson_val *val)
+  {
+    return val ? unsafe_yyjson_is_null (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_is_raw(yyjson_val *val) {
-    return val ? unsafe_yyjson_is_raw(val) : false;
-}
+  yyjson_api_inline bool yyjson_is_true (yyjson_val *val)
+  {
+    return val ? unsafe_yyjson_is_true (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_is_null(yyjson_val *val) {
-    return val ? unsafe_yyjson_is_null(val) : false;
-}
+  yyjson_api_inline bool yyjson_is_false (yyjson_val *val)
+  {
+    return val ? unsafe_yyjson_is_false (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_is_true(yyjson_val *val) {
-    return val ? unsafe_yyjson_is_true(val) : false;
-}
+  yyjson_api_inline bool yyjson_is_bool (yyjson_val *val)
+  {
+    return val ? unsafe_yyjson_is_bool (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_is_false(yyjson_val *val) {
-    return val ? unsafe_yyjson_is_false(val) : false;
-}
+  yyjson_api_inline bool yyjson_is_uint (yyjson_val *val)
+  {
+    return val ? unsafe_yyjson_is_uint (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_is_bool(yyjson_val *val) {
-    return val ? unsafe_yyjson_is_bool(val) : false;
-}
+  yyjson_api_inline bool yyjson_is_sint (yyjson_val *val)
+  {
+    return val ? unsafe_yyjson_is_sint (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_is_uint(yyjson_val *val) {
-    return val ? unsafe_yyjson_is_uint(val) : false;
-}
+  yyjson_api_inline bool yyjson_is_int (yyjson_val *val)
+  {
+    return val ? unsafe_yyjson_is_int (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_is_sint(yyjson_val *val) {
-    return val ? unsafe_yyjson_is_sint(val) : false;
-}
+  yyjson_api_inline bool yyjson_is_real (yyjson_val *val)
+  {
+    return val ? unsafe_yyjson_is_real (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_is_int(yyjson_val *val) {
-    return val ? unsafe_yyjson_is_int(val) : false;
-}
+  yyjson_api_inline bool yyjson_is_num (yyjson_val *val)
+  {
+    return val ? unsafe_yyjson_is_num (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_is_real(yyjson_val *val) {
-    return val ? unsafe_yyjson_is_real(val) : false;
-}
+  yyjson_api_inline bool yyjson_is_str (yyjson_val *val)
+  {
+    return val ? unsafe_yyjson_is_str (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_is_num(yyjson_val *val) {
-    return val ? unsafe_yyjson_is_num(val) : false;
-}
+  yyjson_api_inline bool yyjson_is_arr (yyjson_val *val)
+  {
+    return val ? unsafe_yyjson_is_arr (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_is_str(yyjson_val *val) {
-    return val ? unsafe_yyjson_is_str(val) : false;
-}
+  yyjson_api_inline bool yyjson_is_obj (yyjson_val *val)
+  {
+    return val ? unsafe_yyjson_is_obj (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_is_arr(yyjson_val *val) {
-    return val ? unsafe_yyjson_is_arr(val) : false;
-}
+  yyjson_api_inline bool yyjson_is_ctn (yyjson_val *val)
+  {
+    return val ? unsafe_yyjson_is_ctn (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_is_obj(yyjson_val *val) {
-    return val ? unsafe_yyjson_is_obj(val) : false;
-}
+  /*==============================================================================
+   * JSON Value Content API (Implementation)
+   *============================================================================*/
 
-yyjson_api_inline bool yyjson_is_ctn(yyjson_val *val) {
-    return val ? unsafe_yyjson_is_ctn(val) : false;
-}
+  yyjson_api_inline yyjson_type yyjson_get_type (yyjson_val *val)
+  {
+    return val ? unsafe_yyjson_get_type (val) : YYJSON_TYPE_NONE;
+  }
 
+  yyjson_api_inline yyjson_subtype yyjson_get_subtype (yyjson_val *val)
+  {
+    return val ? unsafe_yyjson_get_subtype (val) : YYJSON_SUBTYPE_NONE;
+  }
 
+  yyjson_api_inline uint8_t yyjson_get_tag (yyjson_val *val)
+  {
+    return val ? unsafe_yyjson_get_tag (val) : 0;
+  }
 
-/*==============================================================================
- * JSON Value Content API (Implementation)
- *============================================================================*/
-
-yyjson_api_inline yyjson_type yyjson_get_type(yyjson_val *val) {
-    return val ? unsafe_yyjson_get_type(val) : YYJSON_TYPE_NONE;
-}
-
-yyjson_api_inline yyjson_subtype yyjson_get_subtype(yyjson_val *val) {
-    return val ? unsafe_yyjson_get_subtype(val) : YYJSON_SUBTYPE_NONE;
-}
-
-yyjson_api_inline uint8_t yyjson_get_tag(yyjson_val *val) {
-    return val ? unsafe_yyjson_get_tag(val) : 0;
-}
-
-yyjson_api_inline const char *yyjson_get_type_desc(yyjson_val *val) {
-    switch (yyjson_get_tag(val)) {
-        case YYJSON_TYPE_RAW  | YYJSON_SUBTYPE_NONE:  return "raw";
-        case YYJSON_TYPE_NULL | YYJSON_SUBTYPE_NONE:  return "null";
-        case YYJSON_TYPE_STR  | YYJSON_SUBTYPE_NONE:  return "string";
-        case YYJSON_TYPE_ARR  | YYJSON_SUBTYPE_NONE:  return "array";
-        case YYJSON_TYPE_OBJ  | YYJSON_SUBTYPE_NONE:  return "object";
-        case YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE:  return "true";
-        case YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE: return "false";
-        case YYJSON_TYPE_NUM  | YYJSON_SUBTYPE_UINT:  return "uint";
-        case YYJSON_TYPE_NUM  | YYJSON_SUBTYPE_SINT:  return "sint";
-        case YYJSON_TYPE_NUM  | YYJSON_SUBTYPE_REAL:  return "real";
-        default:                                      return "unknown";
+  yyjson_api_inline const char *yyjson_get_type_desc (yyjson_val *val)
+  {
+    switch (yyjson_get_tag (val))
+    {
+    case YYJSON_TYPE_RAW | YYJSON_SUBTYPE_NONE:
+      return "raw";
+    case YYJSON_TYPE_NULL | YYJSON_SUBTYPE_NONE:
+      return "null";
+    case YYJSON_TYPE_STR | YYJSON_SUBTYPE_NONE:
+      return "string";
+    case YYJSON_TYPE_ARR | YYJSON_SUBTYPE_NONE:
+      return "array";
+    case YYJSON_TYPE_OBJ | YYJSON_SUBTYPE_NONE:
+      return "object";
+    case YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE:
+      return "true";
+    case YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE:
+      return "false";
+    case YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT:
+      return "uint";
+    case YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT:
+      return "sint";
+    case YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL:
+      return "real";
+    default:
+      return "unknown";
     }
-}
+  }
 
-yyjson_api_inline const char *yyjson_get_raw(yyjson_val *val) {
-    return yyjson_is_raw(val) ? unsafe_yyjson_get_raw(val) : NULL;
-}
+  yyjson_api_inline const char *yyjson_get_raw (yyjson_val *val)
+  {
+    return yyjson_is_raw (val) ? unsafe_yyjson_get_raw (val) : NULL;
+  }
 
-yyjson_api_inline bool yyjson_get_bool(yyjson_val *val) {
-    return yyjson_is_bool(val) ? unsafe_yyjson_get_bool(val) : false;
-}
+  yyjson_api_inline bool yyjson_get_bool (yyjson_val *val)
+  {
+    return yyjson_is_bool (val) ? unsafe_yyjson_get_bool (val) : false;
+  }
 
-yyjson_api_inline uint64_t yyjson_get_uint(yyjson_val *val) {
-    return yyjson_is_int(val) ? unsafe_yyjson_get_uint(val) : 0;
-}
+  yyjson_api_inline uint64_t yyjson_get_uint (yyjson_val *val)
+  {
+    return yyjson_is_int (val) ? unsafe_yyjson_get_uint (val) : 0;
+  }
 
-yyjson_api_inline int64_t yyjson_get_sint(yyjson_val *val) {
-    return yyjson_is_int(val) ? unsafe_yyjson_get_sint(val) : 0;
-}
+  yyjson_api_inline int64_t yyjson_get_sint (yyjson_val *val)
+  {
+    return yyjson_is_int (val) ? unsafe_yyjson_get_sint (val) : 0;
+  }
 
-yyjson_api_inline int yyjson_get_int(yyjson_val *val) {
-    return yyjson_is_int(val) ? unsafe_yyjson_get_int(val) : 0;
-}
+  yyjson_api_inline int yyjson_get_int (yyjson_val *val)
+  {
+    return yyjson_is_int (val) ? unsafe_yyjson_get_int (val) : 0;
+  }
 
-yyjson_api_inline double yyjson_get_real(yyjson_val *val) {
-    return yyjson_is_real(val) ? unsafe_yyjson_get_real(val) : 0.0;
-}
+  yyjson_api_inline double yyjson_get_real (yyjson_val *val)
+  {
+    return yyjson_is_real (val) ? unsafe_yyjson_get_real (val) : 0.0;
+  }
 
-yyjson_api_inline double yyjson_get_num(yyjson_val *val) {
-    return val ? unsafe_yyjson_get_num(val) : 0.0;
-}
+  yyjson_api_inline double yyjson_get_num (yyjson_val *val)
+  {
+    return val ? unsafe_yyjson_get_num (val) : 0.0;
+  }
 
-yyjson_api_inline const char *yyjson_get_str(yyjson_val *val) {
-    return yyjson_is_str(val) ? unsafe_yyjson_get_str(val) : NULL;
-}
+  yyjson_api_inline const char *yyjson_get_str (yyjson_val *val)
+  {
+    return yyjson_is_str (val) ? unsafe_yyjson_get_str (val) : NULL;
+  }
 
-yyjson_api_inline size_t yyjson_get_len(yyjson_val *val) {
-    return val ? unsafe_yyjson_get_len(val) : 0;
-}
+  yyjson_api_inline size_t yyjson_get_len (yyjson_val *val)
+  {
+    return val ? unsafe_yyjson_get_len (val) : 0;
+  }
 
-yyjson_api_inline bool yyjson_equals_str(yyjson_val *val, const char *str) {
-    if (yyjson_likely(val && str)) {
-        return unsafe_yyjson_equals_str(val, str);
+  yyjson_api_inline bool yyjson_equals_str (yyjson_val *val, const char *str)
+  {
+    if (yyjson_likely (val && str))
+    {
+      return unsafe_yyjson_equals_str (val, str);
     }
     return false;
-}
+  }
 
-yyjson_api_inline bool yyjson_equals_strn(yyjson_val *val, const char *str,
-                                          size_t len) {
-    if (yyjson_likely(val && str)) {
-        return unsafe_yyjson_equals_strn(val, str, len);
+  yyjson_api_inline bool yyjson_equals_strn (yyjson_val *val, const char *str,
+                                             size_t len)
+  {
+    if (yyjson_likely (val && str))
+    {
+      return unsafe_yyjson_equals_strn (val, str, len);
     }
     return false;
-}
+  }
 
-yyjson_api bool unsafe_yyjson_equals(yyjson_val *lhs, yyjson_val *rhs);
+  yyjson_api bool unsafe_yyjson_equals (yyjson_val *lhs, yyjson_val *rhs);
 
-yyjson_api_inline bool yyjson_equals(yyjson_val *lhs, yyjson_val *rhs) {
-    if (yyjson_unlikely(!lhs || !rhs)) return false;
-    return unsafe_yyjson_equals(lhs, rhs);
-}
+  yyjson_api_inline bool yyjson_equals (yyjson_val *lhs, yyjson_val *rhs)
+  {
+    if (yyjson_unlikely (!lhs || !rhs))
+      return false;
+    return unsafe_yyjson_equals (lhs, rhs);
+  }
 
-yyjson_api_inline bool yyjson_set_raw(yyjson_val *val,
-                                      const char *raw, size_t len) {
-    if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val))) return false;
-    unsafe_yyjson_set_raw(val, raw, len);
+  yyjson_api_inline bool yyjson_set_raw (yyjson_val *val,
+                                         const char *raw, size_t len)
+  {
+    if (yyjson_unlikely (!val || unsafe_yyjson_is_ctn (val)))
+      return false;
+    unsafe_yyjson_set_raw (val, raw, len);
     return true;
-}
+  }
 
-yyjson_api_inline bool yyjson_set_null(yyjson_val *val) {
-    if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val))) return false;
-    unsafe_yyjson_set_null(val);
+  yyjson_api_inline bool yyjson_set_null (yyjson_val *val)
+  {
+    if (yyjson_unlikely (!val || unsafe_yyjson_is_ctn (val)))
+      return false;
+    unsafe_yyjson_set_null (val);
     return true;
-}
+  }
 
-yyjson_api_inline bool yyjson_set_bool(yyjson_val *val, bool num) {
-    if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val))) return false;
-    unsafe_yyjson_set_bool(val, num);
+  yyjson_api_inline bool yyjson_set_bool (yyjson_val *val, bool num)
+  {
+    if (yyjson_unlikely (!val || unsafe_yyjson_is_ctn (val)))
+      return false;
+    unsafe_yyjson_set_bool (val, num);
     return true;
-}
+  }
 
-yyjson_api_inline bool yyjson_set_uint(yyjson_val *val, uint64_t num) {
-    if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val))) return false;
-    unsafe_yyjson_set_uint(val, num);
+  yyjson_api_inline bool yyjson_set_uint (yyjson_val *val, uint64_t num)
+  {
+    if (yyjson_unlikely (!val || unsafe_yyjson_is_ctn (val)))
+      return false;
+    unsafe_yyjson_set_uint (val, num);
     return true;
-}
+  }
 
-yyjson_api_inline bool yyjson_set_sint(yyjson_val *val, int64_t num) {
-    if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val))) return false;
-    unsafe_yyjson_set_sint(val, num);
+  yyjson_api_inline bool yyjson_set_sint (yyjson_val *val, int64_t num)
+  {
+    if (yyjson_unlikely (!val || unsafe_yyjson_is_ctn (val)))
+      return false;
+    unsafe_yyjson_set_sint (val, num);
     return true;
-}
+  }
 
-yyjson_api_inline bool yyjson_set_int(yyjson_val *val, int num) {
-    if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val))) return false;
-    unsafe_yyjson_set_sint(val, (int64_t)num);
+  yyjson_api_inline bool yyjson_set_int (yyjson_val *val, int num)
+  {
+    if (yyjson_unlikely (!val || unsafe_yyjson_is_ctn (val)))
+      return false;
+    unsafe_yyjson_set_sint (val, (int64_t)num);
     return true;
-}
+  }
 
-yyjson_api_inline bool yyjson_set_real(yyjson_val *val, double num) {
-    if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val))) return false;
-    unsafe_yyjson_set_real(val, num);
+  yyjson_api_inline bool yyjson_set_real (yyjson_val *val, double num)
+  {
+    if (yyjson_unlikely (!val || unsafe_yyjson_is_ctn (val)))
+      return false;
+    unsafe_yyjson_set_real (val, num);
     return true;
-}
+  }
 
-yyjson_api_inline bool yyjson_set_str(yyjson_val *val, const char *str) {
-    if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val))) return false;
-    if (yyjson_unlikely(!str)) return false;
-    unsafe_yyjson_set_str(val, str);
+  yyjson_api_inline bool yyjson_set_str (yyjson_val *val, const char *str)
+  {
+    if (yyjson_unlikely (!val || unsafe_yyjson_is_ctn (val)))
+      return false;
+    if (yyjson_unlikely (!str))
+      return false;
+    unsafe_yyjson_set_str (val, str);
     return true;
-}
+  }
 
-yyjson_api_inline bool yyjson_set_strn(yyjson_val *val,
-                                       const char *str, size_t len) {
-    if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val))) return false;
-    if (yyjson_unlikely(!str)) return false;
-    unsafe_yyjson_set_strn(val, str, len);
+  yyjson_api_inline bool yyjson_set_strn (yyjson_val *val,
+                                          const char *str, size_t len)
+  {
+    if (yyjson_unlikely (!val || unsafe_yyjson_is_ctn (val)))
+      return false;
+    if (yyjson_unlikely (!str))
+      return false;
+    unsafe_yyjson_set_strn (val, str, len);
     return true;
-}
+  }
 
+  /*==============================================================================
+   * JSON Array API (Implementation)
+   *============================================================================*/
 
+  yyjson_api_inline size_t yyjson_arr_size (yyjson_val *arr)
+  {
+    return yyjson_is_arr (arr) ? unsafe_yyjson_get_len (arr) : 0;
+  }
 
-/*==============================================================================
- * JSON Array API (Implementation)
- *============================================================================*/
-
-yyjson_api_inline size_t yyjson_arr_size(yyjson_val *arr) {
-    return yyjson_is_arr(arr) ? unsafe_yyjson_get_len(arr) : 0;
-}
-
-yyjson_api_inline yyjson_val *yyjson_arr_get(yyjson_val *arr, size_t idx) {
-    if (yyjson_likely(yyjson_is_arr(arr))) {
-        if (yyjson_likely(unsafe_yyjson_get_len(arr) > idx)) {
-            yyjson_val *val = unsafe_yyjson_get_first(arr);
-            if (unsafe_yyjson_arr_is_flat(arr)) {
-                return val + idx;
-            } else {
-                while (idx-- > 0) val = unsafe_yyjson_get_next(val);
-                return val;
-            }
+  yyjson_api_inline yyjson_val *yyjson_arr_get (yyjson_val *arr, size_t idx)
+  {
+    if (yyjson_likely (yyjson_is_arr (arr)))
+    {
+      if (yyjson_likely (unsafe_yyjson_get_len (arr) > idx))
+      {
+        yyjson_val *val = unsafe_yyjson_get_first (arr);
+        if (unsafe_yyjson_arr_is_flat (arr))
+        {
+          return val + idx;
         }
+        else
+        {
+          while (idx-- > 0)
+            val = unsafe_yyjson_get_next (val);
+          return val;
+        }
+      }
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_val *yyjson_arr_get_first(yyjson_val *arr) {
-    if (yyjson_likely(yyjson_is_arr(arr))) {
-        if (yyjson_likely(unsafe_yyjson_get_len(arr) > 0)) {
-            return unsafe_yyjson_get_first(arr);
-        }
+  yyjson_api_inline yyjson_val *yyjson_arr_get_first (yyjson_val *arr)
+  {
+    if (yyjson_likely (yyjson_is_arr (arr)))
+    {
+      if (yyjson_likely (unsafe_yyjson_get_len (arr) > 0))
+      {
+        return unsafe_yyjson_get_first (arr);
+      }
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_val *yyjson_arr_get_last(yyjson_val *arr) {
-    if (yyjson_likely(yyjson_is_arr(arr))) {
-        size_t len = unsafe_yyjson_get_len(arr);
-        if (yyjson_likely(len > 0)) {
-            yyjson_val *val = unsafe_yyjson_get_first(arr);
-            if (unsafe_yyjson_arr_is_flat(arr)) {
-                return val + (len - 1);
-            } else {
-                while (len-- > 1) val = unsafe_yyjson_get_next(val);
-                return val;
-            }
+  yyjson_api_inline yyjson_val *yyjson_arr_get_last (yyjson_val *arr)
+  {
+    if (yyjson_likely (yyjson_is_arr (arr)))
+    {
+      size_t len = unsafe_yyjson_get_len (arr);
+      if (yyjson_likely (len > 0))
+      {
+        yyjson_val *val = unsafe_yyjson_get_first (arr);
+        if (unsafe_yyjson_arr_is_flat (arr))
+        {
+          return val + (len - 1);
         }
+        else
+        {
+          while (len-- > 1)
+            val = unsafe_yyjson_get_next (val);
+          return val;
+        }
+      }
     }
     return NULL;
-}
+  }
 
+  /*==============================================================================
+   * JSON Array Iterator API (Implementation)
+   *============================================================================*/
 
-
-/*==============================================================================
- * JSON Array Iterator API (Implementation)
- *============================================================================*/
-
-yyjson_api_inline bool yyjson_arr_iter_init(yyjson_val *arr,
-                                            yyjson_arr_iter *iter) {
-    if (yyjson_likely(yyjson_is_arr(arr) && iter)) {
-        iter->idx = 0;
-        iter->max = unsafe_yyjson_get_len(arr);
-        iter->cur = unsafe_yyjson_get_first(arr);
-        return true;
+  yyjson_api_inline bool yyjson_arr_iter_init (yyjson_val *arr,
+                                               yyjson_arr_iter *iter)
+  {
+    if (yyjson_likely (yyjson_is_arr (arr) && iter))
+    {
+      iter->idx = 0;
+      iter->max = unsafe_yyjson_get_len (arr);
+      iter->cur = unsafe_yyjson_get_first (arr);
+      return true;
     }
-    if (iter) memset(iter, 0, sizeof(yyjson_arr_iter));
+    if (iter)
+      memset (iter, 0, sizeof (yyjson_arr_iter));
     return false;
-}
+  }
 
-yyjson_api_inline yyjson_arr_iter yyjson_arr_iter_with(yyjson_val *arr) {
+  yyjson_api_inline yyjson_arr_iter yyjson_arr_iter_with (yyjson_val *arr)
+  {
     yyjson_arr_iter iter;
-    yyjson_arr_iter_init(arr, &iter);
+    yyjson_arr_iter_init (arr, &iter);
     return iter;
-}
+  }
 
-yyjson_api_inline bool yyjson_arr_iter_has_next(yyjson_arr_iter *iter) {
+  yyjson_api_inline bool yyjson_arr_iter_has_next (yyjson_arr_iter *iter)
+  {
     return iter ? iter->idx < iter->max : false;
-}
+  }
 
-yyjson_api_inline yyjson_val *yyjson_arr_iter_next(yyjson_arr_iter *iter) {
+  yyjson_api_inline yyjson_val *yyjson_arr_iter_next (yyjson_arr_iter *iter)
+  {
     yyjson_val *val;
-    if (iter && iter->idx < iter->max) {
-        val = iter->cur;
-        iter->cur = unsafe_yyjson_get_next(val);
-        iter->idx++;
-        return val;
+    if (iter && iter->idx < iter->max)
+    {
+      val       = iter->cur;
+      iter->cur = unsafe_yyjson_get_next (val);
+      iter->idx++;
+      return val;
     }
     return NULL;
-}
+  }
 
+  /*==============================================================================
+   * JSON Object API (Implementation)
+   *============================================================================*/
 
+  yyjson_api_inline size_t yyjson_obj_size (yyjson_val *obj)
+  {
+    return yyjson_is_obj (obj) ? unsafe_yyjson_get_len (obj) : 0;
+  }
 
-/*==============================================================================
- * JSON Object API (Implementation)
- *============================================================================*/
+  yyjson_api_inline yyjson_val *yyjson_obj_get (yyjson_val *obj,
+                                                const char *key)
+  {
+    return yyjson_obj_getn (obj, key, key ? strlen (key) : 0);
+  }
 
-yyjson_api_inline size_t yyjson_obj_size(yyjson_val *obj) {
-    return yyjson_is_obj(obj) ? unsafe_yyjson_get_len(obj) : 0;
-}
-
-yyjson_api_inline yyjson_val *yyjson_obj_get(yyjson_val *obj,
-                                             const char *key) {
-    return yyjson_obj_getn(obj, key, key ? strlen(key) : 0);
-}
-
-yyjson_api_inline yyjson_val *yyjson_obj_getn(yyjson_val *obj,
-                                              const char *_key,
-                                              size_t key_len) {
+  yyjson_api_inline yyjson_val *yyjson_obj_getn (yyjson_val *obj,
+                                                 const char *_key,
+                                                 size_t key_len)
+  {
     uint64_t tag = (((uint64_t)key_len) << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-    if (yyjson_likely(yyjson_is_obj(obj) && _key)) {
-        size_t len = unsafe_yyjson_get_len(obj);
-        yyjson_val *key = unsafe_yyjson_get_first(obj);
-        while (len-- > 0) {
-            if (key->tag == tag &&
-                memcmp(key->uni.ptr, _key, key_len) == 0) {
-                return key + 1;
-            }
-            key = unsafe_yyjson_get_next(key + 1);
+    if (yyjson_likely (yyjson_is_obj (obj) && _key))
+    {
+      size_t len      = unsafe_yyjson_get_len (obj);
+      yyjson_val *key = unsafe_yyjson_get_first (obj);
+      while (len-- > 0)
+      {
+        if (key->tag == tag &&
+            memcmp (key->uni.ptr, _key, key_len) == 0)
+        {
+          return key + 1;
         }
+        key = unsafe_yyjson_get_next (key + 1);
+      }
     }
     return NULL;
-}
+  }
 
+  /*==============================================================================
+   * JSON Object Iterator API (Implementation)
+   *============================================================================*/
 
-
-/*==============================================================================
- * JSON Object Iterator API (Implementation)
- *============================================================================*/
-
-yyjson_api_inline bool yyjson_obj_iter_init(yyjson_val *obj,
-                                            yyjson_obj_iter *iter) {
-    if (yyjson_likely(yyjson_is_obj(obj) && iter)) {
-        iter->idx = 0;
-        iter->max = unsafe_yyjson_get_len(obj);
-        iter->cur = unsafe_yyjson_get_first(obj);
-        iter->obj = obj;
-        return true;
+  yyjson_api_inline bool yyjson_obj_iter_init (yyjson_val *obj,
+                                               yyjson_obj_iter *iter)
+  {
+    if (yyjson_likely (yyjson_is_obj (obj) && iter))
+    {
+      iter->idx = 0;
+      iter->max = unsafe_yyjson_get_len (obj);
+      iter->cur = unsafe_yyjson_get_first (obj);
+      iter->obj = obj;
+      return true;
     }
-    if (iter) memset(iter, 0, sizeof(yyjson_obj_iter));
+    if (iter)
+      memset (iter, 0, sizeof (yyjson_obj_iter));
     return false;
-}
+  }
 
-yyjson_api_inline yyjson_obj_iter yyjson_obj_iter_with(yyjson_val *obj) {
+  yyjson_api_inline yyjson_obj_iter yyjson_obj_iter_with (yyjson_val *obj)
+  {
     yyjson_obj_iter iter;
-    yyjson_obj_iter_init(obj, &iter);
+    yyjson_obj_iter_init (obj, &iter);
     return iter;
-}
+  }
 
-yyjson_api_inline bool yyjson_obj_iter_has_next(yyjson_obj_iter *iter) {
+  yyjson_api_inline bool yyjson_obj_iter_has_next (yyjson_obj_iter *iter)
+  {
     return iter ? iter->idx < iter->max : false;
-}
+  }
 
-yyjson_api_inline yyjson_val *yyjson_obj_iter_next(yyjson_obj_iter *iter) {
-    if (iter && iter->idx < iter->max) {
-        yyjson_val *key = iter->cur;
-        iter->idx++;
-        iter->cur = unsafe_yyjson_get_next(key + 1);
-        return key;
+  yyjson_api_inline yyjson_val *yyjson_obj_iter_next (yyjson_obj_iter *iter)
+  {
+    if (iter && iter->idx < iter->max)
+    {
+      yyjson_val *key = iter->cur;
+      iter->idx++;
+      iter->cur = unsafe_yyjson_get_next (key + 1);
+      return key;
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_val *yyjson_obj_iter_get_val(yyjson_val *key) {
+  yyjson_api_inline yyjson_val *yyjson_obj_iter_get_val (yyjson_val *key)
+  {
     return key ? key + 1 : NULL;
-}
+  }
 
-yyjson_api_inline yyjson_val *yyjson_obj_iter_get(yyjson_obj_iter *iter,
-                                                  const char *key) {
-    return yyjson_obj_iter_getn(iter, key, key ? strlen(key) : 0);
-}
+  yyjson_api_inline yyjson_val *yyjson_obj_iter_get (yyjson_obj_iter *iter,
+                                                     const char *key)
+  {
+    return yyjson_obj_iter_getn (iter, key, key ? strlen (key) : 0);
+  }
 
-yyjson_api_inline yyjson_val *yyjson_obj_iter_getn(yyjson_obj_iter *iter,
-                                                   const char *key,
-                                                   size_t key_len) {
-    if (iter && key) {
-        size_t idx = iter->idx;
-        size_t max = iter->max;
-        yyjson_val *cur = iter->cur;
-        if (yyjson_unlikely(idx == max)) {
-            idx = 0;
-            cur = unsafe_yyjson_get_first(iter->obj);
+  yyjson_api_inline yyjson_val *yyjson_obj_iter_getn (yyjson_obj_iter *iter,
+                                                      const char *key,
+                                                      size_t key_len)
+  {
+    if (iter && key)
+    {
+      size_t idx      = iter->idx;
+      size_t max      = iter->max;
+      yyjson_val *cur = iter->cur;
+      if (yyjson_unlikely (idx == max))
+      {
+        idx = 0;
+        cur = unsafe_yyjson_get_first (iter->obj);
+      }
+      while (idx++ < max)
+      {
+        yyjson_val *next = unsafe_yyjson_get_next (cur + 1);
+        if (unsafe_yyjson_get_len (cur) == key_len &&
+            memcmp (cur->uni.str, key, key_len) == 0)
+        {
+          iter->idx = idx;
+          iter->cur = next;
+          return cur + 1;
         }
-        while (idx++ < max) {
-            yyjson_val *next = unsafe_yyjson_get_next(cur + 1);
-            if (unsafe_yyjson_get_len(cur) == key_len &&
-                memcmp(cur->uni.str, key, key_len) == 0) {
-                iter->idx = idx;
-                iter->cur = next;
-                return cur + 1;
-            }
-            cur = next;
-            if (idx == iter->max && iter->idx < iter->max) {
-                idx = 0;
-                max = iter->idx;
-                cur = unsafe_yyjson_get_first(iter->obj);
-            }
+        cur = next;
+        if (idx == iter->max && iter->idx < iter->max)
+        {
+          idx = 0;
+          max = iter->idx;
+          cur = unsafe_yyjson_get_first (iter->obj);
         }
+      }
     }
     return NULL;
-}
+  }
 
+  /*==============================================================================
+   * Mutable JSON Structure (Implementation)
+   *============================================================================*/
 
-
-/*==============================================================================
- * Mutable JSON Structure (Implementation)
- *============================================================================*/
-
-/**
- Mutable JSON value, 24 bytes.
- The 'tag' and 'uni' field is same as immutable value.
- The 'next' field links all elements inside the container to be a cycle.
- */
-struct yyjson_mut_val {
-    uint64_t tag; /**< type, subtype and length */
-    yyjson_val_uni uni; /**< payload */
+  /**
+   Mutable JSON value, 24 bytes.
+   The 'tag' and 'uni' field is same as immutable value.
+   The 'next' field links all elements inside the container to be a cycle.
+   */
+  struct yyjson_mut_val
+  {
+    uint64_t tag;         /**< type, subtype and length */
+    yyjson_val_uni uni;   /**< payload */
     yyjson_mut_val *next; /**< the next value in circular linked list */
-};
+  };
 
-/**
- A memory chunk in string memory pool.
- */
-typedef struct yyjson_str_chunk {
+  /**
+   A memory chunk in string memory pool.
+   */
+  typedef struct yyjson_str_chunk
+  {
     struct yyjson_str_chunk *next; /* next chunk linked list */
-    size_t chunk_size; /* chunk size in bytes */
-    /* char str[]; flexible array member */
-} yyjson_str_chunk;
+    size_t chunk_size;             /* chunk size in bytes */
+                                   /* char str[]; flexible array member */
+  } yyjson_str_chunk;
 
-/**
- A memory pool to hold all strings in a mutable document.
- */
-typedef struct yyjson_str_pool {
-    char *cur; /* cursor inside current chunk */
-    char *end; /* the end of current chunk */
-    size_t chunk_size; /* chunk size in bytes while creating new chunk */
-    size_t chunk_size_max; /* maximum chunk size in bytes */
+  /**
+   A memory pool to hold all strings in a mutable document.
+   */
+  typedef struct yyjson_str_pool
+  {
+    char *cur;                /* cursor inside current chunk */
+    char *end;                /* the end of current chunk */
+    size_t chunk_size;        /* chunk size in bytes while creating new chunk */
+    size_t chunk_size_max;    /* maximum chunk size in bytes */
     yyjson_str_chunk *chunks; /* a linked list of chunks, nullable */
-} yyjson_str_pool;
+  } yyjson_str_pool;
 
-/**
- A memory chunk in value memory pool.
- `sizeof(yyjson_val_chunk)` should not larger than `sizeof(yyjson_mut_val)`.
- */
-typedef struct yyjson_val_chunk {
+  /**
+   A memory chunk in value memory pool.
+   `sizeof(yyjson_val_chunk)` should not larger than `sizeof(yyjson_mut_val)`.
+   */
+  typedef struct yyjson_val_chunk
+  {
     struct yyjson_val_chunk *next; /* next chunk linked list */
-    size_t chunk_size; /* chunk size in bytes */
-    /* char pad[sizeof(yyjson_mut_val) - sizeof(yyjson_val_chunk)]; padding */
-    /* yyjson_mut_val vals[]; flexible array member */
-} yyjson_val_chunk;
+    size_t chunk_size;             /* chunk size in bytes */
+                                   /* char pad[sizeof(yyjson_mut_val) - sizeof(yyjson_val_chunk)]; padding */
+                                   /* yyjson_mut_val vals[]; flexible array member */
+  } yyjson_val_chunk;
 
-/**
- A memory pool to hold all values in a mutable document.
- */
-typedef struct yyjson_val_pool {
-    yyjson_mut_val *cur; /* cursor inside current chunk */
-    yyjson_mut_val *end; /* the end of current chunk */
-    size_t chunk_size; /* chunk size in bytes while creating new chunk */
-    size_t chunk_size_max; /* maximum chunk size in bytes */
+  /**
+   A memory pool to hold all values in a mutable document.
+   */
+  typedef struct yyjson_val_pool
+  {
+    yyjson_mut_val *cur;      /* cursor inside current chunk */
+    yyjson_mut_val *end;      /* the end of current chunk */
+    size_t chunk_size;        /* chunk size in bytes while creating new chunk */
+    size_t chunk_size_max;    /* maximum chunk size in bytes */
     yyjson_val_chunk *chunks; /* a linked list of chunks, nullable */
-} yyjson_val_pool;
+  } yyjson_val_pool;
 
-struct yyjson_mut_doc {
-    yyjson_mut_val *root; /**< root value of the JSON document, nullable */
-    yyjson_alc alc; /**< a valid allocator, nonnull */
+  struct yyjson_mut_doc
+  {
+    yyjson_mut_val *root;     /**< root value of the JSON document, nullable */
+    yyjson_alc alc;           /**< a valid allocator, nonnull */
     yyjson_str_pool str_pool; /**< string memory pool */
     yyjson_val_pool val_pool; /**< value memory pool */
-};
+  };
 
-/* Ensures the capacity to at least equal to the specified byte length. */
-yyjson_api bool unsafe_yyjson_str_pool_grow(yyjson_str_pool *pool,
-                                            const yyjson_alc *alc,
-                                            size_t len);
+  /* Ensures the capacity to at least equal to the specified byte length. */
+  yyjson_api bool unsafe_yyjson_str_pool_grow (yyjson_str_pool *pool,
+                                               const yyjson_alc *alc,
+                                               size_t len);
 
-/* Ensures the capacity to at least equal to the specified value count. */
-yyjson_api bool unsafe_yyjson_val_pool_grow(yyjson_val_pool *pool,
-                                            const yyjson_alc *alc,
-                                            size_t count);
+  /* Ensures the capacity to at least equal to the specified value count. */
+  yyjson_api bool unsafe_yyjson_val_pool_grow (yyjson_val_pool *pool,
+                                               const yyjson_alc *alc,
+                                               size_t count);
 
-yyjson_api_inline char *unsafe_yyjson_mut_strncpy(yyjson_mut_doc *doc,
-                                                  const char *str, size_t len) {
+  yyjson_api_inline char *unsafe_yyjson_mut_strncpy (yyjson_mut_doc *doc,
+                                                     const char *str, size_t len)
+  {
     char *mem;
     const yyjson_alc *alc = &doc->alc;
     yyjson_str_pool *pool = &doc->str_pool;
-    
-    if (!str) return NULL;
-    if (yyjson_unlikely((size_t)(pool->end - pool->cur) <= len)) {
-        if (yyjson_unlikely(!unsafe_yyjson_str_pool_grow(pool, alc, len + 1))) {
-            return NULL;
-        }
+
+    if (!str)
+      return NULL;
+    if (yyjson_unlikely ((size_t)(pool->end - pool->cur) <= len))
+    {
+      if (yyjson_unlikely (!unsafe_yyjson_str_pool_grow (pool, alc, len + 1)))
+      {
+        return NULL;
+      }
     }
-    
-    mem = pool->cur;
+
+    mem       = pool->cur;
     pool->cur = mem + len + 1;
-    memcpy((void *)mem, (const void *)str, len);
+    memcpy ((void *)mem, (const void *)str, len);
     mem[len] = '\0';
     return mem;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *unsafe_yyjson_mut_val(yyjson_mut_doc *doc,
-                                                        size_t count) {
+  yyjson_api_inline yyjson_mut_val *unsafe_yyjson_mut_val (yyjson_mut_doc *doc,
+                                                           size_t count)
+  {
     yyjson_mut_val *val;
-    yyjson_alc *alc = &doc->alc;
+    yyjson_alc *alc       = &doc->alc;
     yyjson_val_pool *pool = &doc->val_pool;
-    if (yyjson_unlikely((size_t)(pool->end - pool->cur) < count)) {
-        if (yyjson_unlikely(!unsafe_yyjson_val_pool_grow(pool, alc, count))) {
-            return NULL;
-        }
+    if (yyjson_unlikely ((size_t)(pool->end - pool->cur) < count))
+    {
+      if (yyjson_unlikely (!unsafe_yyjson_val_pool_grow (pool, alc, count)))
+      {
+        return NULL;
+      }
     }
-    
+
     val = pool->cur;
     pool->cur += count;
     return val;
-}
+  }
 
+  /*==============================================================================
+   * Mutable JSON Document API (Implementation)
+   *============================================================================*/
 
-
-/*==============================================================================
- * Mutable JSON Document API (Implementation)
- *============================================================================*/
-
-yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_root(yyjson_mut_doc *doc) {
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_root (yyjson_mut_doc *doc)
+  {
     return doc ? doc->root : NULL;
-}
+  }
 
-yyjson_api_inline void yyjson_mut_doc_set_root(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *root) {
-    if (doc) doc->root = root;
-}
+  yyjson_api_inline void yyjson_mut_doc_set_root (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *root)
+  {
+    if (doc)
+      doc->root = root;
+  }
 
+  /*==============================================================================
+   * Mutable JSON Value Type API (Implementation)
+   *============================================================================*/
 
+  yyjson_api_inline bool yyjson_mut_is_raw (yyjson_mut_val *val)
+  {
+    return val ? unsafe_yyjson_is_raw (val) : false;
+  }
 
-/*==============================================================================
- * Mutable JSON Value Type API (Implementation)
- *============================================================================*/
+  yyjson_api_inline bool yyjson_mut_is_null (yyjson_mut_val *val)
+  {
+    return val ? unsafe_yyjson_is_null (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_mut_is_raw(yyjson_mut_val *val) {
-    return val ? unsafe_yyjson_is_raw(val) : false;
-}
+  yyjson_api_inline bool yyjson_mut_is_true (yyjson_mut_val *val)
+  {
+    return val ? unsafe_yyjson_is_true (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_mut_is_null(yyjson_mut_val *val) {
-    return val ? unsafe_yyjson_is_null(val) : false;
-}
+  yyjson_api_inline bool yyjson_mut_is_false (yyjson_mut_val *val)
+  {
+    return val ? unsafe_yyjson_is_false (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_mut_is_true(yyjson_mut_val *val) {
-    return val ? unsafe_yyjson_is_true(val) : false;
-}
+  yyjson_api_inline bool yyjson_mut_is_bool (yyjson_mut_val *val)
+  {
+    return val ? unsafe_yyjson_is_bool (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_mut_is_false(yyjson_mut_val *val) {
-    return val ? unsafe_yyjson_is_false(val) : false;
-}
+  yyjson_api_inline bool yyjson_mut_is_uint (yyjson_mut_val *val)
+  {
+    return val ? unsafe_yyjson_is_uint (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_mut_is_bool(yyjson_mut_val *val) {
-    return val ? unsafe_yyjson_is_bool(val) : false;
-}
+  yyjson_api_inline bool yyjson_mut_is_sint (yyjson_mut_val *val)
+  {
+    return val ? unsafe_yyjson_is_sint (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_mut_is_uint(yyjson_mut_val *val) {
-    return val ? unsafe_yyjson_is_uint(val) : false;
-}
+  yyjson_api_inline bool yyjson_mut_is_int (yyjson_mut_val *val)
+  {
+    return val ? unsafe_yyjson_is_int (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_mut_is_sint(yyjson_mut_val *val) {
-    return val ? unsafe_yyjson_is_sint(val) : false;
-}
+  yyjson_api_inline bool yyjson_mut_is_real (yyjson_mut_val *val)
+  {
+    return val ? unsafe_yyjson_is_real (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_mut_is_int(yyjson_mut_val *val) {
-    return val ? unsafe_yyjson_is_int(val) : false;
-}
+  yyjson_api_inline bool yyjson_mut_is_num (yyjson_mut_val *val)
+  {
+    return val ? unsafe_yyjson_is_num (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_mut_is_real(yyjson_mut_val *val) {
-    return val ? unsafe_yyjson_is_real(val) : false;
-}
+  yyjson_api_inline bool yyjson_mut_is_str (yyjson_mut_val *val)
+  {
+    return val ? unsafe_yyjson_is_str (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_mut_is_num(yyjson_mut_val *val) {
-    return val ? unsafe_yyjson_is_num(val) : false;
-}
+  yyjson_api_inline bool yyjson_mut_is_arr (yyjson_mut_val *val)
+  {
+    return val ? unsafe_yyjson_is_arr (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_mut_is_str(yyjson_mut_val *val) {
-    return val ? unsafe_yyjson_is_str(val) : false;
-}
+  yyjson_api_inline bool yyjson_mut_is_obj (yyjson_mut_val *val)
+  {
+    return val ? unsafe_yyjson_is_obj (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_mut_is_arr(yyjson_mut_val *val) {
-    return val ? unsafe_yyjson_is_arr(val) : false;
-}
+  yyjson_api_inline bool yyjson_mut_is_ctn (yyjson_mut_val *val)
+  {
+    return val ? unsafe_yyjson_is_ctn (val) : false;
+  }
 
-yyjson_api_inline bool yyjson_mut_is_obj(yyjson_mut_val *val) {
-    return val ? unsafe_yyjson_is_obj(val) : false;
-}
+  /*==============================================================================
+   * Mutable JSON Value Content API (Implementation)
+   *============================================================================*/
 
-yyjson_api_inline bool yyjson_mut_is_ctn(yyjson_mut_val *val) {
-    return val ? unsafe_yyjson_is_ctn(val) : false;
-}
+  yyjson_api_inline yyjson_type yyjson_mut_get_type (yyjson_mut_val *val)
+  {
+    return yyjson_get_type ((yyjson_val *)val);
+  }
 
+  yyjson_api_inline yyjson_subtype yyjson_mut_get_subtype (yyjson_mut_val *val)
+  {
+    return yyjson_get_subtype ((yyjson_val *)val);
+  }
 
+  yyjson_api_inline uint8_t yyjson_mut_get_tag (yyjson_mut_val *val)
+  {
+    return yyjson_get_tag ((yyjson_val *)val);
+  }
 
-/*==============================================================================
- * Mutable JSON Value Content API (Implementation)
- *============================================================================*/
+  yyjson_api_inline const char *yyjson_mut_get_type_desc (yyjson_mut_val *val)
+  {
+    return yyjson_get_type_desc ((yyjson_val *)val);
+  }
 
-yyjson_api_inline yyjson_type yyjson_mut_get_type(yyjson_mut_val *val) {
-    return yyjson_get_type((yyjson_val *)val);
-}
+  yyjson_api_inline const char *yyjson_mut_get_raw (yyjson_mut_val *val)
+  {
+    return yyjson_get_raw ((yyjson_val *)val);
+  }
 
-yyjson_api_inline yyjson_subtype yyjson_mut_get_subtype(yyjson_mut_val *val) {
-    return yyjson_get_subtype((yyjson_val *)val);
-}
+  yyjson_api_inline bool yyjson_mut_get_bool (yyjson_mut_val *val)
+  {
+    return yyjson_get_bool ((yyjson_val *)val);
+  }
 
-yyjson_api_inline uint8_t yyjson_mut_get_tag(yyjson_mut_val *val) {
-    return yyjson_get_tag((yyjson_val *)val);
-}
+  yyjson_api_inline uint64_t yyjson_mut_get_uint (yyjson_mut_val *val)
+  {
+    return yyjson_get_uint ((yyjson_val *)val);
+  }
 
-yyjson_api_inline const char *yyjson_mut_get_type_desc(yyjson_mut_val *val) {
-    return yyjson_get_type_desc((yyjson_val *)val);
-}
+  yyjson_api_inline int64_t yyjson_mut_get_sint (yyjson_mut_val *val)
+  {
+    return yyjson_get_sint ((yyjson_val *)val);
+  }
 
-yyjson_api_inline const char *yyjson_mut_get_raw(yyjson_mut_val *val) {
-    return yyjson_get_raw((yyjson_val *)val);
-}
+  yyjson_api_inline int yyjson_mut_get_int (yyjson_mut_val *val)
+  {
+    return yyjson_get_int ((yyjson_val *)val);
+  }
 
-yyjson_api_inline bool yyjson_mut_get_bool(yyjson_mut_val *val) {
-    return yyjson_get_bool((yyjson_val *)val);
-}
+  yyjson_api_inline double yyjson_mut_get_real (yyjson_mut_val *val)
+  {
+    return yyjson_get_real ((yyjson_val *)val);
+  }
 
-yyjson_api_inline uint64_t yyjson_mut_get_uint(yyjson_mut_val *val) {
-    return yyjson_get_uint((yyjson_val *)val);
-}
+  yyjson_api_inline double yyjson_mut_get_num (yyjson_mut_val *val)
+  {
+    return yyjson_get_num ((yyjson_val *)val);
+  }
 
-yyjson_api_inline int64_t yyjson_mut_get_sint(yyjson_mut_val *val) {
-    return yyjson_get_sint((yyjson_val *)val);
-}
+  yyjson_api_inline const char *yyjson_mut_get_str (yyjson_mut_val *val)
+  {
+    return yyjson_get_str ((yyjson_val *)val);
+  }
 
-yyjson_api_inline int yyjson_mut_get_int(yyjson_mut_val *val) {
-    return yyjson_get_int((yyjson_val *)val);
-}
+  yyjson_api_inline size_t yyjson_mut_get_len (yyjson_mut_val *val)
+  {
+    return yyjson_get_len ((yyjson_val *)val);
+  }
 
-yyjson_api_inline double yyjson_mut_get_real(yyjson_mut_val *val) {
-    return yyjson_get_real((yyjson_val *)val);
-}
+  yyjson_api_inline bool yyjson_mut_equals_str (yyjson_mut_val *val,
+                                                const char *str)
+  {
+    return yyjson_equals_str ((yyjson_val *)val, str);
+  }
 
-yyjson_api_inline double yyjson_mut_get_num(yyjson_mut_val *val) {
-    return yyjson_get_num((yyjson_val *)val);
-}
+  yyjson_api_inline bool yyjson_mut_equals_strn (yyjson_mut_val *val,
+                                                 const char *str, size_t len)
+  {
+    return yyjson_equals_strn ((yyjson_val *)val, str, len);
+  }
 
-yyjson_api_inline const char *yyjson_mut_get_str(yyjson_mut_val *val) {
-    return yyjson_get_str((yyjson_val *)val);
-}
+  yyjson_api bool unsafe_yyjson_mut_equals (yyjson_mut_val *lhs,
+                                            yyjson_mut_val *rhs);
 
-yyjson_api_inline size_t yyjson_mut_get_len(yyjson_mut_val *val) {
-    return yyjson_get_len((yyjson_val *)val);
-}
+  yyjson_api_inline bool yyjson_mut_equals (yyjson_mut_val *lhs,
+                                            yyjson_mut_val *rhs)
+  {
+    if (yyjson_unlikely (!lhs || !rhs))
+      return false;
+    return unsafe_yyjson_mut_equals (lhs, rhs);
+  }
 
-yyjson_api_inline bool yyjson_mut_equals_str(yyjson_mut_val *val,
-                                             const char *str) {
-    return yyjson_equals_str((yyjson_val *)val, str);
-}
-
-yyjson_api_inline bool yyjson_mut_equals_strn(yyjson_mut_val *val,
-                                              const char *str, size_t len) {
-    return yyjson_equals_strn((yyjson_val *)val, str, len);
-}
-
-yyjson_api bool unsafe_yyjson_mut_equals(yyjson_mut_val *lhs,
-                                         yyjson_mut_val *rhs);
-
-yyjson_api_inline bool yyjson_mut_equals(yyjson_mut_val *lhs,
-                                         yyjson_mut_val *rhs) {
-    if (yyjson_unlikely(!lhs || !rhs)) return false;
-    return unsafe_yyjson_mut_equals(lhs, rhs);
-}
-
-yyjson_api_inline bool yyjson_mut_set_raw(yyjson_mut_val *val,
-                                          const char *raw, size_t len) {
-    if (yyjson_unlikely(!val || !raw)) return false;
-    unsafe_yyjson_set_raw(val, raw, len);
+  yyjson_api_inline bool yyjson_mut_set_raw (yyjson_mut_val *val,
+                                             const char *raw, size_t len)
+  {
+    if (yyjson_unlikely (!val || !raw))
+      return false;
+    unsafe_yyjson_set_raw (val, raw, len);
     return true;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_set_null(yyjson_mut_val *val) {
-    if (yyjson_unlikely(!val)) return false;
-    unsafe_yyjson_set_null(val);
+  yyjson_api_inline bool yyjson_mut_set_null (yyjson_mut_val *val)
+  {
+    if (yyjson_unlikely (!val))
+      return false;
+    unsafe_yyjson_set_null (val);
     return true;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_set_bool(yyjson_mut_val *val, bool num) {
-    if (yyjson_unlikely(!val)) return false;
-    unsafe_yyjson_set_bool(val, num);
+  yyjson_api_inline bool yyjson_mut_set_bool (yyjson_mut_val *val, bool num)
+  {
+    if (yyjson_unlikely (!val))
+      return false;
+    unsafe_yyjson_set_bool (val, num);
     return true;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_set_uint(yyjson_mut_val *val, uint64_t num) {
-    if (yyjson_unlikely(!val)) return false;
-    unsafe_yyjson_set_uint(val, num);
+  yyjson_api_inline bool yyjson_mut_set_uint (yyjson_mut_val *val, uint64_t num)
+  {
+    if (yyjson_unlikely (!val))
+      return false;
+    unsafe_yyjson_set_uint (val, num);
     return true;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_set_sint(yyjson_mut_val *val, int64_t num) {
-    if (yyjson_unlikely(!val)) return false;
-    unsafe_yyjson_set_sint(val, num);
+  yyjson_api_inline bool yyjson_mut_set_sint (yyjson_mut_val *val, int64_t num)
+  {
+    if (yyjson_unlikely (!val))
+      return false;
+    unsafe_yyjson_set_sint (val, num);
     return true;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_set_int(yyjson_mut_val *val, int num) {
-    if (yyjson_unlikely(!val)) return false;
-    unsafe_yyjson_set_sint(val, (int64_t)num);
+  yyjson_api_inline bool yyjson_mut_set_int (yyjson_mut_val *val, int num)
+  {
+    if (yyjson_unlikely (!val))
+      return false;
+    unsafe_yyjson_set_sint (val, (int64_t)num);
     return true;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_set_real(yyjson_mut_val *val, double num) {
-    if (yyjson_unlikely(!val)) return false;
-    unsafe_yyjson_set_real(val, num);
+  yyjson_api_inline bool yyjson_mut_set_real (yyjson_mut_val *val, double num)
+  {
+    if (yyjson_unlikely (!val))
+      return false;
+    unsafe_yyjson_set_real (val, num);
     return true;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_set_str(yyjson_mut_val *val,
-                                          const char *str) {
-    if (yyjson_unlikely(!val || !str)) return false;
-    unsafe_yyjson_set_str(val, str);
+  yyjson_api_inline bool yyjson_mut_set_str (yyjson_mut_val *val,
+                                             const char *str)
+  {
+    if (yyjson_unlikely (!val || !str))
+      return false;
+    unsafe_yyjson_set_str (val, str);
     return true;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_set_strn(yyjson_mut_val *val,
-                                           const char *str, size_t len) {
-    if (yyjson_unlikely(!val || !str)) return false;
-    unsafe_yyjson_set_strn(val, str, len);
+  yyjson_api_inline bool yyjson_mut_set_strn (yyjson_mut_val *val,
+                                              const char *str, size_t len)
+  {
+    if (yyjson_unlikely (!val || !str))
+      return false;
+    unsafe_yyjson_set_strn (val, str, len);
     return true;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_set_arr(yyjson_mut_val *val) {
-    if (yyjson_unlikely(!val)) return false;
-    unsafe_yyjson_set_arr(val, 0);
+  yyjson_api_inline bool yyjson_mut_set_arr (yyjson_mut_val *val)
+  {
+    if (yyjson_unlikely (!val))
+      return false;
+    unsafe_yyjson_set_arr (val, 0);
     return true;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_set_obj(yyjson_mut_val *val) {
-    if (yyjson_unlikely(!val)) return false;
-    unsafe_yyjson_set_obj(val, 0);
+  yyjson_api_inline bool yyjson_mut_set_obj (yyjson_mut_val *val)
+  {
+    if (yyjson_unlikely (!val))
+      return false;
+    unsafe_yyjson_set_obj (val, 0);
     return true;
-}
+  }
 
+  /*==============================================================================
+   * Mutable JSON Value Creation API (Implementation)
+   *============================================================================*/
 
-
-/*==============================================================================
- * Mutable JSON Value Creation API (Implementation)
- *============================================================================*/
-
-yyjson_api_inline yyjson_mut_val *yyjson_mut_raw(yyjson_mut_doc *doc,
-                                                 const char *str) {
-    if (yyjson_likely(str)) return yyjson_mut_rawn(doc, str, strlen(str));
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_raw (yyjson_mut_doc *doc,
+                                                    const char *str)
+  {
+    if (yyjson_likely (str))
+      return yyjson_mut_rawn (doc, str, strlen (str));
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_rawn(yyjson_mut_doc *doc,
-                                                  const char *str,
-                                                  size_t len) {
-    if (yyjson_likely(doc && str)) {
-        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-        if (yyjson_likely(val)) {
-            val->tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW;
-            val->uni.str = str;
-            return val;
-        }
-    }
-    return NULL;
-}
-
-yyjson_api_inline yyjson_mut_val *yyjson_mut_rawcpy(yyjson_mut_doc *doc,
-                                                    const char *str) {
-    if (yyjson_likely(str)) return yyjson_mut_rawncpy(doc, str, strlen(str));
-    return NULL;
-}
-
-yyjson_api_inline yyjson_mut_val *yyjson_mut_rawncpy(yyjson_mut_doc *doc,
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_rawn (yyjson_mut_doc *doc,
                                                      const char *str,
-                                                     size_t len) {
-    if (yyjson_likely(doc && str)) {
-        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-        char *new_str = unsafe_yyjson_mut_strncpy(doc, str, len);
-        if (yyjson_likely(val && new_str)) {
-            val->tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW;
-            val->uni.str = new_str;
-            return val;
-        }
+                                                     size_t len)
+  {
+    if (yyjson_likely (doc && str))
+    {
+      yyjson_mut_val *val = unsafe_yyjson_mut_val (doc, 1);
+      if (yyjson_likely (val))
+      {
+        val->tag     = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW;
+        val->uni.str = str;
+        return val;
+      }
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_null(yyjson_mut_doc *doc) {
-    if (yyjson_likely(doc)) {
-        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-        if (yyjson_likely(val)) {
-            val->tag = YYJSON_TYPE_NULL | YYJSON_SUBTYPE_NONE;
-            return val;
-        }
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_rawcpy (yyjson_mut_doc *doc,
+                                                       const char *str)
+  {
+    if (yyjson_likely (str))
+      return yyjson_mut_rawncpy (doc, str, strlen (str));
+    return NULL;
+  }
+
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_rawncpy (yyjson_mut_doc *doc,
+                                                        const char *str,
+                                                        size_t len)
+  {
+    if (yyjson_likely (doc && str))
+    {
+      yyjson_mut_val *val = unsafe_yyjson_mut_val (doc, 1);
+      char *new_str       = unsafe_yyjson_mut_strncpy (doc, str, len);
+      if (yyjson_likely (val && new_str))
+      {
+        val->tag     = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW;
+        val->uni.str = new_str;
+        return val;
+      }
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_true(yyjson_mut_doc *doc) {
-    if (yyjson_likely(doc)) {
-        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-        if (yyjson_likely(val)) {
-            val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE;
-            return val;
-        }
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_null (yyjson_mut_doc *doc)
+  {
+    if (yyjson_likely (doc))
+    {
+      yyjson_mut_val *val = unsafe_yyjson_mut_val (doc, 1);
+      if (yyjson_likely (val))
+      {
+        val->tag = YYJSON_TYPE_NULL | YYJSON_SUBTYPE_NONE;
+        return val;
+      }
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_false(yyjson_mut_doc *doc) {
-    if (yyjson_likely(doc)) {
-        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-        if (yyjson_likely(val)) {
-            val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE;
-            return val;
-        }
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_true (yyjson_mut_doc *doc)
+  {
+    if (yyjson_likely (doc))
+    {
+      yyjson_mut_val *val = unsafe_yyjson_mut_val (doc, 1);
+      if (yyjson_likely (val))
+      {
+        val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE;
+        return val;
+      }
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_bool(yyjson_mut_doc *doc,
-                                                  bool _val) {
-    if (yyjson_likely(doc)) {
-        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-        if (yyjson_likely(val)) {
-            val->tag = YYJSON_TYPE_BOOL | (uint8_t)((uint8_t)_val << 3);
-            return val;
-        }
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_false (yyjson_mut_doc *doc)
+  {
+    if (yyjson_likely (doc))
+    {
+      yyjson_mut_val *val = unsafe_yyjson_mut_val (doc, 1);
+      if (yyjson_likely (val))
+      {
+        val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE;
+        return val;
+      }
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_uint(yyjson_mut_doc *doc,
-                                                  uint64_t num) {
-    if (yyjson_likely(doc)) {
-        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-        if (yyjson_likely(val)) {
-            val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
-            val->uni.u64 = num;
-            return val;
-        }
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_bool (yyjson_mut_doc *doc,
+                                                     bool _val)
+  {
+    if (yyjson_likely (doc))
+    {
+      yyjson_mut_val *val = unsafe_yyjson_mut_val (doc, 1);
+      if (yyjson_likely (val))
+      {
+        val->tag = YYJSON_TYPE_BOOL | (uint8_t)((uint8_t)_val << 3);
+        return val;
+      }
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_sint(yyjson_mut_doc *doc,
-                                                  int64_t num) {
-    if (yyjson_likely(doc)) {
-        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-        if (yyjson_likely(val)) {
-            val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
-            val->uni.i64 = num;
-            return val;
-        }
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_uint (yyjson_mut_doc *doc,
+                                                     uint64_t num)
+  {
+    if (yyjson_likely (doc))
+    {
+      yyjson_mut_val *val = unsafe_yyjson_mut_val (doc, 1);
+      if (yyjson_likely (val))
+      {
+        val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
+        val->uni.u64 = num;
+        return val;
+      }
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_int(yyjson_mut_doc *doc,
-                                                 int64_t num) {
-    return yyjson_mut_sint(doc, num);
-}
-
-yyjson_api_inline yyjson_mut_val *yyjson_mut_real(yyjson_mut_doc *doc,
-                                                  double num) {
-    if (yyjson_likely(doc)) {
-        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-        if (yyjson_likely(val)) {
-            val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
-            val->uni.f64 = num;
-            return val;
-        }
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_sint (yyjson_mut_doc *doc,
+                                                     int64_t num)
+  {
+    if (yyjson_likely (doc))
+    {
+      yyjson_mut_val *val = unsafe_yyjson_mut_val (doc, 1);
+      if (yyjson_likely (val))
+      {
+        val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
+        val->uni.i64 = num;
+        return val;
+      }
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_str(yyjson_mut_doc *doc,
-                                                 const char *str) {
-    if (yyjson_likely(str)) return yyjson_mut_strn(doc, str, strlen(str));
-    return NULL;
-}
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_int (yyjson_mut_doc *doc,
+                                                    int64_t num)
+  {
+    return yyjson_mut_sint (doc, num);
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_strn(yyjson_mut_doc *doc,
-                                                  const char *str,
-                                                  size_t len) {
-    if (yyjson_likely(doc && str)) {
-        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-        if (yyjson_likely(val)) {
-            val->tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-            val->uni.str = str;
-            return val;
-        }
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_real (yyjson_mut_doc *doc,
+                                                     double num)
+  {
+    if (yyjson_likely (doc))
+    {
+      yyjson_mut_val *val = unsafe_yyjson_mut_val (doc, 1);
+      if (yyjson_likely (val))
+      {
+        val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
+        val->uni.f64 = num;
+        return val;
+      }
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_strcpy(yyjson_mut_doc *doc,
-                                                    const char *str) {
-    if (yyjson_likely(str)) return yyjson_mut_strncpy(doc, str, strlen(str));
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_str (yyjson_mut_doc *doc,
+                                                    const char *str)
+  {
+    if (yyjson_likely (str))
+      return yyjson_mut_strn (doc, str, strlen (str));
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_strncpy(yyjson_mut_doc *doc,
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_strn (yyjson_mut_doc *doc,
                                                      const char *str,
-                                                     size_t len) {
-    if (yyjson_likely(doc && str)) {
-        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-        char *new_str = unsafe_yyjson_mut_strncpy(doc, str, len);
-        if (yyjson_likely(val && new_str)) {
-            val->tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-            val->uni.str = new_str;
-            return val;
-        }
+                                                     size_t len)
+  {
+    if (yyjson_likely (doc && str))
+    {
+      yyjson_mut_val *val = unsafe_yyjson_mut_val (doc, 1);
+      if (yyjson_likely (val))
+      {
+        val->tag     = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+        val->uni.str = str;
+        return val;
+      }
     }
     return NULL;
-}
+  }
 
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_strcpy (yyjson_mut_doc *doc,
+                                                       const char *str)
+  {
+    if (yyjson_likely (str))
+      return yyjson_mut_strncpy (doc, str, strlen (str));
+    return NULL;
+  }
 
-
-/*==============================================================================
- * Mutable JSON Array API (Implementation)
- *============================================================================*/
-
-yyjson_api_inline size_t yyjson_mut_arr_size(yyjson_mut_val *arr) {
-    return yyjson_mut_is_arr(arr) ? unsafe_yyjson_get_len(arr) : 0;
-}
-
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get(yyjson_mut_val *arr,
-                                                     size_t idx) {
-    if (yyjson_likely(idx < yyjson_mut_arr_size(arr))) {
-        yyjson_mut_val *val = (yyjson_mut_val *)arr->uni.ptr;
-        while (idx-- > 0) val = val->next;
-        return val->next;
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_strncpy (yyjson_mut_doc *doc,
+                                                        const char *str,
+                                                        size_t len)
+  {
+    if (yyjson_likely (doc && str))
+    {
+      yyjson_mut_val *val = unsafe_yyjson_mut_val (doc, 1);
+      char *new_str       = unsafe_yyjson_mut_strncpy (doc, str, len);
+      if (yyjson_likely (val && new_str))
+      {
+        val->tag     = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+        val->uni.str = new_str;
+        return val;
+      }
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get_first(
-    yyjson_mut_val *arr) {
-    if (yyjson_likely(yyjson_mut_arr_size(arr) > 0)) {
-        return ((yyjson_mut_val *)arr->uni.ptr)->next;
+  /*==============================================================================
+   * Mutable JSON Array API (Implementation)
+   *============================================================================*/
+
+  yyjson_api_inline size_t yyjson_mut_arr_size (yyjson_mut_val *arr)
+  {
+    return yyjson_mut_is_arr (arr) ? unsafe_yyjson_get_len (arr) : 0;
+  }
+
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get (yyjson_mut_val *arr,
+                                                        size_t idx)
+  {
+    if (yyjson_likely (idx < yyjson_mut_arr_size (arr)))
+    {
+      yyjson_mut_val *val = (yyjson_mut_val *)arr->uni.ptr;
+      while (idx-- > 0)
+        val = val->next;
+      return val->next;
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get_last(
-    yyjson_mut_val *arr) {
-    if (yyjson_likely(yyjson_mut_arr_size(arr) > 0)) {
-        return ((yyjson_mut_val *)arr->uni.ptr);
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get_first (
+      yyjson_mut_val *arr)
+  {
+    if (yyjson_likely (yyjson_mut_arr_size (arr) > 0))
+    {
+      return ((yyjson_mut_val *)arr->uni.ptr)->next;
     }
     return NULL;
-}
+  }
 
-
-
-/*==============================================================================
- * Mutable JSON Array Iterator API (Implementation)
- *============================================================================*/
-
-yyjson_api_inline bool yyjson_mut_arr_iter_init(yyjson_mut_val *arr,
-                                                yyjson_mut_arr_iter *iter) {
-    if (yyjson_likely(yyjson_mut_is_arr(arr) && iter)) {
-        iter->idx = 0;
-        iter->max = unsafe_yyjson_get_len(arr);
-        iter->cur = iter->max ? (yyjson_mut_val *)arr->uni.ptr : NULL;
-        iter->pre = NULL;
-        iter->arr = arr;
-        return true;
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get_last (
+      yyjson_mut_val *arr)
+  {
+    if (yyjson_likely (yyjson_mut_arr_size (arr) > 0))
+    {
+      return ((yyjson_mut_val *)arr->uni.ptr);
     }
-    if (iter) memset(iter, 0, sizeof(yyjson_mut_arr_iter));
+    return NULL;
+  }
+
+  /*==============================================================================
+   * Mutable JSON Array Iterator API (Implementation)
+   *============================================================================*/
+
+  yyjson_api_inline bool yyjson_mut_arr_iter_init (yyjson_mut_val *arr,
+                                                   yyjson_mut_arr_iter *iter)
+  {
+    if (yyjson_likely (yyjson_mut_is_arr (arr) && iter))
+    {
+      iter->idx = 0;
+      iter->max = unsafe_yyjson_get_len (arr);
+      iter->cur = iter->max ? (yyjson_mut_val *)arr->uni.ptr : NULL;
+      iter->pre = NULL;
+      iter->arr = arr;
+      return true;
+    }
+    if (iter)
+      memset (iter, 0, sizeof (yyjson_mut_arr_iter));
     return false;
-}
+  }
 
-yyjson_api_inline yyjson_mut_arr_iter yyjson_mut_arr_iter_with(
-    yyjson_mut_val *arr) {
+  yyjson_api_inline yyjson_mut_arr_iter yyjson_mut_arr_iter_with (
+      yyjson_mut_val *arr)
+  {
     yyjson_mut_arr_iter iter;
-    yyjson_mut_arr_iter_init(arr, &iter);
+    yyjson_mut_arr_iter_init (arr, &iter);
     return iter;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_arr_iter_has_next(yyjson_mut_arr_iter *iter) {
+  yyjson_api_inline bool yyjson_mut_arr_iter_has_next (yyjson_mut_arr_iter *iter)
+  {
     return iter ? iter->idx < iter->max : false;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_next(
-    yyjson_mut_arr_iter *iter) {
-    if (iter && iter->idx < iter->max) {
-        yyjson_mut_val *val = iter->cur;
-        iter->pre = val;
-        iter->cur = val->next;
-        iter->idx++;
-        return iter->cur;
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_next (
+      yyjson_mut_arr_iter *iter)
+  {
+    if (iter && iter->idx < iter->max)
+    {
+      yyjson_mut_val *val = iter->cur;
+      iter->pre           = val;
+      iter->cur           = val->next;
+      iter->idx++;
+      return iter->cur;
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_remove(
-    yyjson_mut_arr_iter *iter) {
-    if (yyjson_likely(iter && 0 < iter->idx && iter->idx <= iter->max)) {
-        yyjson_mut_val *prev = iter->pre;
-        yyjson_mut_val *cur = iter->cur;
-        yyjson_mut_val *next = cur->next;
-        if (yyjson_unlikely(iter->idx == iter->max)) iter->arr->uni.ptr = prev;
-        iter->idx--;
-        iter->max--;
-        unsafe_yyjson_set_len(iter->arr, iter->max);
-        prev->next = next;
-        iter->cur = next;
-        return cur;
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_remove (
+      yyjson_mut_arr_iter *iter)
+  {
+    if (yyjson_likely (iter && 0 < iter->idx && iter->idx <= iter->max))
+    {
+      yyjson_mut_val *prev = iter->pre;
+      yyjson_mut_val *cur  = iter->cur;
+      yyjson_mut_val *next = cur->next;
+      if (yyjson_unlikely (iter->idx == iter->max))
+        iter->arr->uni.ptr = prev;
+      iter->idx--;
+      iter->max--;
+      unsafe_yyjson_set_len (iter->arr, iter->max);
+      prev->next = next;
+      iter->cur  = next;
+      return cur;
     }
     return NULL;
-}
+  }
 
+  /*==============================================================================
+   * Mutable JSON Array Creation API (Implementation)
+   *============================================================================*/
 
-
-/*==============================================================================
- * Mutable JSON Array Creation API (Implementation)
- *============================================================================*/
-
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr(yyjson_mut_doc *doc) {
-    if (yyjson_likely(doc)) {
-        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-        if (yyjson_likely(val)) {
-            val->tag = YYJSON_TYPE_ARR | YYJSON_SUBTYPE_NONE;
-            return val;
-        }
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr (yyjson_mut_doc *doc)
+  {
+    if (yyjson_likely (doc))
+    {
+      yyjson_mut_val *val = unsafe_yyjson_mut_val (doc, 1);
+      if (yyjson_likely (val))
+      {
+        val->tag = YYJSON_TYPE_ARR | YYJSON_SUBTYPE_NONE;
+        return val;
+      }
     }
     return NULL;
-}
+  }
 
-#define yyjson_mut_arr_with_func(func) \
-    if (yyjson_likely(doc && ((0 < count && count < \
-        (~(size_t)0) / sizeof(yyjson_mut_val) && vals) || count == 0))) { \
-        yyjson_mut_val *arr = unsafe_yyjson_mut_val(doc, 1 + count); \
-        if (yyjson_likely(arr)) { \
-            arr->tag = ((uint64_t)count << YYJSON_TAG_BIT) | YYJSON_TYPE_ARR; \
-            if (count > 0) { \
-                size_t i; \
-                for (i = 0; i < count; i++) { \
-                    yyjson_mut_val *val = arr + i + 1; \
-                    func \
-                    val->next = val + 1; \
-                } \
-                arr[count].next = arr + 1; \
-                arr->uni.ptr = arr + count; \
-            } \
-            return arr; \
-        } \
-    } \
-    return NULL
+#define yyjson_mut_arr_with_func(func)                                                                              \
+  if (yyjson_likely (doc && ((0 < count && count < (~(size_t)0) / sizeof (yyjson_mut_val) && vals) || count == 0))) \
+  {                                                                                                                 \
+    yyjson_mut_val *arr = unsafe_yyjson_mut_val (doc, 1 + count);                                                   \
+    if (yyjson_likely (arr))                                                                                        \
+    {                                                                                                               \
+      arr->tag = ((uint64_t)count << YYJSON_TAG_BIT) | YYJSON_TYPE_ARR;                                             \
+      if (count > 0)                                                                                                \
+      {                                                                                                             \
+        size_t i;                                                                                                   \
+        for (i = 0; i < count; i++)                                                                                 \
+        {                                                                                                           \
+          yyjson_mut_val *val = arr + i + 1;                                                                        \
+          func                                                                                                      \
+              val->next = val + 1;                                                                                  \
+        }                                                                                                           \
+        arr[count].next = arr + 1;                                                                                  \
+        arr->uni.ptr    = arr + count;                                                                              \
+      }                                                                                                             \
+      return arr;                                                                                                   \
+    }                                                                                                               \
+  }                                                                                                                 \
+  return NULL
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_bool(
-    yyjson_mut_doc *doc, const bool *vals, size_t count) {
-    yyjson_mut_arr_with_func({
-        val->tag = YYJSON_TYPE_BOOL | (uint8_t)((uint8_t)vals[i] << 3);
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_bool (
+      yyjson_mut_doc *doc, const bool *vals, size_t count)
+  {
+    yyjson_mut_arr_with_func ({
+      val->tag = YYJSON_TYPE_BOOL | (uint8_t)((uint8_t)vals[i] << 3);
     });
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint(
-    yyjson_mut_doc *doc, const int64_t *vals, size_t count) {
-    return yyjson_mut_arr_with_sint64(doc, vals, count);
-}
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint (
+      yyjson_mut_doc *doc, const int64_t *vals, size_t count)
+  {
+    return yyjson_mut_arr_with_sint64 (doc, vals, count);
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint(
-    yyjson_mut_doc *doc, const uint64_t *vals, size_t count) {
-    return yyjson_mut_arr_with_uint64(doc, vals, count);
-}
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint (
+      yyjson_mut_doc *doc, const uint64_t *vals, size_t count)
+  {
+    return yyjson_mut_arr_with_uint64 (doc, vals, count);
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_real(
-    yyjson_mut_doc *doc, const double *vals, size_t count) {
-    return yyjson_mut_arr_with_double(doc, vals, count);
-}
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_real (
+      yyjson_mut_doc *doc, const double *vals, size_t count)
+  {
+    return yyjson_mut_arr_with_double (doc, vals, count);
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint8(
-    yyjson_mut_doc *doc, const int8_t *vals, size_t count) {
-    yyjson_mut_arr_with_func({
-        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
-        val->uni.i64 = (int64_t)vals[i];
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint8 (
+      yyjson_mut_doc *doc, const int8_t *vals, size_t count)
+  {
+    yyjson_mut_arr_with_func ({
+      val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
+      val->uni.i64 = (int64_t)vals[i];
     });
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint16(
-    yyjson_mut_doc *doc, const int16_t *vals, size_t count) {
-    yyjson_mut_arr_with_func({
-        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
-        val->uni.i64 = vals[i];
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint16 (
+      yyjson_mut_doc *doc, const int16_t *vals, size_t count)
+  {
+    yyjson_mut_arr_with_func ({
+      val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
+      val->uni.i64 = vals[i];
     });
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint32(
-    yyjson_mut_doc *doc, const int32_t *vals, size_t count) {
-    yyjson_mut_arr_with_func({
-        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
-        val->uni.i64 = vals[i];
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint32 (
+      yyjson_mut_doc *doc, const int32_t *vals, size_t count)
+  {
+    yyjson_mut_arr_with_func ({
+      val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
+      val->uni.i64 = vals[i];
     });
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint64(
-    yyjson_mut_doc *doc, const int64_t *vals, size_t count) {
-    yyjson_mut_arr_with_func({
-        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
-        val->uni.i64 = vals[i];
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint64 (
+      yyjson_mut_doc *doc, const int64_t *vals, size_t count)
+  {
+    yyjson_mut_arr_with_func ({
+      val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
+      val->uni.i64 = vals[i];
     });
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint8(
-    yyjson_mut_doc *doc, const uint8_t *vals, size_t count) {
-    yyjson_mut_arr_with_func({
-        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
-        val->uni.u64 = vals[i];
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint8 (
+      yyjson_mut_doc *doc, const uint8_t *vals, size_t count)
+  {
+    yyjson_mut_arr_with_func ({
+      val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
+      val->uni.u64 = vals[i];
     });
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint16(
-    yyjson_mut_doc *doc, const uint16_t *vals, size_t count) {
-    yyjson_mut_arr_with_func({
-        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
-        val->uni.u64 = vals[i];
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint16 (
+      yyjson_mut_doc *doc, const uint16_t *vals, size_t count)
+  {
+    yyjson_mut_arr_with_func ({
+      val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
+      val->uni.u64 = vals[i];
     });
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint32(
-    yyjson_mut_doc *doc, const uint32_t *vals, size_t count) {
-    yyjson_mut_arr_with_func({
-        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
-        val->uni.u64 = vals[i];
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint32 (
+      yyjson_mut_doc *doc, const uint32_t *vals, size_t count)
+  {
+    yyjson_mut_arr_with_func ({
+      val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
+      val->uni.u64 = vals[i];
     });
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint64(
-    yyjson_mut_doc *doc, const uint64_t *vals, size_t count) {
-    yyjson_mut_arr_with_func({
-        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
-        val->uni.u64 = vals[i];
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint64 (
+      yyjson_mut_doc *doc, const uint64_t *vals, size_t count)
+  {
+    yyjson_mut_arr_with_func ({
+      val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
+      val->uni.u64 = vals[i];
     });
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_float(
-    yyjson_mut_doc *doc, const float *vals, size_t count) {
-    yyjson_mut_arr_with_func({
-        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
-        val->uni.f64 = (double)vals[i];
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_float (
+      yyjson_mut_doc *doc, const float *vals, size_t count)
+  {
+    yyjson_mut_arr_with_func ({
+      val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
+      val->uni.f64 = (double)vals[i];
     });
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_double(
-    yyjson_mut_doc *doc, const double *vals, size_t count) {
-    yyjson_mut_arr_with_func({
-        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
-        val->uni.f64 = vals[i];
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_double (
+      yyjson_mut_doc *doc, const double *vals, size_t count)
+  {
+    yyjson_mut_arr_with_func ({
+      val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
+      val->uni.f64 = vals[i];
     });
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_str(
-    yyjson_mut_doc *doc, const char **vals, size_t count) {
-    yyjson_mut_arr_with_func({
-        uint64_t len = (uint64_t)strlen(vals[i]);
-        val->tag = (len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-        val->uni.str = vals[i];
-        if (yyjson_unlikely(!val->uni.str)) return NULL;
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_str (
+      yyjson_mut_doc *doc, const char **vals, size_t count)
+  {
+    yyjson_mut_arr_with_func ({
+      uint64_t len = (uint64_t)strlen (vals[i]);
+      val->tag     = (len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+      val->uni.str = vals[i];
+      if (yyjson_unlikely (!val->uni.str))
+        return NULL;
     });
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strn(
-    yyjson_mut_doc *doc, const char **vals, const size_t *lens, size_t count) {
-    if (yyjson_unlikely(count > 0 && !lens)) return NULL;
-    yyjson_mut_arr_with_func({
-        val->tag = ((uint64_t)lens[i] << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-        val->uni.str = vals[i];
-        if (yyjson_unlikely(!val->uni.str)) return NULL;
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strn (
+      yyjson_mut_doc *doc, const char **vals, const size_t *lens, size_t count)
+  {
+    if (yyjson_unlikely (count > 0 && !lens))
+      return NULL;
+    yyjson_mut_arr_with_func ({
+      val->tag     = ((uint64_t)lens[i] << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+      val->uni.str = vals[i];
+      if (yyjson_unlikely (!val->uni.str))
+        return NULL;
     });
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strcpy(
-    yyjson_mut_doc *doc, const char **vals, size_t count) {
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strcpy (
+      yyjson_mut_doc *doc, const char **vals, size_t count)
+  {
     size_t len;
     const char *str;
-    yyjson_mut_arr_with_func({
-        str = vals[i];
-        if (!str) return NULL;
-        len = strlen(str);
-        val->tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-        val->uni.str = unsafe_yyjson_mut_strncpy(doc, str, len);
-        if (yyjson_unlikely(!val->uni.str)) return NULL;
+    yyjson_mut_arr_with_func ({
+      str = vals[i];
+      if (!str)
+        return NULL;
+      len          = strlen (str);
+      val->tag     = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+      val->uni.str = unsafe_yyjson_mut_strncpy (doc, str, len);
+      if (yyjson_unlikely (!val->uni.str))
+        return NULL;
     });
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strncpy(
-    yyjson_mut_doc *doc, const char **vals, const size_t *lens, size_t count) {
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strncpy (
+      yyjson_mut_doc *doc, const char **vals, const size_t *lens, size_t count)
+  {
     size_t len;
     const char *str;
-    if (yyjson_unlikely(count > 0 && !lens)) return NULL;
-    yyjson_mut_arr_with_func({
-        str = vals[i];
-        len = lens[i];
-        val->tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-        val->uni.str = unsafe_yyjson_mut_strncpy(doc, str, len);
-        if (yyjson_unlikely(!val->uni.str)) return NULL;
+    if (yyjson_unlikely (count > 0 && !lens))
+      return NULL;
+    yyjson_mut_arr_with_func ({
+      str          = vals[i];
+      len          = lens[i];
+      val->tag     = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+      val->uni.str = unsafe_yyjson_mut_strncpy (doc, str, len);
+      if (yyjson_unlikely (!val->uni.str))
+        return NULL;
     });
-}
+  }
 
 #undef yyjson_mut_arr_with_func
 
+  /*==============================================================================
+   * Mutable JSON Array Modification API (Implementation)
+   *============================================================================*/
 
-
-/*==============================================================================
- * Mutable JSON Array Modification API (Implementation)
- *============================================================================*/
-
-yyjson_api_inline bool yyjson_mut_arr_insert(yyjson_mut_val *arr,
-                                             yyjson_mut_val *val, size_t idx) {
-    if (yyjson_likely(yyjson_mut_is_arr(arr) && val)) {
-        size_t len = unsafe_yyjson_get_len(arr);
-        if (yyjson_likely(idx <= len)) {
-            unsafe_yyjson_set_len(arr, len + 1);
-            if (len == 0) {
-                val->next = val;
-                arr->uni.ptr = val;
-            } else {
-                yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-                yyjson_mut_val *next = prev->next;
-                if (idx == len) {
-                    prev->next = val;
-                    val->next = next;
-                    arr->uni.ptr = val;
-                } else {
-                    while (idx-- > 0) {
-                        prev = next;
-                        next = next->next;
-                    }
-                    prev->next = val;
-                    val->next = next;
-                }
-            }
-            return true;
+  yyjson_api_inline bool yyjson_mut_arr_insert (yyjson_mut_val *arr,
+                                                yyjson_mut_val *val, size_t idx)
+  {
+    if (yyjson_likely (yyjson_mut_is_arr (arr) && val))
+    {
+      size_t len = unsafe_yyjson_get_len (arr);
+      if (yyjson_likely (idx <= len))
+      {
+        unsafe_yyjson_set_len (arr, len + 1);
+        if (len == 0)
+        {
+          val->next    = val;
+          arr->uni.ptr = val;
         }
-    }
-    return false;
-}
-
-yyjson_api_inline bool yyjson_mut_arr_append(yyjson_mut_val *arr,
-                                             yyjson_mut_val *val) {
-    if (yyjson_likely(yyjson_mut_is_arr(arr) && val)) {
-        size_t len = unsafe_yyjson_get_len(arr);
-        unsafe_yyjson_set_len(arr, len + 1);
-        if (len == 0) {
-            val->next = val;
-        } else {
-            yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-            yyjson_mut_val *next = prev->next;
-            prev->next = val;
-            val->next = next;
-        }
-        arr->uni.ptr = val;
-        return true;
-    }
-    return false;
-}
-
-yyjson_api_inline bool yyjson_mut_arr_prepend(yyjson_mut_val *arr,
-                                              yyjson_mut_val *val) {
-    if (yyjson_likely(yyjson_mut_is_arr(arr) && val)) {
-        size_t len = unsafe_yyjson_get_len(arr);
-        unsafe_yyjson_set_len(arr, len + 1);
-        if (len == 0) {
-            val->next = val;
+        else
+        {
+          yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+          yyjson_mut_val *next = prev->next;
+          if (idx == len)
+          {
+            prev->next   = val;
+            val->next    = next;
             arr->uni.ptr = val;
-        } else {
-            yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-            yyjson_mut_val *next = prev->next;
+          }
+          else
+          {
+            while (idx-- > 0)
+            {
+              prev = next;
+              next = next->next;
+            }
             prev->next = val;
-            val->next = next;
+            val->next  = next;
+          }
         }
         return true;
+      }
     }
     return false;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_replace(yyjson_mut_val *arr,
-                                                         size_t idx,
-                                                         yyjson_mut_val *val) {
-    if (yyjson_likely(yyjson_mut_is_arr(arr) && val)) {
-        size_t len = unsafe_yyjson_get_len(arr);
-        if (yyjson_likely(idx < len)) {
-            if (yyjson_likely(len > 1)) {
-                yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-                yyjson_mut_val *next = prev->next;
-                while (idx-- > 0) {
-                    prev = next;
-                    next = next->next;
-                }
-                prev->next = val;
-                val->next = next->next;
-                if ((void *)next == arr->uni.ptr) arr->uni.ptr = val;
-                return next;
-            } else {
-                yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-                val->next = val;
-                arr->uni.ptr = val;
-                return prev;
-            }
+  yyjson_api_inline bool yyjson_mut_arr_append (yyjson_mut_val *arr,
+                                                yyjson_mut_val *val)
+  {
+    if (yyjson_likely (yyjson_mut_is_arr (arr) && val))
+    {
+      size_t len = unsafe_yyjson_get_len (arr);
+      unsafe_yyjson_set_len (arr, len + 1);
+      if (len == 0)
+      {
+        val->next = val;
+      }
+      else
+      {
+        yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+        yyjson_mut_val *next = prev->next;
+        prev->next           = val;
+        val->next            = next;
+      }
+      arr->uni.ptr = val;
+      return true;
+    }
+    return false;
+  }
+
+  yyjson_api_inline bool yyjson_mut_arr_prepend (yyjson_mut_val *arr,
+                                                 yyjson_mut_val *val)
+  {
+    if (yyjson_likely (yyjson_mut_is_arr (arr) && val))
+    {
+      size_t len = unsafe_yyjson_get_len (arr);
+      unsafe_yyjson_set_len (arr, len + 1);
+      if (len == 0)
+      {
+        val->next    = val;
+        arr->uni.ptr = val;
+      }
+      else
+      {
+        yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+        yyjson_mut_val *next = prev->next;
+        prev->next           = val;
+        val->next            = next;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_replace (yyjson_mut_val *arr,
+                                                            size_t idx,
+                                                            yyjson_mut_val *val)
+  {
+    if (yyjson_likely (yyjson_mut_is_arr (arr) && val))
+    {
+      size_t len = unsafe_yyjson_get_len (arr);
+      if (yyjson_likely (idx < len))
+      {
+        if (yyjson_likely (len > 1))
+        {
+          yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+          yyjson_mut_val *next = prev->next;
+          while (idx-- > 0)
+          {
+            prev = next;
+            next = next->next;
+          }
+          prev->next = val;
+          val->next  = next->next;
+          if ((void *)next == arr->uni.ptr)
+            arr->uni.ptr = val;
+          return next;
         }
+        else
+        {
+          yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+          val->next            = val;
+          arr->uni.ptr         = val;
+          return prev;
+        }
+      }
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove(yyjson_mut_val *arr,
-                                                        size_t idx) {
-    if (yyjson_likely(yyjson_mut_is_arr(arr))) {
-        size_t len = unsafe_yyjson_get_len(arr);
-        if (yyjson_likely(idx < len)) {
-            unsafe_yyjson_set_len(arr, len - 1);
-            if (yyjson_likely(len > 1)) {
-                yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-                yyjson_mut_val *next = prev->next;
-                while (idx-- > 0) {
-                    prev = next;
-                    next = next->next;
-                }
-                prev->next = next->next;
-                if ((void *)next == arr->uni.ptr) arr->uni.ptr = prev;
-                return next;
-            } else {
-                return ((yyjson_mut_val *)arr->uni.ptr);
-            }
-        }
-    }
-    return NULL;
-}
-
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_first(
-    yyjson_mut_val *arr) {
-    if (yyjson_likely(yyjson_mut_is_arr(arr))) {
-        size_t len = unsafe_yyjson_get_len(arr);
-        if (len > 1) {
-            yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-            yyjson_mut_val *next = prev->next;
-            prev->next = next->next;
-            unsafe_yyjson_set_len(arr, len - 1);
-            return next;
-        } else if (len == 1) {
-            yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-            unsafe_yyjson_set_len(arr, 0);
-            return prev;
-        }
-    }
-    return NULL;
-}
-
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_last(
-    yyjson_mut_val *arr) {
-    if (yyjson_likely(yyjson_mut_is_arr(arr))) {
-        size_t len = unsafe_yyjson_get_len(arr);
-        if (yyjson_likely(len > 1)) {
-            yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-            yyjson_mut_val *next = prev->next;
-            unsafe_yyjson_set_len(arr, len - 1);
-            while (--len > 0) prev = prev->next;
-            prev->next = next;
-            next = (yyjson_mut_val *)arr->uni.ptr;
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove (yyjson_mut_val *arr,
+                                                           size_t idx)
+  {
+    if (yyjson_likely (yyjson_mut_is_arr (arr)))
+    {
+      size_t len = unsafe_yyjson_get_len (arr);
+      if (yyjson_likely (idx < len))
+      {
+        unsafe_yyjson_set_len (arr, len - 1);
+        if (yyjson_likely (len > 1))
+        {
+          yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+          yyjson_mut_val *next = prev->next;
+          while (idx-- > 0)
+          {
+            prev = next;
+            next = next->next;
+          }
+          prev->next = next->next;
+          if ((void *)next == arr->uni.ptr)
             arr->uni.ptr = prev;
-            return next;
-        } else if (len == 1) {
-            yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-            unsafe_yyjson_set_len(arr, 0);
-            return prev;
+          return next;
         }
+        else
+        {
+          return ((yyjson_mut_val *)arr->uni.ptr);
+        }
+      }
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_arr_remove_range(yyjson_mut_val *arr,
-                                                   size_t _idx, size_t _len) {
-    if (yyjson_likely(yyjson_mut_is_arr(arr))) {
-        yyjson_mut_val *prev, *next;
-        bool tail_removed;
-        size_t len = unsafe_yyjson_get_len(arr);
-        if (yyjson_unlikely(_idx + _len > len)) return false;
-        if (yyjson_unlikely(_len == 0)) return true;
-        unsafe_yyjson_set_len(arr, len - _len);
-        if (yyjson_unlikely(len == _len)) return true;
-        tail_removed = (_idx + _len == len);
-        prev = ((yyjson_mut_val *)arr->uni.ptr);
-        while (_idx-- > 0) prev = prev->next;
-        next = prev->next;
-        while (_len-- > 0) next = next->next;
-        prev->next = next;
-        if (yyjson_unlikely(tail_removed)) arr->uni.ptr = prev;
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_first (
+      yyjson_mut_val *arr)
+  {
+    if (yyjson_likely (yyjson_mut_is_arr (arr)))
+    {
+      size_t len = unsafe_yyjson_get_len (arr);
+      if (len > 1)
+      {
+        yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+        yyjson_mut_val *next = prev->next;
+        prev->next           = next->next;
+        unsafe_yyjson_set_len (arr, len - 1);
+        return next;
+      }
+      else if (len == 1)
+      {
+        yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+        unsafe_yyjson_set_len (arr, 0);
+        return prev;
+      }
+    }
+    return NULL;
+  }
+
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_last (
+      yyjson_mut_val *arr)
+  {
+    if (yyjson_likely (yyjson_mut_is_arr (arr)))
+    {
+      size_t len = unsafe_yyjson_get_len (arr);
+      if (yyjson_likely (len > 1))
+      {
+        yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+        yyjson_mut_val *next = prev->next;
+        unsafe_yyjson_set_len (arr, len - 1);
+        while (--len > 0)
+          prev = prev->next;
+        prev->next   = next;
+        next         = (yyjson_mut_val *)arr->uni.ptr;
+        arr->uni.ptr = prev;
+        return next;
+      }
+      else if (len == 1)
+      {
+        yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+        unsafe_yyjson_set_len (arr, 0);
+        return prev;
+      }
+    }
+    return NULL;
+  }
+
+  yyjson_api_inline bool yyjson_mut_arr_remove_range (yyjson_mut_val *arr,
+                                                      size_t _idx, size_t _len)
+  {
+    if (yyjson_likely (yyjson_mut_is_arr (arr)))
+    {
+      yyjson_mut_val *prev, *next;
+      bool tail_removed;
+      size_t len = unsafe_yyjson_get_len (arr);
+      if (yyjson_unlikely (_idx + _len > len))
+        return false;
+      if (yyjson_unlikely (_len == 0))
         return true;
-    }
-    return false;
-}
-
-yyjson_api_inline bool yyjson_mut_arr_clear(yyjson_mut_val *arr) {
-    if (yyjson_likely(yyjson_mut_is_arr(arr))) {
-        unsafe_yyjson_set_len(arr, 0);
+      unsafe_yyjson_set_len (arr, len - _len);
+      if (yyjson_unlikely (len == _len))
         return true;
+      tail_removed = (_idx + _len == len);
+      prev         = ((yyjson_mut_val *)arr->uni.ptr);
+      while (_idx-- > 0)
+        prev = prev->next;
+      next = prev->next;
+      while (_len-- > 0)
+        next = next->next;
+      prev->next = next;
+      if (yyjson_unlikely (tail_removed))
+        arr->uni.ptr = prev;
+      return true;
     }
     return false;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_arr_rotate(yyjson_mut_val *arr,
-                                             size_t idx) {
-    if (yyjson_likely(yyjson_mut_is_arr(arr) &&
-                      unsafe_yyjson_get_len(arr) > idx)) {
-        yyjson_mut_val *val = (yyjson_mut_val *)arr->uni.ptr;
-        while (idx-- > 0) val = val->next;
-        arr->uni.ptr = (void *)val;
-        return true;
+  yyjson_api_inline bool yyjson_mut_arr_clear (yyjson_mut_val *arr)
+  {
+    if (yyjson_likely (yyjson_mut_is_arr (arr)))
+    {
+      unsafe_yyjson_set_len (arr, 0);
+      return true;
     }
     return false;
-}
+  }
 
-
-
-/*==============================================================================
- * Mutable JSON Array Modification Convenience API (Implementation)
- *============================================================================*/
-
-yyjson_api_inline bool yyjson_mut_arr_add_val(yyjson_mut_val *arr,
-                                              yyjson_mut_val *val) {
-    return yyjson_mut_arr_append(arr, val);
-}
-
-yyjson_api_inline bool yyjson_mut_arr_add_null(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *arr) {
-    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-        yyjson_mut_val *val = yyjson_mut_null(doc);
-        return yyjson_mut_arr_append(arr, val);
+  yyjson_api_inline bool yyjson_mut_arr_rotate (yyjson_mut_val *arr,
+                                                size_t idx)
+  {
+    if (yyjson_likely (yyjson_mut_is_arr (arr) &&
+                       unsafe_yyjson_get_len (arr) > idx))
+    {
+      yyjson_mut_val *val = (yyjson_mut_val *)arr->uni.ptr;
+      while (idx-- > 0)
+        val = val->next;
+      arr->uni.ptr = (void *)val;
+      return true;
     }
     return false;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_arr_add_true(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *arr) {
-    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-        yyjson_mut_val *val = yyjson_mut_true(doc);
-        return yyjson_mut_arr_append(arr, val);
+  /*==============================================================================
+   * Mutable JSON Array Modification Convenience API (Implementation)
+   *============================================================================*/
+
+  yyjson_api_inline bool yyjson_mut_arr_add_val (yyjson_mut_val *arr,
+                                                 yyjson_mut_val *val)
+  {
+    return yyjson_mut_arr_append (arr, val);
+  }
+
+  yyjson_api_inline bool yyjson_mut_arr_add_null (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *arr)
+  {
+    if (yyjson_likely (doc && yyjson_mut_is_arr (arr)))
+    {
+      yyjson_mut_val *val = yyjson_mut_null (doc);
+      return yyjson_mut_arr_append (arr, val);
     }
     return false;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_arr_add_false(yyjson_mut_doc *doc,
-                                                yyjson_mut_val *arr) {
-    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-        yyjson_mut_val *val = yyjson_mut_false(doc);
-        return yyjson_mut_arr_append(arr, val);
+  yyjson_api_inline bool yyjson_mut_arr_add_true (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *arr)
+  {
+    if (yyjson_likely (doc && yyjson_mut_is_arr (arr)))
+    {
+      yyjson_mut_val *val = yyjson_mut_true (doc);
+      return yyjson_mut_arr_append (arr, val);
     }
     return false;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_arr_add_bool(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *arr,
-                                               bool _val) {
-    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-        yyjson_mut_val *val = yyjson_mut_bool(doc, _val);
-        return yyjson_mut_arr_append(arr, val);
+  yyjson_api_inline bool yyjson_mut_arr_add_false (yyjson_mut_doc *doc,
+                                                   yyjson_mut_val *arr)
+  {
+    if (yyjson_likely (doc && yyjson_mut_is_arr (arr)))
+    {
+      yyjson_mut_val *val = yyjson_mut_false (doc);
+      return yyjson_mut_arr_append (arr, val);
     }
     return false;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_arr_add_uint(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *arr,
-                                               uint64_t num) {
-    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-        yyjson_mut_val *val = yyjson_mut_uint(doc, num);
-        return yyjson_mut_arr_append(arr, val);
-    }
-    return false;
-}
-
-yyjson_api_inline bool yyjson_mut_arr_add_sint(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *arr,
-                                               int64_t num) {
-    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-        yyjson_mut_val *val = yyjson_mut_sint(doc, num);
-        return yyjson_mut_arr_append(arr, val);
-    }
-    return false;
-}
-
-yyjson_api_inline bool yyjson_mut_arr_add_int(yyjson_mut_doc *doc,
-                                              yyjson_mut_val *arr,
-                                              int64_t num) {
-    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-        yyjson_mut_val *val = yyjson_mut_sint(doc, num);
-        return yyjson_mut_arr_append(arr, val);
-    }
-    return false;
-}
-
-yyjson_api_inline bool yyjson_mut_arr_add_real(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *arr,
-                                               double num) {
-    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-        yyjson_mut_val *val = yyjson_mut_real(doc, num);
-        return yyjson_mut_arr_append(arr, val);
-    }
-    return false;
-}
-
-yyjson_api_inline bool yyjson_mut_arr_add_str(yyjson_mut_doc *doc,
-                                              yyjson_mut_val *arr,
-                                              const char *str) {
-    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-        yyjson_mut_val *val = yyjson_mut_str(doc, str);
-        return yyjson_mut_arr_append(arr, val);
-    }
-    return false;
-}
-
-yyjson_api_inline bool yyjson_mut_arr_add_strn(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *arr,
-                                               const char *str, size_t len) {
-    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-        yyjson_mut_val *val = yyjson_mut_strn(doc, str, len);
-        return yyjson_mut_arr_append(arr, val);
-    }
-    return false;
-}
-
-yyjson_api_inline bool yyjson_mut_arr_add_strcpy(yyjson_mut_doc *doc,
-                                                 yyjson_mut_val *arr,
-                                                 const char *str) {
-    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-        yyjson_mut_val *val = yyjson_mut_strcpy(doc, str);
-        return yyjson_mut_arr_append(arr, val);
-    }
-    return false;
-}
-
-yyjson_api_inline bool yyjson_mut_arr_add_strncpy(yyjson_mut_doc *doc,
+  yyjson_api_inline bool yyjson_mut_arr_add_bool (yyjson_mut_doc *doc,
                                                   yyjson_mut_val *arr,
-                                                  const char *str, size_t len) {
-    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-        yyjson_mut_val *val = yyjson_mut_strncpy(doc, str, len);
-        return yyjson_mut_arr_append(arr, val);
+                                                  bool _val)
+  {
+    if (yyjson_likely (doc && yyjson_mut_is_arr (arr)))
+    {
+      yyjson_mut_val *val = yyjson_mut_bool (doc, _val);
+      return yyjson_mut_arr_append (arr, val);
     }
     return false;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_add_arr(yyjson_mut_doc *doc,
-                                                         yyjson_mut_val *arr) {
-    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-        yyjson_mut_val *val = yyjson_mut_arr(doc);
-        return yyjson_mut_arr_append(arr, val) ? val : NULL;
+  yyjson_api_inline bool yyjson_mut_arr_add_uint (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *arr,
+                                                  uint64_t num)
+  {
+    if (yyjson_likely (doc && yyjson_mut_is_arr (arr)))
+    {
+      yyjson_mut_val *val = yyjson_mut_uint (doc, num);
+      return yyjson_mut_arr_append (arr, val);
+    }
+    return false;
+  }
+
+  yyjson_api_inline bool yyjson_mut_arr_add_sint (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *arr,
+                                                  int64_t num)
+  {
+    if (yyjson_likely (doc && yyjson_mut_is_arr (arr)))
+    {
+      yyjson_mut_val *val = yyjson_mut_sint (doc, num);
+      return yyjson_mut_arr_append (arr, val);
+    }
+    return false;
+  }
+
+  yyjson_api_inline bool yyjson_mut_arr_add_int (yyjson_mut_doc *doc,
+                                                 yyjson_mut_val *arr,
+                                                 int64_t num)
+  {
+    if (yyjson_likely (doc && yyjson_mut_is_arr (arr)))
+    {
+      yyjson_mut_val *val = yyjson_mut_sint (doc, num);
+      return yyjson_mut_arr_append (arr, val);
+    }
+    return false;
+  }
+
+  yyjson_api_inline bool yyjson_mut_arr_add_real (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *arr,
+                                                  double num)
+  {
+    if (yyjson_likely (doc && yyjson_mut_is_arr (arr)))
+    {
+      yyjson_mut_val *val = yyjson_mut_real (doc, num);
+      return yyjson_mut_arr_append (arr, val);
+    }
+    return false;
+  }
+
+  yyjson_api_inline bool yyjson_mut_arr_add_str (yyjson_mut_doc *doc,
+                                                 yyjson_mut_val *arr,
+                                                 const char *str)
+  {
+    if (yyjson_likely (doc && yyjson_mut_is_arr (arr)))
+    {
+      yyjson_mut_val *val = yyjson_mut_str (doc, str);
+      return yyjson_mut_arr_append (arr, val);
+    }
+    return false;
+  }
+
+  yyjson_api_inline bool yyjson_mut_arr_add_strn (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *arr,
+                                                  const char *str, size_t len)
+  {
+    if (yyjson_likely (doc && yyjson_mut_is_arr (arr)))
+    {
+      yyjson_mut_val *val = yyjson_mut_strn (doc, str, len);
+      return yyjson_mut_arr_append (arr, val);
+    }
+    return false;
+  }
+
+  yyjson_api_inline bool yyjson_mut_arr_add_strcpy (yyjson_mut_doc *doc,
+                                                    yyjson_mut_val *arr,
+                                                    const char *str)
+  {
+    if (yyjson_likely (doc && yyjson_mut_is_arr (arr)))
+    {
+      yyjson_mut_val *val = yyjson_mut_strcpy (doc, str);
+      return yyjson_mut_arr_append (arr, val);
+    }
+    return false;
+  }
+
+  yyjson_api_inline bool yyjson_mut_arr_add_strncpy (yyjson_mut_doc *doc,
+                                                     yyjson_mut_val *arr,
+                                                     const char *str, size_t len)
+  {
+    if (yyjson_likely (doc && yyjson_mut_is_arr (arr)))
+    {
+      yyjson_mut_val *val = yyjson_mut_strncpy (doc, str, len);
+      return yyjson_mut_arr_append (arr, val);
+    }
+    return false;
+  }
+
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_add_arr (yyjson_mut_doc *doc,
+                                                            yyjson_mut_val *arr)
+  {
+    if (yyjson_likely (doc && yyjson_mut_is_arr (arr)))
+    {
+      yyjson_mut_val *val = yyjson_mut_arr (doc);
+      return yyjson_mut_arr_append (arr, val) ? val : NULL;
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_add_obj(yyjson_mut_doc *doc,
-                                                         yyjson_mut_val *arr) {
-    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-        yyjson_mut_val *val = yyjson_mut_obj(doc);
-        return yyjson_mut_arr_append(arr, val) ? val : NULL;
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_add_obj (yyjson_mut_doc *doc,
+                                                            yyjson_mut_val *arr)
+  {
+    if (yyjson_likely (doc && yyjson_mut_is_arr (arr)))
+    {
+      yyjson_mut_val *val = yyjson_mut_obj (doc);
+      return yyjson_mut_arr_append (arr, val) ? val : NULL;
     }
     return NULL;
-}
+  }
 
+  /*==============================================================================
+   * Mutable JSON Object API (Implementation)
+   *============================================================================*/
 
+  yyjson_api_inline size_t yyjson_mut_obj_size (yyjson_mut_val *obj)
+  {
+    return yyjson_mut_is_obj (obj) ? unsafe_yyjson_get_len (obj) : 0;
+  }
 
-/*==============================================================================
- * Mutable JSON Object API (Implementation)
- *============================================================================*/
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_get (yyjson_mut_val *obj,
+                                                        const char *key)
+  {
+    return yyjson_mut_obj_getn (obj, key, key ? strlen (key) : 0);
+  }
 
-yyjson_api_inline size_t yyjson_mut_obj_size(yyjson_mut_val *obj) {
-    return yyjson_mut_is_obj(obj) ? unsafe_yyjson_get_len(obj) : 0;
-}
-
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_get(yyjson_mut_val *obj,
-                                                     const char *key) {
-    return yyjson_mut_obj_getn(obj, key, key ? strlen(key) : 0);
-}
-
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_getn(yyjson_mut_val *obj,
-                                                      const char *_key,
-                                                      size_t key_len) {
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_getn (yyjson_mut_val *obj,
+                                                         const char *_key,
+                                                         size_t key_len)
+  {
     uint64_t tag = (((uint64_t)key_len) << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-    size_t len = yyjson_mut_obj_size(obj);
-    if (yyjson_likely(len && _key)) {
-        yyjson_mut_val *key = ((yyjson_mut_val *)obj->uni.ptr)->next->next;
-        while (len-- > 0) {
-            if (key->tag == tag &&
-                memcmp(key->uni.ptr, _key, key_len) == 0) {
-                return key->next;
-            }
-            key = key->next->next;
+    size_t len   = yyjson_mut_obj_size (obj);
+    if (yyjson_likely (len && _key))
+    {
+      yyjson_mut_val *key = ((yyjson_mut_val *)obj->uni.ptr)->next->next;
+      while (len-- > 0)
+      {
+        if (key->tag == tag &&
+            memcmp (key->uni.ptr, _key, key_len) == 0)
+        {
+          return key->next;
         }
+        key = key->next->next;
+      }
     }
     return NULL;
-}
+  }
 
+  /*==============================================================================
+   * Mutable JSON Object Iterator API (Implementation)
+   *============================================================================*/
 
-
-/*==============================================================================
- * Mutable JSON Object Iterator API (Implementation)
- *============================================================================*/
-
-yyjson_api_inline bool yyjson_mut_obj_iter_init(yyjson_mut_val *obj,
-                                                yyjson_mut_obj_iter *iter) {
-    if (yyjson_likely(yyjson_mut_is_obj(obj) && iter)) {
-        iter->idx = 0;
-        iter->max = unsafe_yyjson_get_len(obj);
-        iter->cur = iter->max ? (yyjson_mut_val *)obj->uni.ptr : NULL;
-        iter->pre = NULL;
-        iter->obj = obj;
-        return true;
+  yyjson_api_inline bool yyjson_mut_obj_iter_init (yyjson_mut_val *obj,
+                                                   yyjson_mut_obj_iter *iter)
+  {
+    if (yyjson_likely (yyjson_mut_is_obj (obj) && iter))
+    {
+      iter->idx = 0;
+      iter->max = unsafe_yyjson_get_len (obj);
+      iter->cur = iter->max ? (yyjson_mut_val *)obj->uni.ptr : NULL;
+      iter->pre = NULL;
+      iter->obj = obj;
+      return true;
     }
-    if (iter) memset(iter, 0, sizeof(yyjson_mut_obj_iter));
+    if (iter)
+      memset (iter, 0, sizeof (yyjson_mut_obj_iter));
     return false;
-}
+  }
 
-yyjson_api_inline yyjson_mut_obj_iter yyjson_mut_obj_iter_with(
-    yyjson_mut_val *obj) {
+  yyjson_api_inline yyjson_mut_obj_iter yyjson_mut_obj_iter_with (
+      yyjson_mut_val *obj)
+  {
     yyjson_mut_obj_iter iter;
-    yyjson_mut_obj_iter_init(obj, &iter);
+    yyjson_mut_obj_iter_init (obj, &iter);
     return iter;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_obj_iter_has_next(yyjson_mut_obj_iter *iter) {
+  yyjson_api_inline bool yyjson_mut_obj_iter_has_next (yyjson_mut_obj_iter *iter)
+  {
     return iter ? iter->idx < iter->max : false;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_next(
-    yyjson_mut_obj_iter *iter) {
-    if (iter && iter->idx < iter->max) {
-        yyjson_mut_val *key = iter->cur;
-        iter->pre = key;
-        iter->cur = key->next->next;
-        iter->idx++;
-        return iter->cur;
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_next (
+      yyjson_mut_obj_iter *iter)
+  {
+    if (iter && iter->idx < iter->max)
+    {
+      yyjson_mut_val *key = iter->cur;
+      iter->pre           = key;
+      iter->cur           = key->next->next;
+      iter->idx++;
+      return iter->cur;
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_get_val(
-    yyjson_mut_val *key) {
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_get_val (
+      yyjson_mut_val *key)
+  {
     return key ? key->next : NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_remove(
-    yyjson_mut_obj_iter *iter) {
-    if (yyjson_likely(iter && 0 < iter->idx && iter->idx <= iter->max)) {
-        yyjson_mut_val *prev = iter->pre;
-        yyjson_mut_val *cur = iter->cur;
-        yyjson_mut_val *next = cur->next->next;
-        if (yyjson_unlikely(iter->idx == iter->max)) iter->obj->uni.ptr = prev;
-        iter->idx--;
-        iter->max--;
-        unsafe_yyjson_set_len(iter->obj, iter->max);
-        prev->next->next = next;
-        iter->cur = next;
-        return cur;
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_remove (
+      yyjson_mut_obj_iter *iter)
+  {
+    if (yyjson_likely (iter && 0 < iter->idx && iter->idx <= iter->max))
+    {
+      yyjson_mut_val *prev = iter->pre;
+      yyjson_mut_val *cur  = iter->cur;
+      yyjson_mut_val *next = cur->next->next;
+      if (yyjson_unlikely (iter->idx == iter->max))
+        iter->obj->uni.ptr = prev;
+      iter->idx--;
+      iter->max--;
+      unsafe_yyjson_set_len (iter->obj, iter->max);
+      prev->next->next = next;
+      iter->cur        = next;
+      return cur;
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_get(
-    yyjson_mut_obj_iter *iter, const char *key) {
-    return yyjson_mut_obj_iter_getn(iter, key, key ? strlen(key) : 0);
-}
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_get (
+      yyjson_mut_obj_iter *iter, const char *key)
+  {
+    return yyjson_mut_obj_iter_getn (iter, key, key ? strlen (key) : 0);
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_getn(
-    yyjson_mut_obj_iter *iter, const char *key, size_t key_len) {
-    if (iter && key) {
-        size_t idx = 0;
-        size_t max = iter->max;
-        yyjson_mut_val *pre, *cur = iter->cur;
-        while (idx++ < max) {
-            pre = cur;
-            cur = cur->next->next;
-            if (unsafe_yyjson_get_len(cur) == key_len &&
-                memcmp(cur->uni.str, key, key_len) == 0) {
-                iter->idx += idx;
-                if (iter->idx > max) iter->idx -= max + 1;
-                iter->pre = pre;
-                iter->cur = cur;
-                return cur->next;
-            }
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_getn (
+      yyjson_mut_obj_iter *iter, const char *key, size_t key_len)
+  {
+    if (iter && key)
+    {
+      size_t idx = 0;
+      size_t max = iter->max;
+      yyjson_mut_val *pre, *cur = iter->cur;
+      while (idx++ < max)
+      {
+        pre = cur;
+        cur = cur->next->next;
+        if (unsafe_yyjson_get_len (cur) == key_len &&
+            memcmp (cur->uni.str, key, key_len) == 0)
+        {
+          iter->idx += idx;
+          if (iter->idx > max)
+            iter->idx -= max + 1;
+          iter->pre = pre;
+          iter->cur = cur;
+          return cur->next;
         }
+      }
     }
     return NULL;
-}
+  }
 
+  /*==============================================================================
+   * Mutable JSON Object Creation API (Implementation)
+   *============================================================================*/
 
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj (yyjson_mut_doc *doc)
+  {
+    if (yyjson_likely (doc))
+    {
+      yyjson_mut_val *val = unsafe_yyjson_mut_val (doc, 1);
+      if (yyjson_likely (val))
+      {
+        val->tag = YYJSON_TYPE_OBJ | YYJSON_SUBTYPE_NONE;
+        return val;
+      }
+    }
+    return NULL;
+  }
 
-/*==============================================================================
- * Mutable JSON Object Creation API (Implementation)
- *============================================================================*/
-
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj(yyjson_mut_doc *doc) {
-    if (yyjson_likely(doc)) {
-        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-        if (yyjson_likely(val)) {
-            val->tag = YYJSON_TYPE_OBJ | YYJSON_SUBTYPE_NONE;
-            return val;
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_str (yyjson_mut_doc *doc,
+                                                             const char **keys,
+                                                             const char **vals,
+                                                             size_t count)
+  {
+    if (yyjson_likely (doc && ((count > 0 && keys && vals) || (count == 0))))
+    {
+      yyjson_mut_val *obj = unsafe_yyjson_mut_val (doc, 1 + count * 2);
+      if (yyjson_likely (obj))
+      {
+        obj->tag = ((uint64_t)count << YYJSON_TAG_BIT) | YYJSON_TYPE_OBJ;
+        if (count > 0)
+        {
+          size_t i;
+          for (i = 0; i < count; i++)
+          {
+            yyjson_mut_val *key = obj + (i * 2 + 1);
+            yyjson_mut_val *val = obj + (i * 2 + 2);
+            uint64_t key_len    = (uint64_t)strlen (keys[i]);
+            uint64_t val_len    = (uint64_t)strlen (vals[i]);
+            key->tag            = (key_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+            val->tag            = (val_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+            key->uni.str        = keys[i];
+            val->uni.str        = vals[i];
+            key->next           = val;
+            val->next           = val + 1;
+          }
+          obj[count * 2].next = obj + 1;
+          obj->uni.ptr        = obj + (count * 2 - 1);
         }
+        return obj;
+      }
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_str(yyjson_mut_doc *doc,
-                                                          const char **keys,
-                                                          const char **vals,
-                                                          size_t count) {
-    if (yyjson_likely(doc && ((count > 0 && keys && vals) || (count == 0)))) {
-        yyjson_mut_val *obj = unsafe_yyjson_mut_val(doc, 1 + count * 2);
-        if (yyjson_likely(obj)) {
-            obj->tag = ((uint64_t)count << YYJSON_TAG_BIT) | YYJSON_TYPE_OBJ;
-            if (count > 0) {
-                size_t i;
-                for (i = 0; i < count; i++) {
-                    yyjson_mut_val *key = obj + (i * 2 + 1);
-                    yyjson_mut_val *val = obj + (i * 2 + 2);
-                    uint64_t key_len = (uint64_t)strlen(keys[i]);
-                    uint64_t val_len = (uint64_t)strlen(vals[i]);
-                    key->tag = (key_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-                    val->tag = (val_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-                    key->uni.str = keys[i];
-                    val->uni.str = vals[i];
-                    key->next = val;
-                    val->next = val + 1;
-                }
-                obj[count * 2].next = obj + 1;
-                obj->uni.ptr = obj + (count * 2 - 1);
-            }
-            return obj;
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_kv (yyjson_mut_doc *doc,
+                                                            const char **pairs,
+                                                            size_t count)
+  {
+    if (yyjson_likely (doc && ((count > 0 && pairs) || (count == 0))))
+    {
+      yyjson_mut_val *obj = unsafe_yyjson_mut_val (doc, 1 + count * 2);
+      if (yyjson_likely (obj))
+      {
+        obj->tag = ((uint64_t)count << YYJSON_TAG_BIT) | YYJSON_TYPE_OBJ;
+        if (count > 0)
+        {
+          size_t i;
+          for (i = 0; i < count; i++)
+          {
+            yyjson_mut_val *key = obj + (i * 2 + 1);
+            yyjson_mut_val *val = obj + (i * 2 + 2);
+            const char *key_str = pairs[i * 2 + 0];
+            const char *val_str = pairs[i * 2 + 1];
+            uint64_t key_len    = (uint64_t)strlen (key_str);
+            uint64_t val_len    = (uint64_t)strlen (val_str);
+            key->tag            = (key_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+            val->tag            = (val_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+            key->uni.str        = key_str;
+            val->uni.str        = val_str;
+            key->next           = val;
+            val->next           = val + 1;
+          }
+          obj[count * 2].next = obj + 1;
+          obj->uni.ptr        = obj + (count * 2 - 1);
         }
+        return obj;
+      }
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_kv(yyjson_mut_doc *doc,
-                                                         const char **pairs,
-                                                         size_t count) {
-    if (yyjson_likely(doc && ((count > 0 && pairs) || (count == 0)))) {
-        yyjson_mut_val *obj = unsafe_yyjson_mut_val(doc, 1 + count * 2);
-        if (yyjson_likely(obj)) {
-            obj->tag = ((uint64_t)count << YYJSON_TAG_BIT) | YYJSON_TYPE_OBJ;
-            if (count > 0) {
-                size_t i;
-                for (i = 0; i < count; i++) {
-                    yyjson_mut_val *key = obj + (i * 2 + 1);
-                    yyjson_mut_val *val = obj + (i * 2 + 2);
-                    const char *key_str = pairs[i * 2 + 0];
-                    const char *val_str = pairs[i * 2 + 1];
-                    uint64_t key_len = (uint64_t)strlen(key_str);
-                    uint64_t val_len = (uint64_t)strlen(val_str);
-                    key->tag = (key_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-                    val->tag = (val_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-                    key->uni.str = key_str;
-                    val->uni.str = val_str;
-                    key->next = val;
-                    val->next = val + 1;
-                }
-                obj[count * 2].next = obj + 1;
-                obj->uni.ptr = obj + (count * 2 - 1);
-            }
-            return obj;
-        }
+  /*==============================================================================
+   * Mutable JSON Object Modification API (Implementation)
+   *============================================================================*/
+
+  yyjson_api_inline void unsafe_yyjson_mut_obj_add (yyjson_mut_val *obj,
+                                                    yyjson_mut_val *key,
+                                                    yyjson_mut_val *val,
+                                                    size_t len)
+  {
+    if (yyjson_likely (len))
+    {
+      yyjson_mut_val *prev_val = ((yyjson_mut_val *)obj->uni.ptr)->next;
+      yyjson_mut_val *next_key = prev_val->next;
+      prev_val->next           = key;
+      val->next                = next_key;
     }
-    return NULL;
-}
-
-
-
-/*==============================================================================
- * Mutable JSON Object Modification API (Implementation)
- *============================================================================*/
-
-yyjson_api_inline void unsafe_yyjson_mut_obj_add(yyjson_mut_val *obj,
-                                                 yyjson_mut_val *key,
-                                                 yyjson_mut_val *val,
-                                                 size_t len) {
-    if (yyjson_likely(len)) {
-        yyjson_mut_val *prev_val = ((yyjson_mut_val *)obj->uni.ptr)->next;
-        yyjson_mut_val *next_key = prev_val->next;
-        prev_val->next = key;
-        val->next = next_key;
-    } else {
-        val->next = key;
+    else
+    {
+      val->next = key;
     }
-    key->next = val;
+    key->next    = val;
     obj->uni.ptr = (void *)key;
-    unsafe_yyjson_set_len(obj, len + 1);
-}
+    unsafe_yyjson_set_len (obj, len + 1);
+  }
 
-yyjson_api_inline yyjson_mut_val *unsafe_yyjson_mut_obj_remove(
-    yyjson_mut_val *obj, const char *key, size_t key_len, uint64_t key_tag) {
-    size_t obj_len = unsafe_yyjson_get_len(obj);
-    if (obj_len) {
-        yyjson_mut_val *pre_key = (yyjson_mut_val *)obj->uni.ptr;
-        yyjson_mut_val *cur_key = pre_key->next->next;
-        yyjson_mut_val *removed_item = NULL;
-        size_t i;
-        for (i = 0; i < obj_len; i++) {
-            if (key_tag == cur_key->tag &&
-                memcmp(key, cur_key->uni.ptr, key_len) == 0) {
-                if (!removed_item) removed_item = cur_key->next;
-                cur_key = cur_key->next->next;
-                pre_key->next->next = cur_key;
-                if (i + 1 == obj_len) obj->uni.ptr = pre_key;
-                i--;
-                obj_len--;
-            } else {
-                pre_key = cur_key;
-                cur_key = cur_key->next->next;
-            }
+  yyjson_api_inline yyjson_mut_val *unsafe_yyjson_mut_obj_remove (
+      yyjson_mut_val *obj, const char *key, size_t key_len, uint64_t key_tag)
+  {
+    size_t obj_len = unsafe_yyjson_get_len (obj);
+    if (obj_len)
+    {
+      yyjson_mut_val *pre_key      = (yyjson_mut_val *)obj->uni.ptr;
+      yyjson_mut_val *cur_key      = pre_key->next->next;
+      yyjson_mut_val *removed_item = NULL;
+      size_t i;
+      for (i = 0; i < obj_len; i++)
+      {
+        if (key_tag == cur_key->tag &&
+            memcmp (key, cur_key->uni.ptr, key_len) == 0)
+        {
+          if (!removed_item)
+            removed_item = cur_key->next;
+          cur_key             = cur_key->next->next;
+          pre_key->next->next = cur_key;
+          if (i + 1 == obj_len)
+            obj->uni.ptr = pre_key;
+          i--;
+          obj_len--;
         }
-        unsafe_yyjson_set_len(obj, obj_len);
-        return removed_item;
-    } else {
-        return NULL;
+        else
+        {
+          pre_key = cur_key;
+          cur_key = cur_key->next->next;
+        }
+      }
+      unsafe_yyjson_set_len (obj, obj_len);
+      return removed_item;
     }
-}
+    else
+    {
+      return NULL;
+    }
+  }
 
-yyjson_api_inline bool unsafe_yyjson_mut_obj_replace(yyjson_mut_val *obj,
-                                                     yyjson_mut_val *key,
-                                                     yyjson_mut_val *val) {
-    size_t key_len = unsafe_yyjson_get_len(key);
-    size_t obj_len = unsafe_yyjson_get_len(obj);
-    if (obj_len) {
-        yyjson_mut_val *pre_key = (yyjson_mut_val *)obj->uni.ptr;
-        yyjson_mut_val *cur_key = pre_key->next->next;
-        size_t i;
-        for (i = 0; i < obj_len; i++) {
-            if (key->tag == cur_key->tag &&
-                memcmp(key->uni.str, cur_key->uni.ptr, key_len) == 0) {
-                cur_key->next->tag = val->tag;
-                cur_key->next->uni.u64 = val->uni.u64;
-                return true;
-            } else {
-                cur_key = cur_key->next->next;
-            }
+  yyjson_api_inline bool unsafe_yyjson_mut_obj_replace (yyjson_mut_val *obj,
+                                                        yyjson_mut_val *key,
+                                                        yyjson_mut_val *val)
+  {
+    size_t key_len = unsafe_yyjson_get_len (key);
+    size_t obj_len = unsafe_yyjson_get_len (obj);
+    if (obj_len)
+    {
+      yyjson_mut_val *pre_key = (yyjson_mut_val *)obj->uni.ptr;
+      yyjson_mut_val *cur_key = pre_key->next->next;
+      size_t i;
+      for (i = 0; i < obj_len; i++)
+      {
+        if (key->tag == cur_key->tag &&
+            memcmp (key->uni.str, cur_key->uni.ptr, key_len) == 0)
+        {
+          cur_key->next->tag     = val->tag;
+          cur_key->next->uni.u64 = val->uni.u64;
+          return true;
         }
+        else
+        {
+          cur_key = cur_key->next->next;
+        }
+      }
     }
     return false;
-}
+  }
 
-yyjson_api_inline void unsafe_yyjson_mut_obj_rotate(yyjson_mut_val *obj,
-                                                    size_t idx) {
+  yyjson_api_inline void unsafe_yyjson_mut_obj_rotate (yyjson_mut_val *obj,
+                                                       size_t idx)
+  {
     yyjson_mut_val *key = (yyjson_mut_val *)obj->uni.ptr;
-    while (idx-- > 0) key = key->next->next;
+    while (idx-- > 0)
+      key = key->next->next;
     obj->uni.ptr = (void *)key;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_obj_add(yyjson_mut_val *obj,
-                                          yyjson_mut_val *key,
-                                          yyjson_mut_val *val) {
-    if (yyjson_likely(yyjson_mut_is_obj(obj) &&
-                      yyjson_mut_is_str(key) && val)) {
-        unsafe_yyjson_mut_obj_add(obj, key, val, unsafe_yyjson_get_len(obj));
-        return true;
-    }
-    return false;
-}
-
-yyjson_api_inline bool yyjson_mut_obj_put(yyjson_mut_val *obj,
-                                          yyjson_mut_val *key,
-                                          yyjson_mut_val *val) {
-    if (yyjson_likely(yyjson_mut_is_obj(obj) &&
-                      yyjson_mut_is_str(key))) {
-        unsafe_yyjson_mut_obj_remove(obj, key->uni.str,
-                                     unsafe_yyjson_get_len(key), key->tag);
-        if (yyjson_likely(val)) {
-            unsafe_yyjson_mut_obj_add(obj, key, val,
-                                      unsafe_yyjson_get_len(obj));
-        }
-        return true;
-    }
-    return false;
-}
-
-yyjson_api_inline bool yyjson_mut_obj_insert(yyjson_mut_val *obj,
+  yyjson_api_inline bool yyjson_mut_obj_add (yyjson_mut_val *obj,
                                              yyjson_mut_val *key,
-                                             yyjson_mut_val *val,
-                                             size_t idx) {
-    if (yyjson_likely(yyjson_mut_is_obj(obj) &&
-                      yyjson_mut_is_str(key) && val)) {
-        size_t len = unsafe_yyjson_get_len(obj);
-        if (yyjson_likely(len >= idx)) {
-            if (len > idx) {
-                void *ptr = obj->uni.ptr;
-                unsafe_yyjson_mut_obj_rotate(obj, idx);
-                unsafe_yyjson_mut_obj_add(obj, key, val, len);
-                obj->uni.ptr = ptr;
-            } else {
-                unsafe_yyjson_mut_obj_add(obj, key, val, len);
-            }
-            return true;
+                                             yyjson_mut_val *val)
+  {
+    if (yyjson_likely (yyjson_mut_is_obj (obj) &&
+                       yyjson_mut_is_str (key) && val))
+    {
+      unsafe_yyjson_mut_obj_add (obj, key, val, unsafe_yyjson_get_len (obj));
+      return true;
+    }
+    return false;
+  }
+
+  yyjson_api_inline bool yyjson_mut_obj_put (yyjson_mut_val *obj,
+                                             yyjson_mut_val *key,
+                                             yyjson_mut_val *val)
+  {
+    if (yyjson_likely (yyjson_mut_is_obj (obj) &&
+                       yyjson_mut_is_str (key)))
+    {
+      unsafe_yyjson_mut_obj_remove (obj, key->uni.str,
+                                    unsafe_yyjson_get_len (key), key->tag);
+      if (yyjson_likely (val))
+      {
+        unsafe_yyjson_mut_obj_add (obj, key, val,
+                                   unsafe_yyjson_get_len (obj));
+      }
+      return true;
+    }
+    return false;
+  }
+
+  yyjson_api_inline bool yyjson_mut_obj_insert (yyjson_mut_val *obj,
+                                                yyjson_mut_val *key,
+                                                yyjson_mut_val *val,
+                                                size_t idx)
+  {
+    if (yyjson_likely (yyjson_mut_is_obj (obj) &&
+                       yyjson_mut_is_str (key) && val))
+    {
+      size_t len = unsafe_yyjson_get_len (obj);
+      if (yyjson_likely (len >= idx))
+      {
+        if (len > idx)
+        {
+          void *ptr = obj->uni.ptr;
+          unsafe_yyjson_mut_obj_rotate (obj, idx);
+          unsafe_yyjson_mut_obj_add (obj, key, val, len);
+          obj->uni.ptr = ptr;
         }
-    }
-    return false;
-}
-
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove(yyjson_mut_val *obj,
-    yyjson_mut_val *key) {
-    if (yyjson_likely(yyjson_mut_is_obj(obj) && yyjson_mut_is_str(key))) {
-        return unsafe_yyjson_mut_obj_remove(obj, key->uni.str,
-                                            unsafe_yyjson_get_len(key),
-                                            key->tag);
-    }
-    return NULL;
-}
-
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_key(
-    yyjson_mut_val *obj, const char *key) {
-    if (yyjson_likely(yyjson_mut_is_obj(obj) && key)) {
-        size_t key_len = strlen(key);
-        uint64_t tag = ((uint64_t)key_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-        return unsafe_yyjson_mut_obj_remove(obj, key, key_len, tag);
-    }
-    return NULL;
-}
-
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_keyn(
-    yyjson_mut_val *obj, const char *key, size_t key_len) {
-    if (yyjson_likely(yyjson_mut_is_obj(obj) && key)) {
-        uint64_t tag = ((uint64_t)key_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-        return unsafe_yyjson_mut_obj_remove(obj, key, key_len, tag);
-    }
-    return NULL;
-}
-
-yyjson_api_inline bool yyjson_mut_obj_clear(yyjson_mut_val *obj) {
-    if (yyjson_likely(yyjson_mut_is_obj(obj))) {
-        unsafe_yyjson_set_len(obj, 0);
+        else
+        {
+          unsafe_yyjson_mut_obj_add (obj, key, val, len);
+        }
         return true;
+      }
     }
     return false;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_obj_replace(yyjson_mut_val *obj,
-                                              yyjson_mut_val *key,
-                                              yyjson_mut_val *val) {
-    if (yyjson_likely(yyjson_mut_is_obj(obj) &&
-                      yyjson_mut_is_str(key) && val)) {
-        return unsafe_yyjson_mut_obj_replace(obj, key, val);
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove (yyjson_mut_val *obj,
+                                                           yyjson_mut_val *key)
+  {
+    if (yyjson_likely (yyjson_mut_is_obj (obj) && yyjson_mut_is_str (key)))
+    {
+      return unsafe_yyjson_mut_obj_remove (obj, key->uni.str,
+                                           unsafe_yyjson_get_len (key),
+                                           key->tag);
+    }
+    return NULL;
+  }
+
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_key (
+      yyjson_mut_val *obj, const char *key)
+  {
+    if (yyjson_likely (yyjson_mut_is_obj (obj) && key))
+    {
+      size_t key_len = strlen (key);
+      uint64_t tag   = ((uint64_t)key_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+      return unsafe_yyjson_mut_obj_remove (obj, key, key_len, tag);
+    }
+    return NULL;
+  }
+
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_keyn (
+      yyjson_mut_val *obj, const char *key, size_t key_len)
+  {
+    if (yyjson_likely (yyjson_mut_is_obj (obj) && key))
+    {
+      uint64_t tag = ((uint64_t)key_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+      return unsafe_yyjson_mut_obj_remove (obj, key, key_len, tag);
+    }
+    return NULL;
+  }
+
+  yyjson_api_inline bool yyjson_mut_obj_clear (yyjson_mut_val *obj)
+  {
+    if (yyjson_likely (yyjson_mut_is_obj (obj)))
+    {
+      unsafe_yyjson_set_len (obj, 0);
+      return true;
     }
     return false;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_obj_rotate(yyjson_mut_val *obj,
-                                             size_t idx) {
-    if (yyjson_likely(yyjson_mut_is_obj(obj) &&
-                      unsafe_yyjson_get_len(obj) > idx)) {
-        unsafe_yyjson_mut_obj_rotate(obj, idx);
-        return true;
+  yyjson_api_inline bool yyjson_mut_obj_replace (yyjson_mut_val *obj,
+                                                 yyjson_mut_val *key,
+                                                 yyjson_mut_val *val)
+  {
+    if (yyjson_likely (yyjson_mut_is_obj (obj) &&
+                       yyjson_mut_is_str (key) && val))
+    {
+      return unsafe_yyjson_mut_obj_replace (obj, key, val);
     }
     return false;
-}
+  }
 
+  yyjson_api_inline bool yyjson_mut_obj_rotate (yyjson_mut_val *obj,
+                                                size_t idx)
+  {
+    if (yyjson_likely (yyjson_mut_is_obj (obj) &&
+                       unsafe_yyjson_get_len (obj) > idx))
+    {
+      unsafe_yyjson_mut_obj_rotate (obj, idx);
+      return true;
+    }
+    return false;
+  }
 
+  /*==============================================================================
+   * Mutable JSON Object Modification Convenience API (Implementation)
+   *============================================================================*/
 
-/*==============================================================================
- * Mutable JSON Object Modification Convenience API (Implementation)
- *============================================================================*/
+#define yyjson_mut_obj_add_func(func)                              \
+  if (yyjson_likely (doc && yyjson_mut_is_obj (obj) && _key))      \
+  {                                                                \
+    yyjson_mut_val *key = unsafe_yyjson_mut_val (doc, 2);          \
+    if (yyjson_likely (key))                                       \
+    {                                                              \
+      size_t len          = unsafe_yyjson_get_len (obj);           \
+      yyjson_mut_val *val = key + 1;                               \
+      key->tag            = YYJSON_TYPE_STR | YYJSON_SUBTYPE_NONE; \
+      key->tag |= (uint64_t)strlen (_key) << YYJSON_TAG_BIT;       \
+      key->uni.str = _key;                                         \
+      func                                                         \
+          unsafe_yyjson_mut_obj_add (obj, key, val, len);          \
+      return true;                                                 \
+    }                                                              \
+  }                                                                \
+  return false
 
-#define yyjson_mut_obj_add_func(func) \
-    if (yyjson_likely(doc && yyjson_mut_is_obj(obj) && _key)) { \
-        yyjson_mut_val *key = unsafe_yyjson_mut_val(doc, 2); \
-        if (yyjson_likely(key)) { \
-            size_t len = unsafe_yyjson_get_len(obj); \
-            yyjson_mut_val *val = key + 1; \
-            key->tag = YYJSON_TYPE_STR | YYJSON_SUBTYPE_NONE; \
-            key->tag |= (uint64_t)strlen(_key) << YYJSON_TAG_BIT; \
-            key->uni.str = _key; \
-            func \
-            unsafe_yyjson_mut_obj_add(obj, key, val, len); \
-            return true; \
-        } \
-    } \
-    return false
-
-yyjson_api_inline bool yyjson_mut_obj_add_null(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *obj,
-                                               const char *_key) {
-    yyjson_mut_obj_add_func({
-        val->tag = YYJSON_TYPE_NULL | YYJSON_SUBTYPE_NONE;
+  yyjson_api_inline bool yyjson_mut_obj_add_null (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *obj,
+                                                  const char *_key)
+  {
+    yyjson_mut_obj_add_func ({
+      val->tag = YYJSON_TYPE_NULL | YYJSON_SUBTYPE_NONE;
     });
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_obj_add_true(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *obj,
-                                               const char *_key) {
-    yyjson_mut_obj_add_func({
-        val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE;
+  yyjson_api_inline bool yyjson_mut_obj_add_true (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *obj,
+                                                  const char *_key)
+  {
+    yyjson_mut_obj_add_func ({
+      val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE;
     });
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_obj_add_false(yyjson_mut_doc *doc,
-                                                yyjson_mut_val *obj,
-                                                const char *_key) {
-    yyjson_mut_obj_add_func({
-        val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE;
+  yyjson_api_inline bool yyjson_mut_obj_add_false (yyjson_mut_doc *doc,
+                                                   yyjson_mut_val *obj,
+                                                   const char *_key)
+  {
+    yyjson_mut_obj_add_func ({
+      val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE;
     });
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_obj_add_bool(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *obj,
-                                               const char *_key,
-                                               bool _val) {
-    yyjson_mut_obj_add_func({
-        val->tag = YYJSON_TYPE_BOOL | (uint8_t)((uint8_t)(_val) << 3);
+  yyjson_api_inline bool yyjson_mut_obj_add_bool (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *obj,
+                                                  const char *_key,
+                                                  bool _val)
+  {
+    yyjson_mut_obj_add_func ({
+      val->tag = YYJSON_TYPE_BOOL | (uint8_t)((uint8_t)(_val) << 3);
     });
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_obj_add_uint(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *obj,
-                                               const char *_key,
-                                               uint64_t _val) {
-    yyjson_mut_obj_add_func({
-        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
-        val->uni.u64 = _val;
+  yyjson_api_inline bool yyjson_mut_obj_add_uint (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *obj,
+                                                  const char *_key,
+                                                  uint64_t _val)
+  {
+    yyjson_mut_obj_add_func ({
+      val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
+      val->uni.u64 = _val;
     });
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_obj_add_sint(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *obj,
-                                               const char *_key,
-                                               int64_t _val) {
-    yyjson_mut_obj_add_func({
-        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
-        val->uni.i64 = _val;
+  yyjson_api_inline bool yyjson_mut_obj_add_sint (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *obj,
+                                                  const char *_key,
+                                                  int64_t _val)
+  {
+    yyjson_mut_obj_add_func ({
+      val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
+      val->uni.i64 = _val;
     });
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_obj_add_int(yyjson_mut_doc *doc,
-                                              yyjson_mut_val *obj,
-                                              const char *_key,
-                                              int64_t _val) {
-    yyjson_mut_obj_add_func({
-        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
-        val->uni.i64 = _val;
-    });
-}
-
-yyjson_api_inline bool yyjson_mut_obj_add_real(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *obj,
-                                               const char *_key,
-                                               double _val) {
-    yyjson_mut_obj_add_func({
-        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
-        val->uni.f64 = _val;
-    });
-}
-
-yyjson_api_inline bool yyjson_mut_obj_add_str(yyjson_mut_doc *doc,
-                                              yyjson_mut_val *obj,
-                                              const char *_key,
-                                              const char *_val) {
-    if (yyjson_unlikely(!_val)) return false;
-    yyjson_mut_obj_add_func({
-        val->tag = ((uint64_t)strlen(_val) << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-        val->uni.str = _val;
-    });
-}
-
-yyjson_api_inline bool yyjson_mut_obj_add_strn(yyjson_mut_doc *doc,
-                                               yyjson_mut_val *obj,
-                                               const char *_key,
-                                               const char *_val,
-                                               size_t _len) {
-    if (yyjson_unlikely(!_val)) return false;
-    yyjson_mut_obj_add_func({
-        val->tag = ((uint64_t)_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-        val->uni.str = _val;
-    });
-}
-
-yyjson_api_inline bool yyjson_mut_obj_add_strcpy(yyjson_mut_doc *doc,
+  yyjson_api_inline bool yyjson_mut_obj_add_int (yyjson_mut_doc *doc,
                                                  yyjson_mut_val *obj,
                                                  const char *_key,
-                                                 const char *_val) {
-    if (yyjson_unlikely(!_val)) return false;
-    yyjson_mut_obj_add_func({
-        size_t _len = strlen(_val);
-        val->uni.str = unsafe_yyjson_mut_strncpy(doc, _val, _len);
-        if (yyjson_unlikely(!val->uni.str)) return false;
-        val->tag = ((uint64_t)_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+                                                 int64_t _val)
+  {
+    yyjson_mut_obj_add_func ({
+      val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
+      val->uni.i64 = _val;
     });
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_obj_add_strncpy(yyjson_mut_doc *doc,
+  yyjson_api_inline bool yyjson_mut_obj_add_real (yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *obj,
+                                                  const char *_key,
+                                                  double _val)
+  {
+    yyjson_mut_obj_add_func ({
+      val->tag     = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
+      val->uni.f64 = _val;
+    });
+  }
+
+  yyjson_api_inline bool yyjson_mut_obj_add_str (yyjson_mut_doc *doc,
+                                                 yyjson_mut_val *obj,
+                                                 const char *_key,
+                                                 const char *_val)
+  {
+    if (yyjson_unlikely (!_val))
+      return false;
+    yyjson_mut_obj_add_func ({
+      val->tag     = ((uint64_t)strlen (_val) << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+      val->uni.str = _val;
+    });
+  }
+
+  yyjson_api_inline bool yyjson_mut_obj_add_strn (yyjson_mut_doc *doc,
                                                   yyjson_mut_val *obj,
                                                   const char *_key,
                                                   const char *_val,
-                                                  size_t _len) {
-    if (yyjson_unlikely(!_val)) return false;
-    yyjson_mut_obj_add_func({
-        val->uni.str = unsafe_yyjson_mut_strncpy(doc, _val, _len);
-        if (yyjson_unlikely(!val->uni.str)) return false;
-        val->tag = ((uint64_t)_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+                                                  size_t _len)
+  {
+    if (yyjson_unlikely (!_val))
+      return false;
+    yyjson_mut_obj_add_func ({
+      val->tag     = ((uint64_t)_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+      val->uni.str = _val;
     });
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_obj_add_val(yyjson_mut_doc *doc,
-                                              yyjson_mut_val *obj,
-                                              const char *_key,
-                                              yyjson_mut_val *_val) {
-    if (yyjson_unlikely(!_val)) return false;
-    yyjson_mut_obj_add_func({
-        val = _val;
+  yyjson_api_inline bool yyjson_mut_obj_add_strcpy (yyjson_mut_doc *doc,
+                                                    yyjson_mut_val *obj,
+                                                    const char *_key,
+                                                    const char *_val)
+  {
+    if (yyjson_unlikely (!_val))
+      return false;
+    yyjson_mut_obj_add_func ({
+      size_t _len  = strlen (_val);
+      val->uni.str = unsafe_yyjson_mut_strncpy (doc, _val, _len);
+      if (yyjson_unlikely (!val->uni.str))
+        return false;
+      val->tag = ((uint64_t)_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
     });
-}
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_str(yyjson_mut_val *obj,
-                                                            const char *key) {
-    return yyjson_mut_obj_remove_strn(obj, key, key ? strlen(key) : 0);
-}
+  yyjson_api_inline bool yyjson_mut_obj_add_strncpy (yyjson_mut_doc *doc,
+                                                     yyjson_mut_val *obj,
+                                                     const char *_key,
+                                                     const char *_val,
+                                                     size_t _len)
+  {
+    if (yyjson_unlikely (!_val))
+      return false;
+    yyjson_mut_obj_add_func ({
+      val->uni.str = unsafe_yyjson_mut_strncpy (doc, _val, _len);
+      if (yyjson_unlikely (!val->uni.str))
+        return false;
+      val->tag = ((uint64_t)_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+    });
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_strn(
-    yyjson_mut_val *obj, const char *_key, size_t _len) {
-    if (yyjson_likely(yyjson_mut_is_obj(obj) && _key)) {
-        yyjson_mut_val *key;
-        yyjson_mut_obj_iter iter;
-        yyjson_mut_val *val_removed = NULL;
-        yyjson_mut_obj_iter_init(obj, &iter);
-        while ((key = yyjson_mut_obj_iter_next(&iter)) != NULL) {
-            if (unsafe_yyjson_get_len(key) == _len &&
-                memcmp(key->uni.str, _key, _len) == 0) {
-                if (!val_removed) val_removed = key->next;
-                yyjson_mut_obj_iter_remove(&iter);
-            }
+  yyjson_api_inline bool yyjson_mut_obj_add_val (yyjson_mut_doc *doc,
+                                                 yyjson_mut_val *obj,
+                                                 const char *_key,
+                                                 yyjson_mut_val *_val)
+  {
+    if (yyjson_unlikely (!_val))
+      return false;
+    yyjson_mut_obj_add_func ({
+      val = _val;
+    });
+  }
+
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_str (yyjson_mut_val *obj,
+                                                               const char *key)
+  {
+    return yyjson_mut_obj_remove_strn (obj, key, key ? strlen (key) : 0);
+  }
+
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_strn (
+      yyjson_mut_val *obj, const char *_key, size_t _len)
+  {
+    if (yyjson_likely (yyjson_mut_is_obj (obj) && _key))
+    {
+      yyjson_mut_val *key;
+      yyjson_mut_obj_iter iter;
+      yyjson_mut_val *val_removed = NULL;
+      yyjson_mut_obj_iter_init (obj, &iter);
+      while ((key = yyjson_mut_obj_iter_next (&iter)) != NULL)
+      {
+        if (unsafe_yyjson_get_len (key) == _len &&
+            memcmp (key->uni.str, _key, _len) == 0)
+        {
+          if (!val_removed)
+            val_removed = key->next;
+          yyjson_mut_obj_iter_remove (&iter);
         }
-        return val_removed;
+      }
+      return val_removed;
     }
     return NULL;
-}
+  }
 
-yyjson_api_inline bool yyjson_mut_obj_rename_key(yyjson_mut_doc *doc,
-                                                 yyjson_mut_val *obj,
-                                                 const char *key,
-                                                 const char *new_key) {
-    if (!key || !new_key) return false;
-    return yyjson_mut_obj_rename_keyn(doc, obj, key, strlen(key),
-                                      new_key, strlen(new_key));
-}
+  yyjson_api_inline bool yyjson_mut_obj_rename_key (yyjson_mut_doc *doc,
+                                                    yyjson_mut_val *obj,
+                                                    const char *key,
+                                                    const char *new_key)
+  {
+    if (!key || !new_key)
+      return false;
+    return yyjson_mut_obj_rename_keyn (doc, obj, key, strlen (key),
+                                       new_key, strlen (new_key));
+  }
 
-yyjson_api_inline bool yyjson_mut_obj_rename_keyn(yyjson_mut_doc *doc,
-                                                  yyjson_mut_val *obj,
-                                                  const char *key,
-                                                  size_t len,
-                                                  const char *new_key,
-                                                  size_t new_len) {
+  yyjson_api_inline bool yyjson_mut_obj_rename_keyn (yyjson_mut_doc *doc,
+                                                     yyjson_mut_val *obj,
+                                                     const char *key,
+                                                     size_t len,
+                                                     const char *new_key,
+                                                     size_t new_len)
+  {
     char *cpy_key = NULL;
     yyjson_mut_val *old_key;
     yyjson_mut_obj_iter iter;
-    if (!doc || !obj || !key || !new_key) return false;
-    yyjson_mut_obj_iter_init(obj, &iter);
-    while ((old_key = yyjson_mut_obj_iter_next(&iter))) {
-        if (unsafe_yyjson_equals_strn((void *)old_key, key, len)) {
-            if (!cpy_key) {
-                cpy_key = unsafe_yyjson_mut_strncpy(doc, new_key, new_len);
-                if (!cpy_key) return false;
-            }
-            yyjson_mut_set_strn(old_key, cpy_key, new_len);
+    if (!doc || !obj || !key || !new_key)
+      return false;
+    yyjson_mut_obj_iter_init (obj, &iter);
+    while ((old_key = yyjson_mut_obj_iter_next (&iter)))
+    {
+      if (unsafe_yyjson_equals_strn ((void *)old_key, key, len))
+      {
+        if (!cpy_key)
+        {
+          cpy_key = unsafe_yyjson_mut_strncpy (doc, new_key, new_len);
+          if (!cpy_key)
+            return false;
         }
+        yyjson_mut_set_strn (old_key, cpy_key, new_len);
+      }
     }
     return cpy_key != NULL;
-}
+  }
 
+  /*==============================================================================
+   * JSON Pointer API (Implementation)
+   *============================================================================*/
 
+  /* `val` not null, `ptr` start with '/', `len` > 0. */
+  yyjson_api yyjson_val *unsafe_yyjson_get_pointer (yyjson_val *val,
+                                                    const char *ptr,
+                                                    size_t len);
 
-/*==============================================================================
- * JSON Pointer API (Implementation)
- *============================================================================*/
+  /* `val` not null, `ptr` start with '/', `len` > 0. */
+  yyjson_api yyjson_mut_val *unsafe_yyjson_mut_get_pointer (yyjson_mut_val *val,
+                                                            const char *ptr,
+                                                            size_t len);
 
-/* `val` not null, `ptr` start with '/', `len` > 0. */
-yyjson_api yyjson_val *unsafe_yyjson_get_pointer(yyjson_val *val,
-                                                 const char *ptr,
-                                                 size_t len);
+  yyjson_api_inline yyjson_val *yyjson_get_pointern (yyjson_val *val,
+                                                     const char *ptr,
+                                                     size_t len)
+  {
+    if (!val || !ptr)
+      return NULL;
+    if (len == 0)
+      return val;
+    if (*ptr != '/')
+      return NULL;
+    return unsafe_yyjson_get_pointer (val, ptr, len);
+  }
 
-/* `val` not null, `ptr` start with '/', `len` > 0. */
-yyjson_api yyjson_mut_val *unsafe_yyjson_mut_get_pointer(yyjson_mut_val *val,
+  yyjson_api_inline yyjson_val *yyjson_get_pointer (yyjson_val *val,
+                                                    const char *ptr)
+  {
+    if (!val || !ptr)
+      return NULL;
+    return yyjson_get_pointern (val, ptr, strlen (ptr));
+  }
+
+  yyjson_api_inline yyjson_val *yyjson_doc_get_pointern (yyjson_doc *doc,
                                                          const char *ptr,
-                                                         size_t len);
+                                                         size_t len)
+  {
+    return yyjson_get_pointern (doc ? doc->root : NULL, ptr, len);
+  }
 
-yyjson_api_inline yyjson_val *yyjson_get_pointern(yyjson_val *val,
-                                                  const char *ptr,
-                                                  size_t len) {
-    if (!val || !ptr) return NULL;
-    if (len == 0) return val;
-    if (*ptr != '/') return NULL;
-    return unsafe_yyjson_get_pointer(val, ptr, len);
-}
+  yyjson_api_inline yyjson_val *yyjson_doc_get_pointer (yyjson_doc *doc,
+                                                        const char *ptr)
+  {
+    return yyjson_get_pointer (doc ? doc->root : NULL, ptr);
+  }
 
-yyjson_api_inline yyjson_val *yyjson_get_pointer(yyjson_val *val,
-                                                 const char *ptr) {
-    if (!val || !ptr) return NULL;
-    return yyjson_get_pointern(val, ptr, strlen(ptr));
-}
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_get_pointern (yyjson_mut_val *val,
+                                                             const char *ptr,
+                                                             size_t len)
+  {
+    if (!val || !ptr)
+      return NULL;
+    if (len == 0)
+      return val;
+    if (*ptr != '/')
+      return NULL;
+    return unsafe_yyjson_mut_get_pointer (val, ptr, len);
+  }
 
-yyjson_api_inline yyjson_val *yyjson_doc_get_pointern(yyjson_doc *doc,
-                                                      const char *ptr,
-                                                      size_t len) {
-    return yyjson_get_pointern(doc ? doc->root : NULL, ptr, len);
-}
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_get_pointer (yyjson_mut_val *val,
+                                                            const char *ptr)
+  {
+    if (!val || !ptr)
+      return NULL;
+    return yyjson_mut_get_pointern (val, ptr, strlen (ptr));
+  }
 
-yyjson_api_inline yyjson_val *yyjson_doc_get_pointer(yyjson_doc *doc,
-                                                     const char *ptr) {
-    return yyjson_get_pointer(doc ? doc->root : NULL, ptr);
-}
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_pointern (
+      yyjson_mut_doc *doc, const char *ptr, size_t len)
+  {
+    return yyjson_mut_get_pointern (doc ? doc->root : NULL, ptr, len);
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_get_pointern(yyjson_mut_val *val,
-                                                          const char *ptr,
-                                                          size_t len) {
-    if (!val || !ptr) return NULL;
-    if (len == 0) return val;
-    if (*ptr != '/') return NULL;
-    return unsafe_yyjson_mut_get_pointer(val, ptr, len);
-}
+  yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_pointer (
+      yyjson_mut_doc *doc, const char *ptr)
+  {
+    return yyjson_mut_get_pointer (doc ? doc->root : NULL, ptr);
+  }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_get_pointer(yyjson_mut_val *val,
-                                                         const char *ptr) {
-    if (!val || !ptr) return NULL;
-    return yyjson_mut_get_pointern(val, ptr, strlen(ptr));
-}
+  /*==============================================================================
+   * JSON Value at Pointer API (Implementation)
+   *============================================================================*/
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_pointern(
-    yyjson_mut_doc *doc, const char *ptr, size_t len) {
-    return yyjson_mut_get_pointern(doc ? doc->root : NULL, ptr, len);
-}
-
-yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_pointer(
-    yyjson_mut_doc *doc, const char *ptr) {
-    return yyjson_mut_get_pointer(doc ? doc->root : NULL, ptr);
-}
-
-
-
-/*==============================================================================
- * JSON Value at Pointer API (Implementation)
- *============================================================================*/
-
-/**
- Set provided `value` if the JSON Pointer (RFC 6901) exists and is type bool.
- Returns true if value at `ptr` exists and is the correct type, otherwise false.
- */
-yyjson_api_inline bool yyjson_get_bool_pointer(
-    yyjson_val *root, const char *ptr, bool *value) {
-    yyjson_val *val = yyjson_get_pointer(root, ptr);
-    if (value && yyjson_is_bool(val)) {
-        *value = unsafe_yyjson_get_bool (val);
-        return true;
-    } else {
-        return false;
+  /**
+   Set provided `value` if the JSON Pointer (RFC 6901) exists and is type bool.
+   Returns true if value at `ptr` exists and is the correct type, otherwise false.
+   */
+  yyjson_api_inline bool yyjson_get_bool_pointer (
+      yyjson_val *root, const char *ptr, bool *value)
+  {
+    yyjson_val *val = yyjson_get_pointer (root, ptr);
+    if (value && yyjson_is_bool (val))
+    {
+      *value = unsafe_yyjson_get_bool (val);
+      return true;
     }
-}
-
-/**
- Set provided `value` if the JSON Pointer (RFC 6901) exists and is type uint.
- Returns true if value at `ptr` exists and is the correct type, otherwise false.
- */
-yyjson_api_inline bool yyjson_get_uint_pointer(
-    yyjson_val *root, const char *ptr, uint64_t *value) {
-    yyjson_val *val = yyjson_get_pointer(root, ptr);
-    if (value && yyjson_is_uint(val)) {
-        *value = unsafe_yyjson_get_uint(val);
-        return true;
-    } else {
-        return false;
+    else
+    {
+      return false;
     }
-}
+  }
 
-/**
- Set provided `value` if the JSON Pointer (RFC 6901) exists and is type sint.
- Returns true if value at `ptr` exists and is the correct type, otherwise false.
- */
-yyjson_api_inline bool yyjson_get_sint_pointer(
-    yyjson_val *root, const char *ptr, int64_t *value) {
-    yyjson_val *val = yyjson_get_pointer(root, ptr);
-    if (value && yyjson_is_sint(val)) {
-        *value = unsafe_yyjson_get_sint(val);
-        return true;
-    } else {
-        return false;
+  /**
+   Set provided `value` if the JSON Pointer (RFC 6901) exists and is type uint.
+   Returns true if value at `ptr` exists and is the correct type, otherwise false.
+   */
+  yyjson_api_inline bool yyjson_get_uint_pointer (
+      yyjson_val *root, const char *ptr, uint64_t *value)
+  {
+    yyjson_val *val = yyjson_get_pointer (root, ptr);
+    if (value && yyjson_is_uint (val))
+    {
+      *value = unsafe_yyjson_get_uint (val);
+      return true;
     }
-}
-
-/**
- Set provided `value` if the JSON Pointer (RFC 6901) exists and is type real.
- Returns true if value at `ptr` exists and is the correct type, otherwise false.
- */
-yyjson_api_inline bool yyjson_get_real_pointer(
-    yyjson_val *root, const char *ptr, double *value) {
-    yyjson_val *val = yyjson_get_pointer(root, ptr);
-    if (value && yyjson_is_real(val)) {
-        *value = unsafe_yyjson_get_real(val);
-        return true;
-    } else {
-        return false;
+    else
+    {
+      return false;
     }
-}
+  }
 
-/**
- Set provided `value` if the JSON Pointer (RFC 6901) exists and is type sint,
- uint or real.
- Returns true if value at `ptr` exists and is the correct type, otherwise false.
- */
-yyjson_api_inline bool yyjson_get_num_pointer(
-    yyjson_val *root, const char *ptr, double *value) {
-    yyjson_val *val = yyjson_get_pointer(root, ptr);
-    if (value && yyjson_is_num(val)) {
-        *value = unsafe_yyjson_get_num(val);
-        return true;
-    } else {
-        return false;
+  /**
+   Set provided `value` if the JSON Pointer (RFC 6901) exists and is type sint.
+   Returns true if value at `ptr` exists and is the correct type, otherwise false.
+   */
+  yyjson_api_inline bool yyjson_get_sint_pointer (
+      yyjson_val *root, const char *ptr, int64_t *value)
+  {
+    yyjson_val *val = yyjson_get_pointer (root, ptr);
+    if (value && yyjson_is_sint (val))
+    {
+      *value = unsafe_yyjson_get_sint (val);
+      return true;
     }
-}
-
-/**
- Set provided `value` if the JSON Pointer (RFC 6901) exists and is type string.
- Returns true if value at `ptr` exists and is the correct type, otherwise false.
- */
-yyjson_api_inline bool yyjson_get_str_pointer(
-    yyjson_val *root, const char *ptr, const char **value) {
-    yyjson_val *val = yyjson_get_pointer(root, ptr);
-    if (value && yyjson_is_str(val)) {
-        *value = unsafe_yyjson_get_str(val);
-        return true;
-    } else {
-        return false;
+    else
+    {
+      return false;
     }
-}
+  }
 
+  /**
+   Set provided `value` if the JSON Pointer (RFC 6901) exists and is type real.
+   Returns true if value at `ptr` exists and is the correct type, otherwise false.
+   */
+  yyjson_api_inline bool yyjson_get_real_pointer (
+      yyjson_val *root, const char *ptr, double *value)
+  {
+    yyjson_val *val = yyjson_get_pointer (root, ptr);
+    if (value && yyjson_is_real (val))
+    {
+      *value = unsafe_yyjson_get_real (val);
+      return true;
+    }
+    else
+    {
+      return false;
+    }
+  }
 
+  /**
+   Set provided `value` if the JSON Pointer (RFC 6901) exists and is type sint,
+   uint or real.
+   Returns true if value at `ptr` exists and is the correct type, otherwise false.
+   */
+  yyjson_api_inline bool yyjson_get_num_pointer (
+      yyjson_val *root, const char *ptr, double *value)
+  {
+    yyjson_val *val = yyjson_get_pointer (root, ptr);
+    if (value && yyjson_is_num (val))
+    {
+      *value = unsafe_yyjson_get_num (val);
+      return true;
+    }
+    else
+    {
+      return false;
+    }
+  }
 
-/*==============================================================================
- * Compiler Hint End
- *============================================================================*/
+  /**
+   Set provided `value` if the JSON Pointer (RFC 6901) exists and is type string.
+   Returns true if value at `ptr` exists and is the correct type, otherwise false.
+   */
+  yyjson_api_inline bool yyjson_get_str_pointer (
+      yyjson_val *root, const char *ptr, const char **value)
+  {
+    yyjson_val *val = yyjson_get_pointer (root, ptr);
+    if (value && yyjson_is_str (val))
+    {
+      *value = unsafe_yyjson_get_str (val);
+      return true;
+    }
+    else
+    {
+      return false;
+    }
+  }
+
+  /*==============================================================================
+   * Compiler Hint End
+   *============================================================================*/
 
 #if defined(__clang__)
-#   pragma clang diagnostic pop
+#pragma clang diagnostic pop
 #elif defined(__GNUC__)
-#   if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
-#   pragma GCC diagnostic pop
-#   endif
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+#pragma GCC diagnostic pop
+#endif
 #elif defined(_MSC_VER)
-#   pragma warning(pop)
+#pragma warning(pop)
 #endif /* warning suppress end */
 
 #ifdef __cplusplus


### PR DESCRIPTION
First, apply "forward branches are not likely to be taken" branch pattern on decoded data store branch.

Second, improve nibble selection by altering switch statement to multiple if-else statements.

Third, apply expansion macro for expanding diff array value store for loop.

As I have run `clang-format` for all codes, it is suggested to run `clang-format` on `develop` branch for the case of merging.