### PR TITLE
Const params

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
-2023.184:
+2023.185:
+	- Fix logic in `msr3_duplicate()` for certain cases.
 	- Add many const qualifiers to pointer values where the library
-	interface does not modify the data.
+	interface does not modify the data.  Thanks @damb
 
 2023.180:
 	- Add const qualifier to record pointer declarations where the

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023.184:
+	- Add many const qualifiers to pointer values where the library
+	interface does not modify the data.
+
 2023.180:
 	- Add const qualifier to record pointer declarations where the
 	library interface does not modify the data.

--- a/extraheaders.c
+++ b/extraheaders.c
@@ -147,7 +147,7 @@ parse_json (char *jsonstring, size_t length, LM_PARSED_JSON *parsed)
  * \sa mseh_free_parsestate()
  ***************************************************************************/
 int
-mseh_get_ptr_r (MS3Record *msr, const char *ptr,
+mseh_get_ptr_r (const MS3Record *msr, const char *ptr,
                  void *value, char type, size_t maxlength,
                  LM_PARSED_JSON **parsestate)
 {
@@ -1083,7 +1083,7 @@ mseh_free_parsestate (LM_PARSED_JSON **parsestate)
  * @returns 0 on success and a (negative) libmseed error code on error.
  ***************************************************************************/
 int
-mseh_print (MS3Record *msr, int indent)
+mseh_print (const MS3Record *msr, int indent)
 {
   char *extra;
   int idx;

--- a/fileutils.c
+++ b/fileutils.c
@@ -210,7 +210,7 @@ ms3_shift_msfp (MS3FileParam *msfp, int shift)
  *********************************************************************/
 int
 ms3_readmsr_selection (MS3FileParam **ppmsfp, MS3Record **ppmsr, const char *mspath,
-                       uint32_t flags, MS3Selections *selections, int8_t verbose)
+                       uint32_t flags, const MS3Selections *selections, int8_t verbose)
 {
   MS3FileParam *msfp;
   uint32_t pflags = flags;
@@ -540,7 +540,7 @@ ms3_readmsr_selection (MS3FileParam **ppmsfp, MS3Record **ppmsr, const char *msp
  *********************************************************************/
 int
 ms3_readtracelist (MS3TraceList **ppmstl, const char *mspath,
-                   MS3Tolerance *tolerance, int8_t splitversion,
+                   const MS3Tolerance *tolerance, int8_t splitversion,
                    uint32_t flags, int8_t verbose)
 {
   return ms3_readtracelist_selection (ppmstl, mspath, tolerance, NULL,
@@ -565,7 +565,7 @@ ms3_readtracelist (MS3TraceList **ppmstl, const char *mspath,
  *********************************************************************/
 int
 ms3_readtracelist_timewin (MS3TraceList **ppmstl, const char *mspath,
-                           MS3Tolerance *tolerance,
+                           const MS3Tolerance *tolerance,
                            nstime_t starttime, nstime_t endtime,
                            int8_t splitversion, uint32_t flags, int8_t verbose)
 {
@@ -629,7 +629,7 @@ ms3_readtracelist_timewin (MS3TraceList **ppmstl, const char *mspath,
  *********************************************************************/
 int
 ms3_readtracelist_selection (MS3TraceList **ppmstl, const char *mspath,
-                             MS3Tolerance *tolerance, MS3Selections *selections,
+                             const MS3Tolerance *tolerance, const MS3Selections *selections,
                              int8_t splitversion, uint32_t flags, int8_t verbose)
 {
   MS3Record *msr     = NULL;

--- a/libmseed.h
+++ b/libmseed.h
@@ -435,11 +435,11 @@ typedef struct MS3Selections {
   uint8_t pubversion;                //!< Selected publication version, use 0 for any
 } MS3Selections;
 
-extern MS3Selections* ms3_matchselect (MS3Selections *selections, const char *sid,
-                                       nstime_t starttime, nstime_t endtime,
-                                       int pubversion, MS3SelectTime **ppselecttime);
-extern MS3Selections* msr3_matchselect (MS3Selections *selections, const MS3Record *msr,
-                                        MS3SelectTime **ppselecttime);
+extern const MS3Selections* ms3_matchselect (const MS3Selections *selections, const char *sid,
+                                             nstime_t starttime, nstime_t endtime,
+                                             int pubversion, const MS3SelectTime **ppselecttime);
+extern const MS3Selections* msr3_matchselect (const MS3Selections *selections, const MS3Record *msr,
+                                              const MS3SelectTime **ppselecttime);
 extern int ms3_addselect (MS3Selections **ppselections, const char *sidpattern,
                           nstime_t starttime, nstime_t endtime, uint8_t pubversion);
 extern int ms3_addselect_comp (MS3Selections **ppselections,
@@ -596,8 +596,8 @@ typedef struct MS3TraceList {
  */
 typedef struct MS3Tolerance
 {
-  double (*time) (MS3Record *msr);     //!< Pointer to function that returns time tolerance
-  double (*samprate) (MS3Record *msr); //!< Pointer to function that returns sample rate tolerance
+  double (*time) (const MS3Record *msr);     //!< Pointer to function that returns time tolerance
+  double (*samprate) (const MS3Record *msr); //!< Pointer to function that returns sample rate tolerance
 } MS3Tolerance;
 
 /** @def MS3Tolerance_INITIALIZER
@@ -616,15 +616,15 @@ extern MS3TraceID*   mstl3_findID (MS3TraceList *mstl, const char *sid, uint8_t 
 #define mstl3_addmsr(mstl, msr, splitversion, autoheal, flags, tolerance) \
   mstl3_addmsr_recordptr (mstl, msr, NULL, splitversion, autoheal, flags, tolerance)
 
-extern MS3TraceSeg*  mstl3_addmsr_recordptr (MS3TraceList *mstl, MS3Record *msr, MS3RecordPtr **pprecptr,
+extern MS3TraceSeg*  mstl3_addmsr_recordptr (MS3TraceList *mstl, const MS3Record *msr, MS3RecordPtr **pprecptr,
                                              int8_t splitversion, int8_t autoheal, uint32_t flags,
-                                             MS3Tolerance *tolerance);
+                                             const MS3Tolerance *tolerance);
 extern int64_t       mstl3_readbuffer (MS3TraceList **ppmstl, char *buffer, uint64_t bufferlength,
                                        int8_t splitversion, uint32_t flags,
-                                       MS3Tolerance *tolerance, int8_t verbose);
+                                       const MS3Tolerance *tolerance, int8_t verbose);
 extern int64_t       mstl3_readbuffer_selection (MS3TraceList **ppmstl, char *buffer, uint64_t bufferlength,
                                                  int8_t splitversion, uint32_t flags,
-                                                 MS3Tolerance *tolerance, MS3Selections *selections,
+                                                 const MS3Tolerance *tolerance, const MS3Selections *selections,
                                                  int8_t verbose);
 extern int64_t mstl3_unpack_recordlist (MS3TraceID *id, MS3TraceSeg *seg, void *output,
                                         size_t outputsize, int8_t verbose);
@@ -729,14 +729,14 @@ extern int ms3_readmsr (MS3Record **ppmsr, const char *mspath, uint32_t flags, i
 extern int ms3_readmsr_r (MS3FileParam **ppmsfp, MS3Record **ppmsr, const char *mspath,
                           uint32_t flags, int8_t verbose);
 extern int ms3_readmsr_selection (MS3FileParam **ppmsfp, MS3Record **ppmsr, const char *mspath,
-                                  uint32_t flags, MS3Selections *selections, int8_t verbose);
-extern int ms3_readtracelist (MS3TraceList **ppmstl, const char *mspath, MS3Tolerance *tolerance,
+                                  uint32_t flags, const MS3Selections *selections, int8_t verbose);
+extern int ms3_readtracelist (MS3TraceList **ppmstl, const char *mspath, const MS3Tolerance *tolerance,
                               int8_t splitversion, uint32_t flags, int8_t verbose);
-extern int ms3_readtracelist_timewin (MS3TraceList **ppmstl, const char *mspath, MS3Tolerance *tolerance,
+extern int ms3_readtracelist_timewin (MS3TraceList **ppmstl, const char *mspath, const MS3Tolerance *tolerance,
                                       nstime_t starttime, nstime_t endtime, int8_t splitversion, uint32_t flags,
                                       int8_t verbose);
-extern int ms3_readtracelist_selection (MS3TraceList **ppmstl, const char *mspath, MS3Tolerance *tolerance,
-                                        MS3Selections *selections, int8_t splitversion, uint32_t flags, int8_t verbose);
+extern int ms3_readtracelist_selection (MS3TraceList **ppmstl, const char *mspath, const MS3Tolerance *tolerance,
+                                        const MS3Selections *selections, int8_t splitversion, uint32_t flags, int8_t verbose);
 extern int ms3_url_useragent (const char *program, const char *version);
 extern int ms3_url_userpassword (const char *userpassword);
 extern int ms3_url_addheader (const char *header);

--- a/libmseed.h
+++ b/libmseed.h
@@ -1227,9 +1227,9 @@ extern int ms_readleapsecondfile (const char *filename);
   @brief General utilities
   @{ */
 
-extern uint8_t ms_samplesize (const char sampletype);
-extern int ms_encoding_sizetype (const uint8_t encoding, uint8_t *samplesize, char *sampletype);
-extern const char *ms_encodingstr (const uint8_t encoding);
+extern uint8_t ms_samplesize (char sampletype);
+extern int ms_encoding_sizetype (uint8_t encoding, uint8_t *samplesize, char *sampletype);
+extern const char *ms_encodingstr (uint8_t encoding);
 extern const char *ms_errorstr (int errorcode);
 
 extern nstime_t ms_sampletime (nstime_t time, int64_t offset, double samprate);

--- a/libmseed.h
+++ b/libmseed.h
@@ -384,7 +384,7 @@ extern int msr3_pack_header2 (MS3Record *msr, char *record, uint32_t recbuflen, 
 
 extern int64_t msr3_unpack_data (MS3Record *msr, int8_t verbose);
 
-extern int msr3_data_bounds (MS3Record *msr, uint32_t *dataoffset, uint32_t *datasize);
+extern int msr3_data_bounds (const MS3Record *msr, uint32_t *dataoffset, uint32_t *datasize);
 
 extern int64_t ms_decode_data (const void *input, size_t inputsize, uint8_t encoding,
                                int64_t samplecount, void *output, size_t outputsize,
@@ -392,12 +392,12 @@ extern int64_t ms_decode_data (const void *input, size_t inputsize, uint8_t enco
 
 extern MS3Record* msr3_init (MS3Record *msr);
 extern void       msr3_free (MS3Record **ppmsr);
-extern MS3Record* msr3_duplicate (MS3Record *msr, int8_t datadup);
-extern nstime_t   msr3_endtime (MS3Record *msr);
-extern void       msr3_print (MS3Record *msr, int8_t details);
+extern MS3Record* msr3_duplicate (const MS3Record *msr, int8_t datadup);
+extern nstime_t   msr3_endtime (const MS3Record *msr);
+extern void       msr3_print (const MS3Record *msr, int8_t details);
 extern int        msr3_resize_buffer (MS3Record *msr);
-extern double     msr3_sampratehz (MS3Record *msr);
-extern double     msr3_host_latency (MS3Record *msr);
+extern double     msr3_sampratehz (const MS3Record *msr);
+extern double     msr3_host_latency (const MS3Record *msr);
 
 extern int ms3_detect (const char *record, uint64_t recbuflen, uint8_t *formatversion);
 extern int ms_parse_raw3 (const char *record, int maxreclen, int8_t details);
@@ -435,19 +435,19 @@ typedef struct MS3Selections {
   uint8_t pubversion;                //!< Selected publication version, use 0 for any
 } MS3Selections;
 
-extern MS3Selections* ms3_matchselect (MS3Selections *selections, char *sid,
+extern MS3Selections* ms3_matchselect (MS3Selections *selections, const char *sid,
                                        nstime_t starttime, nstime_t endtime,
                                        int pubversion, MS3SelectTime **ppselecttime);
-extern MS3Selections* msr3_matchselect (MS3Selections *selections, MS3Record *msr,
+extern MS3Selections* msr3_matchselect (MS3Selections *selections, const MS3Record *msr,
                                         MS3SelectTime **ppselecttime);
-extern int ms3_addselect (MS3Selections **ppselections, char *sidpattern,
+extern int ms3_addselect (MS3Selections **ppselections, const char *sidpattern,
                           nstime_t starttime, nstime_t endtime, uint8_t pubversion);
 extern int ms3_addselect_comp (MS3Selections **ppselections,
                                char *network, char* station, char *location, char *channel,
                                nstime_t starttime, nstime_t endtime, uint8_t pubversion);
 extern int ms3_readselectionsfile (MS3Selections **ppselections, char *filename);
 extern void ms3_freeselections (MS3Selections *selections);
-extern void ms3_printselections (MS3Selections *selections);
+extern void ms3_printselections (const MS3Selections *selections);
 /** @} */
 
 /** @addtogroup record-list
@@ -633,10 +633,10 @@ extern int mstl3_resize_buffers (MS3TraceList *mstl);
 extern int64_t mstl3_pack (MS3TraceList *mstl, void (*record_handler) (char *, int, void *),
                            void *handlerdata, int reclen, int8_t encoding,
                            int64_t *packedsamples, uint32_t flags, int8_t verbose, char *extra);
-extern void mstl3_printtracelist (MS3TraceList *mstl, ms_timeformat_t timeformat,
+extern void mstl3_printtracelist (const MS3TraceList *mstl, ms_timeformat_t timeformat,
                                   int8_t details, int8_t gaps, int8_t versions);
-extern void mstl3_printsynclist (MS3TraceList *mstl, char *dccid, ms_subseconds_t subseconds);
-extern void mstl3_printgaplist (MS3TraceList *mstl, ms_timeformat_t timeformat,
+extern void mstl3_printsynclist (const MS3TraceList *mstl, char *dccid, ms_subseconds_t subseconds);
+extern void mstl3_printgaplist (const MS3TraceList *mstl, ms_timeformat_t timeformat,
                                 double *mingap, double *maxgap);
 /** @} */
 
@@ -925,7 +925,7 @@ typedef struct LM_PARSED_JSON_s LM_PARSED_JSON;
 #define mseh_exists(msr, ptr)                  \
   (!mseh_get_ptr_r (msr, ptr, NULL, 0, 0, NULL))
 
-extern int mseh_get_ptr_r (MS3Record *msr, const char *ptr,
+extern int mseh_get_ptr_r (const MS3Record *msr, const char *ptr,
                            void *value, char type, size_t maxlength,
                            LM_PARSED_JSON **parsestate);
 
@@ -977,7 +977,7 @@ extern int mseh_add_recenter_r (MS3Record *msr, const char *ptr,
 extern int mseh_serialize (MS3Record *msr, LM_PARSED_JSON **parsestate);
 extern void mseh_free_parsestate (LM_PARSED_JSON **parsestate);
 
-extern int mseh_print (MS3Record *msr, int indent);
+extern int mseh_print (const MS3Record *msr, int indent);
 /** @} */
 
 /** @addtogroup record-list

--- a/libmseed.h
+++ b/libmseed.h
@@ -388,7 +388,7 @@ extern int msr3_data_bounds (const MS3Record *msr, uint32_t *dataoffset, uint32_
 
 extern int64_t ms_decode_data (const void *input, size_t inputsize, uint8_t encoding,
                                int64_t samplecount, void *output, size_t outputsize,
-                               char *sampletype, int8_t swapflag, char *sid, int8_t verbose);
+                               char *sampletype, int8_t swapflag, const char *sid, int8_t verbose);
 
 extern MS3Record* msr3_init (MS3Record *msr);
 extern void       msr3_free (MS3Record **ppmsr);
@@ -445,7 +445,7 @@ extern int ms3_addselect (MS3Selections **ppselections, const char *sidpattern,
 extern int ms3_addselect_comp (MS3Selections **ppselections,
                                char *network, char* station, char *location, char *channel,
                                nstime_t starttime, nstime_t endtime, uint8_t pubversion);
-extern int ms3_readselectionsfile (MS3Selections **ppselections, char *filename);
+extern int ms3_readselectionsfile (MS3Selections **ppselections, const char *filename);
 extern void ms3_freeselections (MS3Selections *selections);
 extern void ms3_printselections (const MS3Selections *selections);
 /** @} */

--- a/lookup.c
+++ b/lookup.c
@@ -36,7 +36,7 @@
  * @returns The sample size based on type code or 0 for unknown.
  ***************************************************************************/
 uint8_t
-ms_samplesize (const char sampletype)
+ms_samplesize (char sampletype)
 {
   switch (sampletype)
   {
@@ -71,7 +71,7 @@ ms_samplesize (const char sampletype)
  * @returns 0 on success, -1 on error
  ***************************************************************************/
 int
-ms_encoding_sizetype (const uint8_t encoding, uint8_t *samplesize, char *sampletype)
+ms_encoding_sizetype (uint8_t encoding, uint8_t *samplesize, char *sampletype)
 {
   switch (encoding)
   {
@@ -123,7 +123,7 @@ ms_encoding_sizetype (const uint8_t encoding, uint8_t *samplesize, char *samplet
  * @returns a string describing a data encoding format
  ***************************************************************************/
 const char *
-ms_encodingstr (const uint8_t encoding)
+ms_encodingstr (uint8_t encoding)
 {
   switch (encoding)
   {

--- a/msrutils.c
+++ b/msrutils.c
@@ -118,11 +118,9 @@ msr3_free (MS3Record **ppmsr)
  * \ref MessageOnError - this function logs a message on error
  ***************************************************************************/
 MS3Record *
-msr3_duplicate (MS3Record *msr, int8_t datadup)
+msr3_duplicate (const MS3Record *msr, int8_t datadup)
 {
   MS3Record *dupmsr = 0;
-  size_t datasize = 0;
-  int samplesize = 0;
 
   if (!msr)
   {
@@ -137,9 +135,12 @@ msr3_duplicate (MS3Record *msr, int8_t datadup)
   /* Copy MS3Record structure */
   memcpy (dupmsr, msr, sizeof (MS3Record));
 
-  /* Reset pointers to not alias memory held by other structures */
+  /* Disconnect pointers from the source structure and reference values */
   dupmsr->extra = NULL;
+  dupmsr->extralength = 0;
   dupmsr->datasamples = NULL;
+  dupmsr->datasize = 0;
+  dupmsr->numsamples = 0;
 
   /* Copy extra headers */
   if (msr->extralength > 0 && msr->extra)
@@ -153,40 +154,29 @@ msr3_duplicate (MS3Record *msr, int8_t datadup)
     }
 
     memcpy (dupmsr->extra, msr->extra, msr->extralength);
+
+    if (dupmsr->extra)
+      dupmsr->extralength = msr->extralength;
   }
 
   /* Copy data samples if requested and available */
-  if (datadup && msr->numsamples > 0 && msr->datasamples)
+  if (datadup && msr->numsamples > 0 && msr->datasize > 0 && msr->datasamples)
   {
-    /* Determine size of samples in bytes */
-    samplesize = ms_samplesize (msr->sampletype);
-
-    if (samplesize == 0)
-    {
-      ms_log (2, "Unrecognized sample type: '%c'\n", msr->sampletype);
-      msr3_free (&dupmsr);
-      return NULL;
-    }
-
-    datasize = msr->numsamples * samplesize;
-
     /* Allocate memory for new data array */
-    if ((dupmsr->datasamples = libmseed_memory.malloc ((size_t) (datasize))) == NULL)
+    if ((dupmsr->datasamples = libmseed_memory.malloc ((size_t) (msr->datasize))) == NULL)
     {
       ms_log (2, "Error allocating memory\n");
       msr3_free (&dupmsr);
       return NULL;
     }
-    msr->datasize = datasize;
 
-    memcpy (dupmsr->datasamples, msr->datasamples, datasize);
-  }
-  /* Otherwise make sure the sample array and count are zero */
-  else
-  {
-    dupmsr->datasamples = NULL;
-    dupmsr->datasize = 0;
-    dupmsr->numsamples = 0;
+    memcpy (dupmsr->datasamples, msr->datasamples, msr->datasize);
+
+    if (dupmsr->datasamples)
+    {
+      dupmsr->datasize   = msr->datasize;
+      dupmsr->numsamples = msr->numsamples;
+    }
   }
 
   return dupmsr;
@@ -209,7 +199,7 @@ msr3_duplicate (MS3Record *msr, int8_t datadup)
  * @returns Time of the last sample on success and NSTERROR on error.
  ***************************************************************************/
 nstime_t
-msr3_endtime (MS3Record *msr)
+msr3_endtime (const MS3Record *msr)
 {
   int64_t sampleoffset = 0;
 
@@ -235,7 +225,7 @@ msr3_endtime (MS3Record *msr)
  * @endparblock
  ***************************************************************************/
 void
-msr3_print (MS3Record *msr, int8_t details)
+msr3_print (const MS3Record *msr, int8_t details)
 {
   char time[40];
   char b;
@@ -354,7 +344,7 @@ msr3_resize_buffer (MS3Record *msr)
  * @returns Return sample rate in Hertz (samples per second)
  ***************************************************************************/
 inline double
-msr3_sampratehz (MS3Record *msr)
+msr3_sampratehz (const MS3Record *msr)
 {
   if (!msr)
     return 0.0;
@@ -381,7 +371,7 @@ msr3_sampratehz (MS3Record *msr)
  * 0.0 latency).
  ***************************************************************************/
 double
-msr3_host_latency (MS3Record *msr)
+msr3_host_latency (const MS3Record *msr)
 {
   double span = 0.0; /* Time covered by the samples */
   double epoch;      /* Current epoch time */

--- a/selection.c
+++ b/selection.c
@@ -424,7 +424,7 @@ ms3_addselect_comp (MS3Selections **ppselections, char *network, char *station,
  * \ref MessageOnError - this function logs a message on error
  ***************************************************************************/
 int
-ms3_readselectionsfile (MS3Selections **ppselections, char *filename)
+ms3_readselectionsfile (MS3Selections **ppselections, const char *filename)
 {
   FILE *fp;
   nstime_t starttime;

--- a/selection.c
+++ b/selection.c
@@ -55,7 +55,7 @@ static int ms_globmatch (const char *string, const char *pattern);
  * match and NULL for no match or error.
  ***************************************************************************/
 MS3Selections *
-ms3_matchselect (MS3Selections *selections, char *sid, nstime_t starttime,
+ms3_matchselect (MS3Selections *selections, const char *sid, nstime_t starttime,
                  nstime_t endtime, int pubversion, MS3SelectTime **ppselecttime)
 {
   MS3Selections *findsl = NULL;
@@ -142,7 +142,8 @@ ms3_matchselect (MS3Selections *selections, char *sid, nstime_t starttime,
  * match and NULL for no match or error.
  ***************************************************************************/
 MS3Selections *
-msr3_matchselect (MS3Selections *selections, MS3Record *msr, MS3SelectTime **ppselecttime)
+msr3_matchselect (MS3Selections *selections, const MS3Record *msr,
+                  MS3SelectTime **ppselecttime)
 {
   nstime_t endtime;
 
@@ -177,7 +178,7 @@ msr3_matchselect (MS3Selections *selections, MS3Record *msr, MS3SelectTime **pps
  * \ref MessageOnError - this function logs a message on error
  ***************************************************************************/
 int
-ms3_addselect (MS3Selections **ppselections, char *sidpattern,
+ms3_addselect (MS3Selections **ppselections, const char *sidpattern,
                nstime_t starttime, nstime_t endtime, uint8_t pubversion)
 {
   MS3Selections *newsl = NULL;
@@ -701,9 +702,9 @@ ms3_freeselections (MS3Selections *selections)
  * @param[in] selections Start of ::MS3Selections to print
  ***************************************************************************/
 void
-ms3_printselections (MS3Selections *selections)
+ms3_printselections (const MS3Selections *selections)
 {
-  MS3Selections *select;
+  const MS3Selections *select;
   MS3SelectTime *selecttime;
   char starttime[50];
   char endtime[50];

--- a/selection.c
+++ b/selection.c
@@ -54,13 +54,13 @@ static int ms_globmatch (const char *string, const char *pattern);
  * @returns A pointer to matching ::MS3Selections entry successful
  * match and NULL for no match or error.
  ***************************************************************************/
-MS3Selections *
-ms3_matchselect (MS3Selections *selections, const char *sid, nstime_t starttime,
-                 nstime_t endtime, int pubversion, MS3SelectTime **ppselecttime)
+const MS3Selections *
+ms3_matchselect (const MS3Selections *selections, const char *sid, nstime_t starttime,
+                 nstime_t endtime, int pubversion, const MS3SelectTime **ppselecttime)
 {
-  MS3Selections *findsl = NULL;
-  MS3SelectTime *findst = NULL;
-  MS3SelectTime *matchst = NULL;
+  const MS3Selections *findsl = NULL;
+  const MS3SelectTime *findst = NULL;
+  const MS3SelectTime *matchst = NULL;
 
   if (selections)
   {
@@ -141,9 +141,9 @@ ms3_matchselect (MS3Selections *selections, const char *sid, nstime_t starttime,
  * @returns A pointer to matching ::MS3Selections entry successful
  * match and NULL for no match or error.
  ***************************************************************************/
-MS3Selections *
-msr3_matchselect (MS3Selections *selections, const MS3Record *msr,
-                  MS3SelectTime **ppselecttime)
+const MS3Selections *
+msr3_matchselect (const MS3Selections *selections, const MS3Record *msr,
+                  const MS3SelectTime **ppselecttime)
 {
   nstime_t endtime;
 

--- a/test/test-selection.c
+++ b/test/test-selection.c
@@ -3,9 +3,9 @@
 
 TEST (selection, match)
 {
-  MS3Selections *selections = NULL;
-  MS3Selections *match      = NULL;
-  MS3SelectTime *timematch  = NULL;
+  MS3Selections *selections      = NULL;
+  const MS3Selections *match     = NULL;
+  const MS3SelectTime *timematch = NULL;
   nstime_t starttime;
   nstime_t endtime;
   int rv;
@@ -52,8 +52,8 @@ TEST (selection, match)
 
 TEST (selection, error)
 {
-  MS3Selections *selections = NULL;
-  MS3Selections *match      = NULL;
+  MS3Selections *selections  = NULL;
+  const MS3Selections *match = NULL;
   int rv;
 
   rv = ms3_addselect (NULL, "FDSN:XX_*", NSTUNSET, NSTUNSET, 0);

--- a/tracelist.c
+++ b/tracelist.c
@@ -2143,11 +2143,11 @@ mstl3_pack (MS3TraceList *mstl, void (*record_handler) (char *, int, void *),
  * @param[in] versions Flag to control inclusion of publication version on SourceIDs
  ***************************************************************************/
 void
-mstl3_printtracelist (MS3TraceList *mstl, ms_timeformat_t timeformat,
+mstl3_printtracelist (const MS3TraceList *mstl, ms_timeformat_t timeformat,
                       int8_t details, int8_t gaps, int8_t versions)
 {
-  MS3TraceID *id = 0;
-  MS3TraceSeg *seg = 0;
+  const MS3TraceID *id = 0;
+  const MS3TraceSeg *seg = 0;
   char stime[40];
   char etime[40];
   char gapstr[40];
@@ -2158,7 +2158,7 @@ mstl3_printtracelist (MS3TraceList *mstl, ms_timeformat_t timeformat,
   int segcnt = 0;
 
   char versioned_sid[LM_SIDLEN + 10] = {0};
-  char *display_sid = NULL;
+  const char *display_sid = NULL;
 
   if (!mstl)
   {
@@ -2275,10 +2275,10 @@ mstl3_printtracelist (MS3TraceList *mstl, ms_timeformat_t timeformat,
  * @param[in] subseconds Inclusion of subseconds, one of @ref ms_subseconds_t
  ***************************************************************************/
 void
-mstl3_printsynclist (MS3TraceList *mstl, char *dccid, ms_subseconds_t subseconds)
+mstl3_printsynclist (const MS3TraceList *mstl, char *dccid, ms_subseconds_t subseconds)
 {
-  MS3TraceID *id = 0;
-  MS3TraceSeg *seg = 0;
+  const MS3TraceID *id = 0;
+  const MS3TraceSeg *seg = 0;
   char starttime[40];
   char endtime[40];
   char yearday[32];
@@ -2348,11 +2348,11 @@ mstl3_printsynclist (MS3TraceList *mstl, char *dccid, ms_subseconds_t subseconds
  * @param[in] maxgap Maximum gap to print in seconds (pointer to value)
  ***************************************************************************/
 void
-mstl3_printgaplist (MS3TraceList *mstl, ms_timeformat_t timeformat,
+mstl3_printgaplist (const MS3TraceList *mstl, ms_timeformat_t timeformat,
                     double *mingap, double *maxgap)
 {
-  MS3TraceID *id = 0;
-  MS3TraceSeg *seg = 0;
+  const MS3TraceID *id = 0;
+  const MS3TraceSeg *seg = 0;
 
   char time1[40], time2[40];
   char gapstr[40];

--- a/tracelist.c
+++ b/tracelist.c
@@ -26,10 +26,10 @@
 
 #include "libmseed.h"
 
-MS3TraceSeg *mstl3_msr2seg (MS3Record *msr, nstime_t endtime);
-MS3TraceSeg *mstl3_addmsrtoseg (MS3TraceSeg *seg, MS3Record *msr, nstime_t endtime, int8_t whence);
+MS3TraceSeg *mstl3_msr2seg (const MS3Record *msr, nstime_t endtime);
+MS3TraceSeg *mstl3_addmsrtoseg (MS3TraceSeg *seg, const MS3Record *msr, nstime_t endtime, int8_t whence);
 MS3TraceSeg *mstl3_addsegtoseg (MS3TraceSeg *seg1, MS3TraceSeg *seg2);
-MS3RecordPtr *mstl3_add_recordptr (MS3TraceSeg *seg, MS3Record *msr, nstime_t endtime, int8_t whence);
+MS3RecordPtr *mstl3_add_recordptr (MS3TraceSeg *seg, const MS3Record *msr, nstime_t endtime, int8_t whence);
 
 static uint32_t lm_lcg_r (uint64_t *state);
 static uint8_t lm_random_height (uint8_t maximum, uint64_t *state);
@@ -358,9 +358,9 @@ mstl3_addID (MS3TraceList *mstl, MS3TraceID *id, MS3TraceID **prev)
  * \ref MessageOnError - this function logs a message on error
  ***************************************************************************/
 MS3TraceSeg *
-mstl3_addmsr_recordptr (MS3TraceList *mstl, MS3Record *msr, MS3RecordPtr **pprecptr,
+mstl3_addmsr_recordptr (MS3TraceList *mstl, const MS3Record *msr, MS3RecordPtr **pprecptr,
                         int8_t splitversion, int8_t autoheal, uint32_t flags,
-                        MS3Tolerance *tolerance)
+                        const MS3Tolerance *tolerance)
 {
   MS3TraceID *id = 0;
   MS3TraceID *previd[MSTRACEID_SKIPLIST_HEIGHT] = {NULL};
@@ -851,7 +851,7 @@ mstl3_addmsr_recordptr (MS3TraceList *mstl, MS3Record *msr, MS3RecordPtr **pprec
 int64_t
 mstl3_readbuffer (MS3TraceList **ppmstl, char *buffer, uint64_t bufferlength,
                   int8_t splitversion, uint32_t flags,
-                  MS3Tolerance *tolerance, int8_t verbose)
+                  const MS3Tolerance *tolerance, int8_t verbose)
 {
   return mstl3_readbuffer_selection (ppmstl, buffer, bufferlength,
                                      splitversion, flags, tolerance,
@@ -900,7 +900,7 @@ mstl3_readbuffer (MS3TraceList **ppmstl, char *buffer, uint64_t bufferlength,
 int64_t
 mstl3_readbuffer_selection (MS3TraceList **ppmstl, char *buffer, uint64_t bufferlength,
                             int8_t splitversion, uint32_t flags,
-                            MS3Tolerance *tolerance, MS3Selections *selections,
+                            const MS3Tolerance *tolerance, const MS3Selections *selections,
                             int8_t verbose)
 {
   MS3Record *msr   = NULL;
@@ -1021,7 +1021,7 @@ mstl3_readbuffer_selection (MS3TraceList **ppmstl, char *buffer, uint64_t buffer
  * \ref MessageOnError - this function logs a message on error
  ***************************************************************************/
 MS3TraceSeg *
-mstl3_msr2seg (MS3Record *msr, nstime_t endtime)
+mstl3_msr2seg (const MS3Record *msr, nstime_t endtime)
 {
   MS3TraceSeg *seg = 0;
   size_t datasize = 0;
@@ -1080,7 +1080,7 @@ mstl3_msr2seg (MS3Record *msr, nstime_t endtime)
  * \ref MessageOnError - this function logs a message on error
  ***************************************************************************/
 MS3TraceSeg *
-mstl3_addmsrtoseg (MS3TraceSeg *seg, MS3Record *msr, nstime_t endtime, int8_t whence)
+mstl3_addmsrtoseg (MS3TraceSeg *seg, const MS3Record *msr, nstime_t endtime, int8_t whence)
 {
   int samplesize = 0;
   void *newdatasamples = NULL;
@@ -1289,7 +1289,7 @@ mstl3_addsegtoseg (MS3TraceSeg *seg1, MS3TraceSeg *seg2)
  * \sa mstl3_addmsr()
  ***************************************************************************/
 MS3RecordPtr *
-mstl3_add_recordptr (MS3TraceSeg *seg, MS3Record *msr, nstime_t endtime, int8_t whence)
+mstl3_add_recordptr (MS3TraceSeg *seg, const MS3Record *msr, nstime_t endtime, int8_t whence)
 {
   MS3RecordPtr *recordptr = NULL;
 

--- a/unpack.c
+++ b/unpack.c
@@ -1019,7 +1019,7 @@ msr3_unpack_mseed2 (const char *record, int reclen, MS3Record **ppmsr,
  * \ref MessageOnError - this function logs a message on error
  ************************************************************************/
 int
-msr3_data_bounds (MS3Record *msr, uint32_t *dataoffset, uint32_t *datasize)
+msr3_data_bounds (const MS3Record *msr, uint32_t *dataoffset, uint32_t *datasize)
 {
   uint8_t nullframe[64] = {0};
   uint8_t samplebytes = 0;

--- a/unpack.c
+++ b/unpack.c
@@ -1272,7 +1272,7 @@ msr3_unpack_data (MS3Record *msr, int8_t verbose)
 int64_t
 ms_decode_data (const void *input, size_t inputsize, uint8_t encoding,
                 int64_t samplecount, void *output, size_t outputsize,
-                char *sampletype, int8_t swapflag, char *sid, int8_t verbose)
+                char *sampletype, int8_t swapflag, const char *sid, int8_t verbose)
 {
   size_t decodedsize; /* byte size of decodeded samples */
   int32_t nsamples; /* number of samples unpacked */

--- a/unpackdata.c
+++ b/unpackdata.c
@@ -192,7 +192,7 @@ msr_decode_float64 (double *input, int64_t samplecount, double *output,
  ************************************************************************/
 int
 msr_decode_steim1 (int32_t *input, int inputlength, int64_t samplecount,
-                   int32_t *output, int64_t outputlength, char *srcname,
+                   int32_t *output, int64_t outputlength, const char *srcname,
                    int swapflag)
 {
   int32_t *outputptr = output; /* Pointer to next output sample location */
@@ -345,7 +345,7 @@ msr_decode_steim1 (int32_t *input, int inputlength, int64_t samplecount,
  ************************************************************************/
 int
 msr_decode_steim2 (int32_t *input, int inputlength, int64_t samplecount,
-                   int32_t *output, int64_t outputlength, char *srcname,
+                   int32_t *output, int64_t outputlength, const char *srcname,
                    int swapflag)
 {
   int32_t *outputptr = output; /* Pointer to next output sample location */
@@ -596,7 +596,7 @@ msr_decode_steim2 (int32_t *input, int inputlength, int64_t samplecount,
 int
 msr_decode_geoscope (char *input, int64_t samplecount, float *output,
                      int64_t outputlength, int encoding,
-                     char *srcname, int swapflag)
+                     const char *srcname, int swapflag)
 {
   int idx = 0;
   int mantissa;  /* mantissa from SEED data */
@@ -837,7 +837,7 @@ msr_decode_cdsn (int16_t *input, int64_t samplecount, int32_t *output,
  ************************************************************************/
 int
 msr_decode_sro (int16_t *input, int64_t samplecount, int32_t *output,
-                int64_t outputlength, char *srcname, int swapflag)
+                int64_t outputlength, const char *srcname, int swapflag)
 {
   int32_t idx = 0;
   int32_t mantissa;   /* mantissa */

--- a/unpackdata.h
+++ b/unpackdata.h
@@ -40,18 +40,18 @@ extern int msr_decode_float32 (float *input, int64_t samplecount, float *output,
 extern int msr_decode_float64 (double *input, int64_t samplecount, double *output,
                                int64_t outputlength, int swapflag);
 extern int msr_decode_steim1 (int32_t *input, int inputlength, int64_t samplecount,
-                              int32_t *output, int64_t outputlength, char *srcname,
+                              int32_t *output, int64_t outputlength, const char *srcname,
                               int swapflag);
 extern int msr_decode_steim2 (int32_t *input, int inputlength, int64_t samplecount,
-                              int32_t *output, int64_t outputlength, char *srcname,
+                              int32_t *output, int64_t outputlength, const char *srcname,
                               int swapflag);
 extern int msr_decode_geoscope (char *input, int64_t samplecount, float *output,
-                                int64_t outputlength, int encoding, char *srcname,
+                                int64_t outputlength, int encoding, const char *srcname,
                                 int swapflag);
 extern int msr_decode_cdsn (int16_t *input, int64_t samplecount, int32_t *output,
                             int64_t outputlength, int swapflag);
 extern int msr_decode_sro (int16_t *input, int64_t samplecount, int32_t *output,
-                           int64_t outputlength, char *srcname, int swapflag);
+                           int64_t outputlength, const char *srcname, int swapflag);
 extern int msr_decode_dwwssn (int16_t *input, int64_t samplecount, int32_t *output,
                               int64_t outputlength, int swapflag);
 


### PR DESCRIPTION
**Changes**:

- Do not declare pass-by-value function params as `const`
- Implement const-correctness throughout the library