### PR TITLE
Add const qualifier to record pointer declarations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023.180:
+	- Add const qualifier to record pointer declarations where the
+	library interface does not modify the data.
+
 2023.177:
 	- Incorporate ms_gswapX() functions into libmseed.h to promote inlining.
 

--- a/libmseed.h
+++ b/libmseed.h
@@ -343,7 +343,7 @@ extern int ms_md2doy (int year, int month, int mday, int *yday);
 
 /** @brief miniSEED record container */
 typedef struct MS3Record {
-  char           *record;            //!< Raw miniSEED record, if available
+  const char     *record;            //!< Raw miniSEED record, if available
   int32_t         reclen;            //!< Length of miniSEED record in bytes
   uint8_t         swapflag;          //!< Byte swap indicator (bitmask), see @ref byte-swap-flags
 
@@ -368,7 +368,7 @@ typedef struct MS3Record {
   char            sampletype;        //!< Sample type code: a, i, f, d @ref sample-types
 } MS3Record;
 
-extern int msr3_parse (char *record, uint64_t recbuflen, MS3Record **ppmsr,
+extern int msr3_parse (const char *record, uint64_t recbuflen, MS3Record **ppmsr,
                        uint32_t flags, int8_t verbose);
 
 extern int msr3_pack (MS3Record *msr,
@@ -400,8 +400,8 @@ extern double     msr3_sampratehz (MS3Record *msr);
 extern double     msr3_host_latency (MS3Record *msr);
 
 extern int ms3_detect (const char *record, uint64_t recbuflen, uint8_t *formatversion);
-extern int ms_parse_raw3 (char *record, int maxreclen, int8_t details);
-extern int ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag);
+extern int ms_parse_raw3 (const char *record, int maxreclen, int8_t details);
+extern int ms_parse_raw2 (const char *record, int maxreclen, int8_t details, int8_t swapflag);
 /** @} */
 
 /** @addtogroup data-selections

--- a/parseutils.c
+++ b/parseutils.c
@@ -58,7 +58,7 @@
  * \ref MessageOnError - this function logs a message on error except MS_NOTSEED
  ***************************************************************************/
 int
-msr3_parse (char *record, uint64_t recbuflen, MS3Record **ppmsr,
+msr3_parse (const char *record, uint64_t recbuflen, MS3Record **ppmsr,
             uint32_t flags, int8_t verbose)
 {
   int reclen  = 0;
@@ -311,10 +311,10 @@ ms3_detect (const char *record, uint64_t recbuflen, uint8_t *formatversion)
  * \ref MessageOnError - this function logs a message on error
  ***************************************************************************/
 int
-ms_parse_raw3 (char *record, int maxreclen, int8_t details)
+ms_parse_raw3 (const char *record, int maxreclen, int8_t details)
 {
   MS3Record msr;
-  char *X;
+  const char *X;
   uint8_t b;
 
   int retval = 0;
@@ -476,12 +476,12 @@ ms_parse_raw3 (char *record, int maxreclen, int8_t details)
     ms_log (0, "          extra headers:\n");
     if ((MS3FSDH_LENGTH + sidlength + msr.extralength) <= maxreclen)
     {
-      msr.extra = record + MS3FSDH_LENGTH + sidlength;
+      msr.extra = (char *)record + MS3FSDH_LENGTH + sidlength;
       mseh_print (&msr, 10);
     }
     else
     {
-      ms_log (0, "      [buffer does not contain all extra headers]\n");
+      ms_log (0, "      [buffer does not contain extra headers]\n");
     }
   }
 
@@ -521,11 +521,11 @@ ms_parse_raw3 (char *record, int maxreclen, int8_t details)
  * \ref MessageOnError - this function logs a message on error
  ***************************************************************************/
 int
-ms_parse_raw2 (char *record, int maxreclen, int8_t details, int8_t swapflag)
+ms_parse_raw2 (const char *record, int maxreclen, int8_t details, int8_t swapflag)
 {
   double nomsamprate;
   char sid[21] = {0};
-  char *X;
+  const char *X;
   uint8_t b;
   int retval = 0;
   int b1000encoding = -1;

--- a/unpack.c
+++ b/unpack.c
@@ -72,7 +72,7 @@ static nstime_t ms_btime2nstime (uint8_t *btime, int8_t swapflag);
  * \ref MessageOnError - this function logs a message on error
  ***************************************************************************/
 int64_t
-msr3_unpack_mseed3 (char *record, int reclen, MS3Record **ppmsr,
+msr3_unpack_mseed3 (const char *record, int reclen, MS3Record **ppmsr,
                     uint32_t flags, int8_t verbose)
 {
   MS3Record *msr = NULL;
@@ -255,7 +255,7 @@ msr3_unpack_mseed3 (char *record, int reclen, MS3Record **ppmsr,
  * \ref MessageOnError - this function logs a message on error
  ***************************************************************************/
 int64_t
-msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
+msr3_unpack_mseed2 (const char *record, int reclen, MS3Record **ppmsr,
                     uint32_t flags, int8_t verbose)
 {
   int B1000offset = 0;
@@ -1480,7 +1480,7 @@ ms_nomsamprate (int factor, int multiplier)
  * Returns a pointer to the resulting string or NULL on error.
  ***************************************************************************/
 char *
-ms2_recordsid (char *record, char *sid, int sidlen)
+ms2_recordsid (const char *record, char *sid, int sidlen)
 {
   char net[3] = {0};
   char sta[6] = {0};

--- a/unpack.h
+++ b/unpack.h
@@ -27,13 +27,13 @@ extern "C" {
 
 #include "libmseed.h"
 
-extern int64_t msr3_unpack_mseed3 (char *record, int reclen, MS3Record **ppmsr,
+extern int64_t msr3_unpack_mseed3 (const char *record, int reclen, MS3Record **ppmsr,
                                    uint32_t flags, int8_t verbose);
-extern int64_t msr3_unpack_mseed2 (char *record, int reclen, MS3Record **ppmsr,
+extern int64_t msr3_unpack_mseed2 (const char *record, int reclen, MS3Record **ppmsr,
                                    uint32_t flags, int8_t verbose);
 
 extern double ms_nomsamprate (int factor, int multiplier);
-extern char *ms2_recordsid (char *record, char *sid, int sidlen);
+extern char *ms2_recordsid (const char *record, char *sid, int sidlen);
 extern const char *ms2_blktdesc (uint16_t blkttype);
 uint16_t ms2_blktlen (uint16_t blkttype, const char *blkt, int8_t swapflag);
 


### PR DESCRIPTION
- Add `const` qualifier to record pointer declarations where the interface does not modify the data and the `MS3Record.record` pointer, which should not be modified.